### PR TITLE
Remove END_PUSH_PROMISE in favor of END_HEADERS

### DIFF
--- a/draft-ietf-httpbis-http2.xml
+++ b/draft-ietf-httpbis-http2.xml
@@ -651,11 +651,11 @@ HTTP2-Settings    = token68
           <list style="symbols">
             <t>
               a single <x:ref>HEADERS</x:ref> or <x:ref>PUSH_PROMISE</x:ref> frame,
-              with the END_HEADERS or END_PUSH_PROMISE flag set, or
+              with the END_HEADERS flag set, or
             </t>
             <t>
-              a <x:ref>HEADERS</x:ref> or <x:ref>PUSH_PROMISE</x:ref> frame with the END_HEADERS or
-              END_PUSH_PROMISE flag cleared and one or more <x:ref>CONTINUATION</x:ref> frames,
+              a <x:ref>HEADERS</x:ref> or <x:ref>PUSH_PROMISE</x:ref> frame with the END_HEADERS
+              flag cleared and one or more <x:ref>CONTINUATION</x:ref> frames,
               where the last <x:ref>CONTINUATION</x:ref> frame has the END_HEADERS flag set.
             </t>
           </list>
@@ -665,8 +665,7 @@ HTTP2-Settings    = token68
           frames of any other type or from any other stream.  The last frame in a sequence of
           <x:ref>HEADERS</x:ref> or <x:ref>CONTINUATION</x:ref> frames MUST have the END_HEADERS
           flag set.  The last frame in a sequence of <x:ref>PUSH_PROMISE</x:ref> or
-          <x:ref>CONTINUATION</x:ref> frames MUST have the END_PUSH_PROMISE or END_HEADERS flag set
-          (respectively).
+          <x:ref>CONTINUATION</x:ref> frames MUST have the END_HEADERS flag set.
         </t>
         <t>
           Header block fragments can only be sent as the payload of <x:ref>HEADERS</x:ref>,
@@ -1810,14 +1809,14 @@ HTTP2-Settings    = token68
           <t>
             The PUSH_PROMISE frame defines the following flags:
             <list style="hanging">
-              <x:lt hangText="END_PUSH_PROMISE (0x4):">
+              <x:lt hangText="END_HEADERS (0x4):">
                 <t>
                   Bit 3 being set indicates that this frame contains an entire <xref
                   target="HeaderBlock">header block</xref> and is not followed by any
                   <x:ref>CONTINUATION</x:ref> frames.
                 </t>
                 <t>
-                  A PUSH_PROMISE frame without the END_PUSH_PROMISE flag set MUST be followed by a
+                  A PUSH_PROMISE frame without the END_HEADERS flag set MUST be followed by a
                   CONTINUATION frame for the same stream.  A receiver MUST treat the receipt of any
                   other type of frame or a frame on a different stream as a <xref
                   target="ConnectionErrorHandler">connection error</xref> of type
@@ -2234,7 +2233,7 @@ HTTP2-Settings    = token68
             target="HeaderBlock">header block fragments</xref>.  Any number of CONTINUATION frames
             can be sent on an existing stream, as long as the preceding frame on the same stream is
             one of <x:ref>HEADERS</x:ref>, <x:ref>PUSH_PROMISE</x:ref> or CONTINUATION without the
-            END_HEADERS or END_PUSH_PROMISE flag set.
+            END_HEADERS flag set.
           </t>
 
           <figure title="CONTINUATION Frame Payload">


### PR DESCRIPTION
This simplifies the text and makes flag consistent with CONTINUATION
which only bears END_HEADERS.

Technically, both have the same meaning of ending sequence of
header block fragments. Therefore there is no reason to use the
different flag name for the same purpose.

This will also make the implementaion easier because most likely
HEADERS and PUSH_PROMISE handling share the same code and
dancing with END_PUSH_PROMISE and END_HEADERS is not fun.
Although currently they have the same number, it is not
guaranteed to the last. If they are guarenteed to be the same, then
it is simpler to use the same name for same value.
