### PR TITLE
FRAME_TOO_LARGE renamed to FRAME_SIZE_ERROR ...

### DIFF
--- a/draft-ietf-httpbis-http2.xml
+++ b/draft-ietf-httpbis-http2.xml
@@ -525,9 +525,10 @@ Upgrade: HTTP/2.0
           <t>
             If an endpoint is unable to process a frame due to the payload size, 
             or if the size exceeds a strictly defined limit, the endpoint MUST 
-            send a FRAME_TOO_LARGE error. If the frame stream identifier is 0x0, 
-            this code MUST be sent as a connection error. If the stream 
-            identifier is anything other than 0x0, it is sent as a stream error.
+            send a FRAME_SIZE_ERROR. If the frame stream identifier is 0x0, or
+            if the Frame contains a <xref target="HeaderBlock">compressed header 
+            block</xref>, this code MUST be sent as a connection error; otherwise
+            it is sent as a stream error.
           </t>
         </section>
       </section>
@@ -819,9 +820,11 @@ Upgrade: HTTP/2.0
               <t hangText="STREAM_CLOSED (5):">
                 The endpoint received a frame after a stream was half-closed.
               </t>
-              <t hangText="FRAME_TOO_LARGE (6):">
-                The endpoint received a frame that was larger than the maximum size that it
-                supports.
+              <t hangText="FRAME_SIZE_ERROR (6):">
+                The endpoint received a frame that could not be processed
+                successfully because the frame's payload contained an incorrect
+                number of octets. For instance, a <xref target="PING">PING</xref>
+                frame containing fewer or more than 8 octets of payload data.
               </t>
               <t hangText="REFUSED_STREAM (7):">
                 The endpoint refuses the stream prior to performing any application processing, see


### PR DESCRIPTION
Per #140 ... Suggested pull request replacing FRAME_TOO_LARGE with FRAME_SIZE_ERROR
