### PR TITLE
Drop SETTINGS persistence as discussed at the interim

### DIFF
--- a/draft-ietf-httpbis-http2.xml
+++ b/draft-ietf-httpbis-http2.xml
@@ -1136,13 +1136,7 @@ Upgrade: HTTP/2.0
             applies.
           </t>
           <t>
-            The SETTINGS frame defines the following flag:
-            <list style="hanging">
-              <t hangText="CLEAR_PERSISTED (0x2):">
-                Bit 2 being set indicates a request to clear any previously persisted settings
-                before processing the settings.  Clients MUST NOT set this flag.
-              </t>
-            </list>
+            The SETTINGS frame does not have any frame specific flags.
           </t>
           <t>
             SETTINGS frames always apply to a connection, never a single stream.  
@@ -1174,78 +1168,11 @@ Upgrade: HTTP/2.0
             </figure>
             
             <t>
-              Two flags are defined for the 8-bit flags field:
-              <list style="hanging">
-                <t hangText="PERSIST_VALUE (0x1):">
-                  Bit 1 (the least significant bit) being set indicates a request from the server
-                  to the client to persist this setting.  A client MUST NOT set this flag.
-                </t>
-                <t hangText="PERSISTED (0x2):">
-                  Bit 2 being set indicates that this setting is a persisted setting being
-                  returned by the client to the server.  This also indicates that this setting is
-                  not a client setting, but a value previously set by the server.  A server MUST
-                  NOT set this flag.
-                </t>
-              </list>
+              There currently are no defined flags.
+              <cref>Ed. Note: Can we drop flags on individual settings</cref>
             </t>
           </section>
 
-          <section title="Setting Persistence">
-            <t>
-              <cref>Note that persistence of settings is under discussion in the WG and might be
-              removed in a future version of this document.</cref>
-            </t>
-            
-            <t>
-              A server endpoint can request that configuration parameters 
-              sent to a client in a SETTINGS frame are to be persisted by 
-              the client across HTTP/2.0 connections and returned to the server
-              in any new SETTINGS frame the client sends to the server
-              in the current connection or any future connections.
-            </t>
-            
-            <t>
-              Persistence is requested on a per-setting basis by setting the
-              PERSIST_VALUE flag (0x1).
-            </t>
-            
-            <t>
-              Client endpoints are not permitted to make such requests. Servers
-              MUST ignore any attempt by clients to request that a server 
-              persist configuration parameters.
-            </t>
-            
-            <t>
-              Persistence of configuration parameters is done on a per-origin
-              basis (see <xref target="RFC6454"/>). That is, when a client 
-              establishes a connection with a server, and the server requests that
-              the client maintain persistent settings, the client SHOULD return 
-              the persisted settings on all future connections to the same origin,
-              IP address and TCP port.
-            </t>
-
-            <t>
-              Whenever the client sends a SETTINGS frame in the current connection,
-              or establishes a new connection with the same origin, persisted 
-              configuration parameters are sent with the PERSISTED
-              flag (0x2) set for each persisted parameter.
-            </t>
-            
-            <t>
-              Persisted settings accumulate until the server requests that
-              all previously persisted settings are to be cleared by setting 
-              the CLEAR_PERSISTED (0x2) flag on the SETTINGS frame.
-            </t>
-
-            <t>
-              For example, if the server sends IDs 1, 2, and 3 with the 
-              FLAG_SETTINGS_PERSIST_VALUE in a first SETTINGS frame, and then 
-              sends IDs 4 and 5 with the FLAG_SETTINGS_PERSIST_VALUE in a 
-              subsequent SETTINGS frame, the client will return values for 
-              all 5 settings (1, 2, 3, 4, and 5 in this example) to the server.
-            </t>          
-          </section>
-          
           <section anchor="SettingValues" title="Defined Settings">
             <t>
               The following settings are defined:
@@ -2254,22 +2181,6 @@ Upgrade: HTTP/2.0
         </t>
       </section>
 
-      <section title="SETTINGS frame">
-        <t>
-          The HTTP/2.0 SETTINGS frame allows servers to store out-of-band transmitted information
-          about the communication between client and server on the client.  Although this is
-          intended only to be used to reduce latency, renegade servers could use it as a mechanism
-          to store identifying information about the client in future requests.
-        </t>
-
-        <t>
-          Clients implementing privacy modes can disable client-persisted SETTINGS storage.
-        </t>
-
-        <t>
-          Clients MUST clear persisted SETTINGS information when clearing the cookies.
-        </t>
-      </section>
     </section>
 
     <section title="IANA Considerations">
@@ -2296,7 +2207,7 @@ Upgrade: HTTP/2.0
           <c>1</c><c>HEADERS+PRIORITY</c><c>CONTINUES(2)</c>
           <c>2</c><c>PRIORITY</c><c>-</c>
           <c>3</c><c>RST_STREAM</c><c>-</c>
-          <c>4</c><c>SETTINGS</c><c>CLEAR_PERSISTED(2)</c>
+          <c>4</c><c>SETTINGS</c><c>-</c>
           <c>5</c><c>PUSH_PROMISE</c><c>CONTINUES(2)</c>
           <c>6</c><c>PING</c><c>PONG(2)</c>
           <c>7</c><c>GOAWAY</c><c>-</c>


### PR DESCRIPTION
Drops all mentions of SETTINGS persistence in the current draft as discussed at the interim
