### PR TITLE
Reserve PRI method in HTTP/1.1 to avoid collision

### DIFF
--- a/draft-ietf-httpbis-http2.xml
+++ b/draft-ietf-httpbis-http2.xml
@@ -449,7 +449,8 @@ HTTP2-Settings    = token68
         <t>
           A client can learn that a particular server supports HTTP/2.0 by other means.  A client
           MAY immediately send HTTP/2.0 frames to a server that is known to support HTTP/2.0, after
-          the <xref target="ConnectionHeader">connection header</xref>.  This only affects the
+          the <xref target="ConnectionHeader">connection header</xref>.  A server can identify such
+          a connection by the use of the "PRI" method in the connection header.  This only affects the
           resolution of "http" URIs; servers supporting HTTP/2.0 are required to support <xref
           target="TLSALPN">protocol negotiation in TLS</xref> for "https" URIs.
         </t>
@@ -3040,6 +3041,10 @@ HTTP2-Settings    = token68
         This document registers the <spanx style="verb">HTTP2-Settings</spanx> header field for
         use in HTTP.
       </t>
+      <t>
+          This document registers the <spanx style="verb">PRI</spanx> method for use in HTTP, to
+          avoid collisions with the <xref target="ConnectionHeader">connection header</xref>.
+      </t>
 
       <section anchor="iana-alpn" title="Registration of HTTP/2.0 Identification String">
         <t>
@@ -3196,6 +3201,33 @@ HTTP2-Settings    = token68
             </t>
             <t hangText="Related information:">
               This header field is only used by an HTTP/2.0 client for Upgrade-based negotiation.
+            </t>
+          </list>
+        </t>
+      </section>
+      
+      <section title="PRI Method Registration">
+        <t>
+          This section registers the <spanx style="verb">PRI</spanx> method in the 
+          <xref target="HTTP-p2">HTTP Method Registry</xref>.
+          <list style="hanging">
+            <t hangText="Method Name:">
+                 PRI
+            </t>
+            <t hangText="Safe">
+                 No
+            </t>
+            <t hangText="Idempotent">
+                 No
+            </t>
+            <t hangText="Specification document(s)">
+                 <xref target="ConnectionHeader"/> of this document
+            </t>
+            <t hangText="Related information:">
+                 This method is never used by an actual client.  This method will
+                 appear to be used when an HTTP/1.1 server or intermediary attempts
+                 to parse an HTTP/2.0 connection <xref target="known-http">with prior
+                 knowledge</xref>.
             </t>
           </list>
         </t>
@@ -3567,7 +3599,7 @@ HTTP2-Settings    = token68
 
       <section title="Since draft-ietf-httpbis-http2-08" anchor="changes.since.draft-ietf-httpbis-http2-09">
         <t>
-          None yet.
+          Reserved PRI method in HTTP/1.1 to avoid possible future collisions.
         </t>
       </section>
 


### PR DESCRIPTION
In http://www.w3.org/mid/5215922F.4090509@treenet.co.nz;list=ietf-http-wg, it was proposed that the PRI method be reserved in the HTTP/1.1 method registration document to avoid possible future reservation and ensure that the magic string remains a reliable way of differentiating HTTP/1.1 connections from HTTP/2.0 connections.  There was a +1 and some offline discussion along the same vein, no dissent that I heard or saw.  However, I don’t see it in http://tools.ietf.org/html/draft-ietf-httpbis-method-registrations-14, presumably because no RFC exists to reference.  The appropriate doc is probably HTTP/2.0 rather than breaking the glass on the prepopulated registrations.
