### PR TITLE
Fixing the example of trailer

### DIFF
--- a/draft-ietf-httpbis-http2.xml
+++ b/draft-ietf-httpbis-http2.xml
@@ -2636,18 +2636,18 @@ HTTP2-Settings    = token68
   HTTP/1.1 200 OK               HEADERS
   Content-Type: image/jpeg ===>   - END_STREAM
   Transfer-Encoding: chunked      + END_HEADERS
-  TE: trailers                      :status        = 200
-                                    content-length = 123
-  123                               content-type   = image/jpeg
+  Trailer: X-Checksum               :status        = 200
+                                    content-type   = image/jpeg
+  123                               trailer        = x-checksum
   {binary data}
   0                             DATA
-  Foo: bar                        - END_STREAM
+  X-Checksum: 4649beaf            - END_STREAM
                                     {binary data}
 
                                 HEADERS
                                   + END_STREAM
                                   + END_HEADERS
-                                    foo: bar
+                                    x-checksum     = 4649beaf
 ]]></artwork>
         </figure>
       </section>


### PR DESCRIPTION
- TE: should be Tariler:
- content-length should be removed
- trailer should be in HEADERS
- Foo should be another reasonable header - X-Checksum
