### PR TITLE
Remove 0x2 bit from SETTINGS_FLOW_CONTROL_OPTIONS.

### DIFF
--- a/draft-ietf-httpbis-http2.xml
+++ b/draft-ietf-httpbis-http2.xml
@@ -1258,8 +1258,7 @@ Upgrade: HTTP/2.0
                   <t>
                     indicates that streams directed to the sender will not
                     be subject to flow control.  The least significant bit (0x1) is set to indicate
-                    that new streams are not flow controlled.  Bit 2 (0x2) is set to indicate that the
-                    connection is not flow controlled.  All other bits are reserved.
+                    that new streams are not flow controlled.  All other bits are reserved.
                   </t>
                   <t>
                     This setting applies to all streams, including existing streams.


### PR DESCRIPTION
It controls the connection window, but there is already a mechanism for
that in WINDOW_UPDATE with stream 0 and the END_FLOW_CONTROL flag,
therefore it is redundant.

Issue #88.
Discussion: http://lists.w3.org/Archives/Public/ietf-http-wg/2013AprJun/0709.html
