### PR TITLE
Remove error code of INVALID_STREAM

### DIFF
--- a/draft-ietf-httpbis-http2.xml
+++ b/draft-ietf-httpbis-http2.xml
@@ -799,9 +799,6 @@ Upgrade: HTTP/2.0
               <t hangText="FLOW_CONTROL_ERROR (3):">
                 The endpoint detected that its peer violated the flow control protocol.
               </t>
-              <t hangText="INVALID_STREAM (4):">
-                The endpoint received a frame for an inactive stream.
-              </t>
               <t hangText="STREAM_CLOSED (5):">
                 The endpoint received a frame after a stream was half-closed.
               </t>


### PR DESCRIPTION
It is no longer used after d5a8faeaa605bdff7b96287d72913b4b742104cf
