### PR TITLE
Drop deflate as a required content-encoding.

### DIFF
--- a/draft-ietf-httpbis-http2.xml
+++ b/draft-ietf-httpbis-http2.xml
@@ -3213,9 +3213,8 @@ HTTP2-Settings    = token68
       <section anchor="Compression" title="GZip Content-Encoding">
         <t>
           Clients MUST support gzip compression for HTTP response bodies.  Regardless of the value
-          of the accept-encoding header field, a server MAY send responses with gzip or deflate
-          encoding.  A compressed response MUST still bear an appropriate content-encoding header
-          field.
+          of the accept-encoding header field, a server MAY send responses with gzip encoding.  A
+          compressed response MUST still bear an appropriate content-encoding header field.
         </t>
       </section>
     </section>


### PR DESCRIPTION
See http://lists.w3.org/Archives/Public/ietf-http-wg/2014JanMar/0699.html
