### PR TITLE
typo

### DIFF
--- a/draft-ietf-httpbis-http2.xml
+++ b/draft-ietf-httpbis-http2.xml
@@ -360,7 +360,7 @@ Upgrade: HTTP/2.0
           connection initiator.
         </t>
         <t>HTTP/2.0 connections are persistent. That is, for best performance,
-          it is expected a clients will not close connections until it is 
+          it is expected clients will not close connections until it is 
           determined that no further communication with a server is necessary
           (for example, when a user navigates away from a particular web page),
           or until the server closes the connection.</t>


### PR DESCRIPTION
or

"a client with not close connections"
