### PR TITLE
Clarifying that the PRIORITY frame does not define any type-specific flags

### DIFF
--- a/draft-ietf-httpbis-http2.xml
+++ b/draft-ietf-httpbis-http2.xml
@@ -1059,6 +1059,11 @@ Upgrade: HTTP/2.0
             The payload of a PRIORITY frame contains a single reserved bit and a
             31-bit priority.
           </t>
+
+          <t>
+            The PRIORITY frame does not define any type-specific flags.
+          </t>
+
           <t>
             The PRIORITY frame is associated with an existing stream. If 
             a PRIORITY frame is received with a stream identifier of 0x0, 


### PR DESCRIPTION
All other frame descriptions specify explicitly if the frame type does not have any type-specific flags. The PRIORITY frame description should do the same if there are no flags.
