### PR TITLE
Adding ASSOCIATED_ONLY flag as discussed at the Interim

### DIFF
--- a/draft-ietf-httpbis-http2.xml
+++ b/draft-ietf-httpbis-http2.xml
@@ -1156,9 +1156,9 @@ Upgrade: HTTP/2.0
           <t>
             The effect of the RST_STREAM frame depends on whether the
             ASSOCIATED_ONLY flag is set or not. When the flag is set, 
-            the RST_STREAM half-closes the associated streams but not
+            the RST_STREAM closes the associated streams but not
             the referenced stream. When it is unset, the RST_STREAM 
-            half-closes the referenced stream but not the associated ones 
+            closes the referenced stream but not the associated ones 
             (see <xref target="promise_association" />) .
           </t>
 
@@ -1443,7 +1443,7 @@ Upgrade: HTTP/2.0
             <t>
               Sending RST_STREAM in this way causes Streams #2 and #4 to
               enter the half-closed state but has no effect on the state 
-              of Stream #1. To half-close Stream #1, the endpoint would
+              of Stream #1. To close Stream #1, the endpoint would
               send an additional RST_STREAM referencing Stream #1 without
               the ASSOCIATED_ONLY flag.
             </t>


### PR DESCRIPTION
ASSOCIATED_ONLY on PRIORITY and RST_STREAM, better explanation and examples of promised stream association.
