### PR TITLE
Editorial fix

### DIFF
--- a/draft-ietf-httpbis-http2.xml
+++ b/draft-ietf-httpbis-http2.xml
@@ -398,7 +398,7 @@ Content-Type: text/html
           <artwork type="message/http; msgtype=&#34;response&#34;" x:indent-with="  ">
 HTTP/1.1 101 Switching Protocols
 Connection: Upgrade
-Upgrade: h2
+Upgrade: h2c
 
 [ HTTP/2 connection ...
 </artwork>


### PR DESCRIPTION
Unless I am completely wrong, the Upgrade response header field also includes h2c since this is a cleartext http2 negotiated.
