### PR TITLE
Correct very minor grammatical error in section 8.3

### DIFF
--- a/draft-ietf-httpbis-http2.xml
+++ b/draft-ietf-httpbis-http2.xml
@@ -2756,7 +2756,7 @@ HTTP2-Settings    = token68
         <t>
           The HTTP pseudo-method CONNECT (<xref target="HTTP-p2" x:fmt="," x:rel="#CONNECT"/>) is
           used to convert an HTTP/1.1 connection into a tunnel to a remote host.  CONNECT is
-          primarily used with HTTP proxies to established a TLS session with a server for the
+          primarily used with HTTP proxies to establish a TLS session with a server for the
           purposes of interacting with <spanx style="verb">https</spanx> resources.
         </t>
         <t>


### PR DESCRIPTION
The sentence in 8.3:

"CONNECT is primarily used with HTTP proxies to **established** a TLS session with a server for the purposes of interacting with https resources."

... does not read. I believe it should be:

"CONNECT is primarily used with HTTP proxies to **establish** a TLS session with a server for the purposes of interacting with https resources."

This pull request fixes this incredibly minor issue.
