### PR TITLE
Clarify text for PUSH_PROMISE

### DIFF
--- a/draft-ietf-httpbis-http2.xml
+++ b/draft-ietf-httpbis-http2.xml
@@ -2086,8 +2086,10 @@ HTTP2-Settings    = token68
           </t>
 
           <t>
-            PUSH_PROMISE frames MUST be associated with an existing, peer-initiated stream. If the
-            stream identifier field specifies the value 0x0, a recipient MUST respond with a <xref
+            PUSH_PROMISE frames MUST be associated with an existing, peer-initiated stream. The 
+            stream identifier of a PUSH_PROMISE frame indicates the stream it is associated with.
+            If the stream identifier field specifies the value 0x0, a recipient MUST respond with a
+            <xref 
             target="ConnectionErrorHandler">connection error</xref> of type
             <x:ref>PROTOCOL_ERROR</x:ref>.
           </t>


### PR DESCRIPTION
I realize this is somewhat redundant given section 5.1.1, so I don't mind if this pull is rejected. The main reason I think this might be useful is since there are two different stream identifiers involved in PUSH_PROMISE: the promised stream id and the stream identifier in the common header. The extra sentence just makes it explicit how PUSH_PROMISE is linked to an earlier request. It also puts the following sentence in better context.
