### PR TITLE
Corrected description of CANCEL

### DIFF
--- a/draft-ietf-httpbis-http2.xml
+++ b/draft-ietf-httpbis-http2.xml
@@ -813,7 +813,7 @@ Upgrade: HTTP/2.0
                 The endpoint is refusing the stream before processing its payload.
               </t>
               <t hangText="CANCEL (8):">
-                Used by the creator of a stream to indicate that the stream is no longer needed.
+                Used by the endpoint to indicate that the stream is no longer needed.
               </t>
               <t hangText="COMPRESSION_ERROR (9):">
                 The endpoint is unable to maintain the compression context for the connection.


### PR DESCRIPTION
3.4.1 Stream Creation says that either endpoint can send CNCEL.
