### PR TITLE
8-byte ping frame as discussed in the interim

### DIFF
--- a/draft-ietf-httpbis-http2.xml
+++ b/draft-ietf-httpbis-http2.xml
@@ -1395,10 +1395,12 @@ Upgrade: HTTP/2.0
           </t>
           
           <t>
-            PING frames consist of an arbitrary, variable-length sequence of 
-            octets. Receivers of a PING send a response PING frame with the PONG
-            flag set and precisely the same sequence of octets back to the 
-            sender as soon as possible.
+            In addition to the frame header, PING frames MUST contain 8 
+            additional octets of opaque data. A sender can utilize this 
+            payload in any manner it wishes but MUST include the
+            octets even if they are unused. Receivers of a PING send a 
+            response PING frame with the PONG flag set and precisely the 
+            same sequence of octets back to the sender as soon as possible.
           </t>
           
           <t>


### PR DESCRIPTION
As discussed in the interim, 8-byte PING frame, opaque octets that MUST be included regardless of whether they are used.
