### PR TITLE
Add text to tell how to obtain [1,256] weight from 1 octet field

### DIFF
--- a/draft-ietf-httpbis-http2.xml
+++ b/draft-ietf-httpbis-http2.xml
@@ -1608,7 +1608,8 @@ B   C              / \
               </t>
               <t hangText="Weight:">
                 An 8-bit weight for the identified priority group, see <xref
-                target="StreamPriority"/>.  This field is optional and is only present if the
+                target="StreamPriority"/>.  Add one to the value to obtain a weight between 1 and 256.
+                This field is optional and is only present if the
                 PRIORITY_GROUP flag is set.
               </t>
               <t hangText="E:">
@@ -1759,7 +1760,8 @@ B   C              / \
               </t>
               <t hangText="Weight:">
                 An 8-bit weight for the identified priority group, see <xref
-                target="StreamPriority"/>.  This field is optional and is only present if the
+                target="StreamPriority"/>.  Add one to the value to obtain a weight between 1 and 256.
+                This field is optional and is only present if the
                 PRIORITY_GROUP flag is set.
               </t>
               <t hangText="E:">


### PR DESCRIPTION
This wording once existed in priority branch in github, but missing in
the current draft.
