### PR TITLE
Editorial fix in PUSH_PROMISE and make PAD_LOW/PAD_HIGH bit consistent

### DIFF
--- a/draft-ietf-httpbis-http2.xml
+++ b/draft-ietf-httpbis-http2.xml
@@ -1470,11 +1470,11 @@ HTTP2-Settings    = token68
                 Intermediaries MUST NOT coalesce frames across a segment boundary and MUST preserve
                 segment boundaries when forwarding frames.
               </t>
-              <t hangText="PAD_LOW (0x10):">
-                Bit 5 being set indicates that the Pad Low field is present.
+              <t hangText="PAD_LOW (0x08):">
+                Bit 4 being set indicates that the Pad Low field is present.
               </t>
-              <t hangText="PAD_HIGH (0x20):">
-                Bit 6 being set indicates that the Pad High field is present.  This bit MUST NOT be
+              <t hangText="PAD_HIGH (0x10):">
+                Bit 5 being set indicates that the Pad High field is present.  This bit MUST NOT be
                 set unless the PAD_LOW flag is also set.  Endpoints that receive a frame with
                 PAD_HIGH set and PAD_LOW cleared MUST treat this as a <xref
                 target="ConnectionErrorHandler">connection error</xref> of type
@@ -2023,7 +2023,7 @@ HTTP2-Settings    = token68
 ]]></artwork>
           </figure>
           <t>
-            The HEADERS frame payload has the following fields:
+            The PUSH_PROMISE frame payload has the following fields:
             <list style="hanging">
               <t hangText="Pad High:">
                 Padding size high bits.  This field is only present if the PAD_HIGH flag is set.


### PR DESCRIPTION
I believe that PAD_LOW and PAD_HIGH bits in DATA frame were not updated when the dependency based priority was merged. It is quite a headache for implementors if these bits differ across frames.
