### PR TITLE
remove description of unsupported or unrecognized settings

### DIFF
--- a/draft-ietf-httpbis-http2.xml
+++ b/draft-ietf-httpbis-http2.xml
@@ -1598,10 +1598,7 @@ HTTP2-Settings    = token68
           </t>
 
           <t>
-            Implementations MUST support all of the settings defined by this specification and MAY
-            support additional settings defined by extensions to this protocol. Unsupported or
-            unrecognized settings MUST be ignored.  New settings MUST NOT be defined or implemented
-            in a way that requires endpoints to understand them in order to communicate successfully.
+            Implementations MUST support all of the settings defined by this specification.
           </t>
 
           <t>


### PR DESCRIPTION
Extension of settings was dropped in #95
