### PR TITLE
Specify how to handle PING frames of lengths that aren't 8.

### DIFF
--- a/draft-ietf-httpbis-http2.xml
+++ b/draft-ietf-httpbis-http2.xml
@@ -1364,11 +1364,14 @@ Upgrade: HTTP/2.0
           
           <t>
             In addition to the frame header, PING frames MUST contain 8 
-            additional octets of opaque data. A sender can utilize this 
-            payload in any manner it wishes but MUST include the
-            octets even if they are unused. Receivers of a PING send a 
-            response PING frame with the PONG flag set and precisely the 
-            same sequence of octets back to the sender as soon as possible.
+            additional octets of opaque data. If a PING frame is received with
+            a length field value other than 8, the recipient MUST respond with a
+            <xref target="ConnectionErrorHandler">connection error</xref> of
+            type PROTOCOL_ERROR. A sender can utilize this payload in any manner
+            it wishes but MUST include the octets even if they are unused.
+            Receivers of a PING send a response PING frame with the PONG flag
+            set and precisely the same sequence of octets back to the sender as
+            soon as possible.
           </t>
           
           <t>


### PR DESCRIPTION
Specifically calls them out as connection errors of type
PROTOCOL_ERROR.

This addresses issue #68.
