### PR TITLE
Clarify no duplicate instances of HTTP2-Settings

### DIFF
--- a/draft-ietf-httpbis-http2.xml
+++ b/draft-ietf-httpbis-http2.xml
@@ -320,7 +320,7 @@
           A client that makes a request to an "http" URI without prior knowledge about support for
           HTTP/2.0 uses the HTTP Upgrade mechanism (<xref target="HTTP-p1" x:fmt="of"
           x:rel="#header.upgrade"/>).  The client makes an HTTP/1.1 request that includes an Upgrade
-          header field identifying HTTP/2.0.  The HTTP/1.1 request MUST include an <xref 
+          header field identifying HTTP/2.0.  The HTTP/1.1 request MUST include exactly one <xref 
             target="Http2SettingsHeader">HTTP2-Settings</xref> header field.
         </t>
         <figure>
@@ -388,7 +388,7 @@ Upgrade: HTTP/2.0
 
         <section anchor="Http2SettingsHeader" title="HTTP2-Settings Header Field">
           <t>
-            A client that upgrades from HTTP/1.1 to HTTP/2.0 MUST include an
+            A client that upgrades from HTTP/1.1 to HTTP/2.0 MUST include exactly one
             <spanx style="verb">HTTP2-Settings</spanx> header field.
             The <spanx style="verb">HTTP2-Settings</spanx> header field is a hop-by-hop header 
             field that includes settings that govern the HTTP/2.0 connection,


### PR DESCRIPTION
I think this is strictly an editorial clarification, not a technical change, but something that came up in discussions within the team.  If there's any question about that, feel free to push it back and we'll discuss on-list.
