### PR TITLE
Describe handling of invalid values for SETTINGS_ENABLE_PUSH.

### DIFF
--- a/draft-ietf-httpbis-http2.xml
+++ b/draft-ietf-httpbis-http2.xml
@@ -1625,7 +1625,10 @@ HTTP2-Settings    = token68
                     <x:ref>PROTOCOL_ERROR</x:ref>.
                   </t>
                   <t>
-                    The initial value is 1, which indicates that push is permitted.
+                    The initial value is 1, which indicates that push is permitted. Any value other
+                    than 0 or 1 MUST be treated as a  <xref
+                      target="ConnectionErrorHandler">connection error</xref> of type
+                    <x:ref>PROTOCOL_ERROR</x:ref>.
                   </t>
                 </x:lt>
                 <x:lt hangText="SETTINGS_MAX_CONCURRENT_STREAMS (3):" anchor="SETTINGS_MAX_CONCURRENT_STREAMS">


### PR DESCRIPTION
SETTINGS_ENABLE_PUSH values different from 0 or 1 should be handled as a connection error.
