### PR TITLE
Fixing a typo.

### DIFF
--- a/draft-ietf-httpbis-http2.xml
+++ b/draft-ietf-httpbis-http2.xml
@@ -1180,7 +1180,7 @@ Upgrade: HTTP/2.0
                 target="ConnectionErrorHandler">connection error</xref> of type PROTOCOL_ERROR.
               </t>
               <t hangText="PRIORITY (0x8):">
-                Bit 4 being set indicates that the first four octets of this frame contain a
+                Bit 8 being set indicates that the first four octets of this frame contain a
                 single reserved bit and a 31-bit priority; see <xref target="StreamPriority"/>.
               </t>
             </list>


### PR DESCRIPTION
"PRIORITY (0x8): Bit 4 being set..." -> "PRIORITY (0x8): Bit 8 being set..."
