### PR TITLE
Remove reference to push headers being inherited

### DIFF
--- a/draft-ietf-httpbis-http2.xml
+++ b/draft-ietf-httpbis-http2.xml
@@ -2868,8 +2868,9 @@ HTTP2-Settings    = token68
           resource is synthesized from the request that triggered the push, plus resource
           identification information provided by the server.  Request header fields are necessary
           for HTTP cache control validations (such as the Vary header field) to work.  For this
-          reason, caches MUST inherit request header fields from the associated stream for the push.
-          This includes the Cookie header field.
+          reason, caches MUST associate the request header fields from the PUSH_PROMISE frame
+          with the response headers and content delivered on the pushed stream.  This includes
+          the Cookie header field.
         </t>
         <t>
           Caching resources that are pushed is possible, based on the guidance provided by the


### PR DESCRIPTION
We've long since agreed that full request headers are sent in the PUSH_PROMISE frame; found a lingering reference to pushed resources "inheriting" headers from the original request.  Revised it to reference the request headers in the PUSH_PROMISE frame like everywhere else.
