### PR TITLE
Fix error handlings on HEADERS and PRIORITY

### DIFF
--- a/draft-ietf-httpbis-http2.xml
+++ b/draft-ietf-httpbis-http2.xml
@@ -1045,7 +1045,7 @@ Upgrade: HTTP/2.0
             The PRIORITY frame is associated with an existing stream. If 
             a PRIORITY frame is received with a stream identifier of 0x0, 
             the recipient MUST respond with a
-            <xref target="StreamErrorHandler">stream error</xref> of type
+            <xref target="ConnectionErrorHandler">connection error</xref> of type
             PROTOCOL_ERROR.
           </t>
         </section>
@@ -1546,7 +1546,7 @@ Upgrade: HTTP/2.0
             The HEADERS frame is associated with an existing stream. If 
             a HEADERS frame is received with a stream identifier of 0x0, 
             the recipient MUST respond with a
-            <xref target="StreamErrorHandler">stream error</xref> of type
+            <xref target="ConnectionErrorHandler">connection error</xref> of type
             PROTOCOL_ERROR.
           </t>
           <t>


### PR DESCRIPTION
Error when stream identifier field is 0x0 is not stream error but connection error because it is impossible to send RST_STREAM of 0x0. 
