### PR TITLE
change connection header magic string

### DIFF
--- a/draft-ietf-httpbis-http2.xml
+++ b/draft-ietf-httpbis-http2.xml
@@ -381,9 +381,9 @@ Upgrade: HTTP/2.0
           The client connection header is a sequence of 24 octets (in hex notation)
         </t>
         <figure><artwork type="inline">
-464f4f202a20485454502f322e300d0a0d0a42410d0a0d0a</artwork></figure>
+434f4e202a20485454502f322e300d0a0d0a676f0d0a0d0a</artwork></figure>
         <t>
-          (the string <spanx style="verb">FOO * HTTP/2.0\r\n\r\nBA\r\n\r\n</spanx>) followed by a
+          (the string <spanx style="verb">CON * HTTP/2.0\r\n\r\ngo\r\n\r\n</spanx>) followed by a
           <xref target="SETTINGS">SETTINGS frame</xref>.  The client sends the client connection header
           immediately upon receipt of a 101 Switching Protocols response (indicating a successful
           upgrade), or after receiving a TLS Finished message from the server. If starting an


### PR DESCRIPTION
If the goal of the connection header magic string is to emulate a HTTP/1.x request in a way that is both as transparent as possible (can be parsed as HTTP/1.x) and unambiguously differentiated (could NOT be understood as HTTP/1.x), I understand the criteria to be:

When interpreted as a HTTP/1.x request:
- the HTTP-Version must be "HTTP/2.0";
- the Request-URI must be "*", since this message is not resource-specific;
- the Method should not coincide with any extant HTTP/1.x methods, since a poorly-implemented device might, for example, only inspect the minor part of the HTTP-Version and misinterpret the header as a HTTP/1.0 request;
- the Method should be exactly three or four bytes in length, since there are known implementations in the wild that have this expectation.

To fit in a 24-byte structure, using the standard pattern, we would have to use either a three-byte Method and a two-byte entity (before the final "\r\n\r\n"), or a four-byte Method and a one-byte entity.  I think 3-2 is better, aesthetically.

I also think it's better to avoid encoding a metasyntactic variable into the standard.  "FOO" is universally used as a placeholder for user-supplied data, and it may be confusing for the spec to require implementers to send or expect the literal value "FOO".  Additionally there is a legitimate chance that there are implementations in the wild that actually use "FOO" as a method, e.g. for developmental purposes.

I propose "CON" and "go" as the Method and message entity parts.

This was discussed on the HTTP Working Group ietf-http-wg@w3.org and essentially discarded as a minor detail, so I'm making this pull request without contacting the list so that editors and coordinators can make the final decision.
