### PR TITLE
Move Pad High and Pad Low to right after frame header for HEADERS

### DIFF
--- a/draft-ietf-httpbis-http2.xml
+++ b/draft-ietf-httpbis-http2.xml
@@ -1367,10 +1367,10 @@ HTTP2-Settings    = token68
  0                   1                   2                   3
  0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
  +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
- |X|                       [Priority (31)]                       |
- +-+-------------+---------------+-------------------------------+
- | [Pad High(8)] | [Pad Low (8)] |  Header Block Fragment (*)    .
- +---------------+---------------+-------------------------------+
+ | [Pad High(8)] | [Pad Low (8)] |X|      [Priority (31)]      ...
+ +---------------+---------------+-+-----------------------------+
+ ...[Priority]                   | Header Block Fragment (*)   ...
+ +-------------------------------+-------------------------------+
  |                   Header Block Fragment (*)                 ...
  +---------------------------------------------------------------+
  |                           Padding (*)                       ...
@@ -1380,6 +1380,12 @@ HTTP2-Settings    = token68
           <t>
             The HEADERS frame payload has the following fields:
             <list style="hanging">
+              <t hangText="Pad High:">
+                Padding size high bits.  This field is only present if the PAD_HIGH flag is set.
+              </t>
+              <t hangText="Pad Low:">
+                Padding size low bits.  This field is only present if the PAD_LOW flag is set.
+              </t>
               <t hangText="X:">
                 A single reserved bit.  This field is optional and is only present if the PRIORITY
                 flag is set.
@@ -1387,12 +1393,6 @@ HTTP2-Settings    = token68
               <t hangText="Priority:">
                 Prioritization information for the stream, see <xref target="StreamPriority"/>.
                 This field is optional and is only present if the PRIORITY flag is set.
-              </t>
-              <t hangText="Pad High:">
-                Padding size high bits.  This field is only present if the PAD_HIGH flag is set.
-              </t>
-              <t hangText="Pad Low:">
-                Padding size low bits.  This field is only present if the PAD_LOW flag is set.
               </t>
               <t hangText="Header Block Fragment:">
                 A <xref target="HeaderBlock">header block fragment</xref>.


### PR DESCRIPTION
Padding is made to a frame and other frames
(DATA and CONTINUATION) have these 2 bytes right after the frame
header. It is easier for implementation to put the same constructs
in the same position.
