### PR TITLE
Revive the CONNECT method and spec a mapping on top of a stream.

### DIFF
--- a/draft-ietf-httpbis-http2.xml
+++ b/draft-ietf-httpbis-http2.xml
@@ -2470,7 +2470,7 @@ HTTP2-Settings    = token68
         <t>
           In HTTP/2.0, the CONNECT method is used to establish a tunnel over a
           single HTTP/2.0 stream to a remote host. The HTTP header mapping works
-          as mostly as defined in <xref target="HttpRequest">HttpRequest</xref>, with a few
+          as mostly as defined in <xref target="HttpRequest">Request Header Fields</xref>, with a few
           differences. Specifically:
           <list style="symbols">
               <t>


### PR DESCRIPTION
This pull request fixes #230 as per discussion in http://lists.w3.org/Archives/Public/ietf-http-wg/2013JulSep/1016.html.
