### PR TITLE
HEADERS to start a stream

### DIFF
--- a/draft-ietf-httpbis-http2.xml
+++ b/draft-ietf-httpbis-http2.xml
@@ -572,8 +572,8 @@ Upgrade: HTTP/2.0
           <t>
             There is no coordination or shared action between the client and 
             server required to create a stream. Rather, new streams are 
-            established by sending a frame whose stream identifier field 
-            references a previously unused stream identifier.
+            opened by sending a HEADERS frame referencing a previously unused 
+            stream identifier.
           </t>
 
           <t>


### PR DESCRIPTION
Quick edit indicating that HEADERS are used to start a stream.

Additional refactoring will be done once the layering tf sections are filled in...
