### PR TITLE
Enable weight of 0.

### DIFF
--- a/draft-ietf-httpbis-http2.xml
+++ b/draft-ietf-httpbis-http2.xml
@@ -1187,7 +1187,7 @@ HTTP2-Settings    = token68
         <section title="Priority Groups and Weighting" anchor="pri-group">
           <t>
             All streams are assigned a priority group.  Each priority group is allocated a 31-bit
-            identifier and an integer weight between 1 to 256 (inclusive).
+            identifier and an integer weight between 0 to 255 (inclusive).
           </t>
           <t>
             Specifying a priority group and weight for a stream causes the stream to be assigned to
@@ -1198,6 +1198,11 @@ HTTP2-Settings    = token68
             Resources are divided proportionally between priority groups based on their weight.  For
             example, a priority group with weight 4 ideally receives one third of the resources
             allocated to a stream with weight 12.
+          </t>
+          <t>
+            A weight of 0 indicates that no resources should be allocated to the priority group,
+            unless these resources cannot be used by priority groups with a weight strictly greater
+            than 0.
           </t>
         </section>
 


### PR DESCRIPTION
Change the range of weight for a priority group to 0-255.
0 means that no resource is to be allocated to the group, unless there is nothing else to do.
It enables an efficient way of pausing a set of streams.
