### PR TITLE
obvious typos and simple copy-editing fixes

### DIFF
--- a/draft-ietf-httpbis-http2.xml
+++ b/draft-ietf-httpbis-http2.xml
@@ -318,7 +318,7 @@ Upgrade: HTTP/2.0
 
         <t>
           The first HTTP/2.0 frame sent by the server is a <xref target="SETTINGS">SETTINGS
-          frame</xref>.  Upon receiving the 101 response, the client sents a <xref
+          frame</xref>.  Upon receiving the 101 response, the client sends a <xref
           target="SessionHeader">session header</xref>, which includes a SETTINGS frame.
         </t>
       </section>
@@ -1617,7 +1617,7 @@ Upgrade: HTTP/2.0
               <t>A new :scheme header field has been added to specify the 
                 scheme portion of the request-target (e.g. "https")</t>
               <t>All header field names MUST be lowercased, and the 
-                definitions of all header fields names defined by 
+                definitions of all header field names defined by 
                 HTTP/1.1 are updated to be all lowercase.</t>
               <t>The Connection, Host, Keep-Alive, Proxy-Connection, and 
                 Transfer-Encoding header fields are no longer valid and 
@@ -1653,10 +1653,10 @@ Upgrade: HTTP/2.0
           <t>
              Although POSTs are inherently chunked, POST requests SHOULD also be accompanied by a
              Content-Length header field.  First, it informs the server of how much data to
-             expect, which the server can used to track overall progress and provide appropriate
+             expect, which the server can use to track overall progress and provide appropriate
              user feedback.  More importantly, some HTTP server implementations fail to correctly
              process requests that omit the Content-Length header field.  Many existing clients
-             send a Content-Length header field, which caused server implementations have come to
+             send a Content-Length header field, and some server implementations have come to
              depend upon its presence.
           </t>
 


### PR DESCRIPTION
Additionally, section 4.2.3 contains a lot of text that is similar to 4.2.2, but there may be a reason for that.
