### PR TITLE
shorten alpn token from HTTP/2.0 to h2

### DIFF
--- a/draft-ietf-httpbis-http2.xml
+++ b/draft-ietf-httpbis-http2.xml
@@ -283,13 +283,13 @@
 
       <section anchor="versioning" title="HTTP/2.0 Version Identification">
         <t>
-          The protocol defined in this document is identified using the string "HTTP/2.0".  This
+          The protocol defined in this document is identified using the string "h2".  This
           identification is used in the HTTP/1.1 Upgrade header field, in the <xref
           target="TLSALPN">TLS application layer protocol negotiation extension</xref> field, and
           other places where protocol identification is required.
         </t>
         <t>
-          Negotiating "HTTP/2.0" implies the use of the transport, security, framing and message
+          Negotiating "h2" implies the use of the transport, security, framing and message
           semantics described in this document.
         </t>
         <t>
@@ -297,26 +297,24 @@
           of a final version of this document.</cref>
         </t>
         <t>
-          Only implementations of the final, published RFC can identify themselves as "HTTP/2.0".
-          Until such an RFC exists, implementations MUST NOT identify themselves using "HTTP/2.0".
+          Only implementations of the final, published RFC can identify themselves as "h2".
+          Until such an RFC exists, implementations MUST NOT identify themselves using "h2".
         </t>
         <t>
-          Examples and text throughout the rest of this document use "HTTP/2.0" as a matter of
+          Examples and text throughout the rest of this document use "h2" as a matter of
           editorial convenience only.  Implementations of draft versions MUST NOT identify using
-          this string.  The exception to this rule is the string included in the connection header
-          sent by clients immediately after establishing an HTTP/2.0 connection (see <xref
-          target="ConnectionHeader"/>); this fixed length sequence of octets does not change.
+          this string.
         </t>
         <t>
-          Implementations of draft versions of the protocol MUST add the string "-draft-" and the
-          corresponding draft number to the identifier before the separator ('/').  For example,
-          draft-ietf-httpbis-http2-03 is identified using the string "HTTP-draft-03/2.0".
+          Implementations of draft versions of the protocol MUST add the string "-" and the
+          corresponding draft number to the identifier. For example, draft-ietf-httpbis-http2-09
+          is identified using the string "h2-09".
         </t>
         <t>
-          Non-compatible experiments that are based on these draft versions MUST instead replace the
-          string "draft" with a different identifier.  For example, an experimental implementation
-          of packet mood-based encoding based on draft-ietf-httpbis-http2-07 might identify itself
-          as "HTTP-emo-07/2.0".  Note that any label MUST conform to the "token" syntax defined in
+          Non-compatible experiments that are based on these draft versions MUST append the string
+          "-" and a experiment name to the identifier.  For example, an experimental implementation
+          of packet mood-based encoding based on draft-ietf-httpbis-http2-09 might identify itself
+          as "h2-09-emo".  Note that any label MUST conform to the "token" syntax defined in
           <xref target="HTTP-p1" x:fmt="of" x:rel="#field.components"/>.  Experimenters are
           encouraged to coordinate their experiments on the ietf-http-wg@w3.org mailing list.
         </t>
@@ -327,7 +325,8 @@
           A client that makes a request to an "http" URI without prior knowledge about support for
           HTTP/2.0 uses the HTTP Upgrade mechanism (<xref target="HTTP-p1" x:fmt="of"
           x:rel="#header.upgrade"/>).  The client makes an HTTP/1.1 request that includes an Upgrade
-          header field identifying HTTP/2.0.  The HTTP/1.1 request MUST include exactly one <xref
+          header field identifying HTTP/2.0 with the h2 token.
+          The HTTP/1.1 request MUST include exactly one <xref
           target="Http2SettingsHeader">HTTP2-Settings</xref> header field.
         </t>
         <figure>
@@ -336,7 +335,7 @@
 GET /default.htm HTTP/1.1
 Host: server.example.com
 Connection: Upgrade, HTTP2-Settings
-Upgrade: HTTP/2.0
+Upgrade: h2
 HTTP2-Settings: &lt;base64url encoding of HTTP/2.0 SETTINGS payload>
 </artwork>
         </figure>
@@ -374,7 +373,7 @@ Content-Type: text/html
           <artwork type="message/http; msgtype=&#34;response&#34;" x:indent-with="  ">
 HTTP/1.1 101 Switching Protocols
 Connection: Upgrade
-Upgrade: HTTP/2.0
+Upgrade: h2
 
 [ HTTP/2.0 connection ...
 </artwork>
@@ -2984,8 +2983,8 @@ HTTP2-Settings    = token68
           target="TLSALPN"/>.
           <list style="hanging">
             <t hangText="Protocol:">HTTP/2.0</t>
-            <t hangText="Identification Sequence:">0x48 0x54 0x54 0x50 0x2f 0x32 0x2e 0x30
-            ("HTTP/2.0")</t>
+            <t hangText="Identification Sequence:"> 0x68 0x32
+            ("h2")</t>
             <t hangText="Specification:">This document (RFCXXXX)</t>
           </list>
         </t>


### PR DESCRIPTION
TLS Client Hello's between 256 and 512 bytes need to be rounded up to 512 for compatibility reasons. This incents us to keep Client Hello parameters as small as possible to avoid the rounding - this change shortens the ALPN token of HTTP/2.0 to be simply "h2"
