### PR TITLE
Separate errors on HEADER with CONTINUES into stream and connection

### DIFF
--- a/draft-ietf-httpbis-http2.xml
+++ b/draft-ietf-httpbis-http2.xml
@@ -1533,8 +1533,9 @@ Upgrade: HTTP/2.0
                 <vspace blankLines="1"/>
                 A HEADERS frame that includes a CONTINUES bit MUST be followed by a HEADERS frame
                 for the same stream.  A receiver MUST treat the receipt of any other type of frame
-                or a frame on a different stream as a <xref
-                target="ConnectionErrorHandler">connection error</xref> of type PROTOCOL_ERROR.
+                on the same stream as a <xref target="StreamErrorHandler">stream error</xref> and a
+                frame on a different stream as a <xref target="ConnectionErrorHandler">connection
+                error</xref> of type PROTOCOL_ERROR.
               </t>
             </list>
 


### PR DESCRIPTION
Error caused by other type of frames on the same stream id is stream error. I think this is editorial but if it is design issue, I will send this to ML.
