### PR TITLE
Add condition of a promised stream in receiving PUSH_PROMISE

### DIFF
--- a/draft-ietf-httpbis-http2.xml
+++ b/draft-ietf-httpbis-http2.xml
@@ -1494,6 +1494,13 @@ HTTP2-Settings    = token68
           </t>
 
           <t>
+            Upon receiving a PUSH_PROMISE frame, a promised stream MUST be
+            in the "idle" state. If the promised stream is not in the "idle" state,
+            the recipient MUST respond with a <xref target="ConnectionErrorHandler">
+            connection error</xref> of type PROTOCOL_ERROR.
+          </t>
+
+          <t>
             Recipients of PUSH_PROMISE frames can choose to reject promised
             streams by returning a RST_STREAM referencing the promised stream
             identifier back to the sender of the PUSH_PROMISE.


### PR DESCRIPTION
As shown in the table in #175, the promised stream MUST be in the "idle" state in receiving PUSH_PROMISE.
