### PR TITLE
Small clarification on what kind of extension

### DIFF
--- a/draft-ietf-httpbis-http2.xml
+++ b/draft-ietf-httpbis-http2.xml
@@ -1599,9 +1599,9 @@ HTTP2-Settings    = token68
 
           <t>
             Implementations MUST support all of the settings defined by this specification and MAY
-            support additional settings defined by extensions. Unsupported or unrecognized settings
-            MUST be ignored.  New settings MUST NOT be defined or implemented in a way that requires
-            endpoints to understand them in order to communicate successfully.
+            support additional settings defined by extensions to this protocol. Unsupported or 
+            unrecognized settings MUST be ignored.  New settings MUST NOT be defined or implemented
+            in a way that requires endpoints to understand them in order to communicate successfully.
           </t>
 
           <t>


### PR DESCRIPTION
This is a really minor thing, but as I was reading the spec, I was wondering for a bit what "extensions" meant (user defined? something else?). I think the intent is to reference extensions defined by future RFCs that revise HTTP/2 protocol.
