### PR TITLE
Update static table indexes in example

### DIFF
--- a/draft-ietf-httpbis-header-compression.xml
+++ b/draft-ietf-httpbis-header-compression.xml
@@ -2102,7 +2102,7 @@ to HTTP requests, on the same connection.
             <figure>
                 <preamble>Hex dump of encoded data:</preamble>
                 <artwork>
-<![CDATA[8287 8604 0f77 7777 2e65 7861 6d70 6c65 | .....www.example
+<![CDATA[8286 8404 0f77 7777 2e65 7861 6d70 6c65 | .....www.example
 2e63 6f6d                               | .com]]></artwork>
             </figure>
         </t>


### PR DESCRIPTION
I _think_ these indexes should be 6 and 4 rather than 7 and 6 - in the static table 7 and 6 are ":scheme: https" and ":scheme: http" respectively.
