### PR TITLE
Priority update

### DIFF
--- a/draft-ietf-httpbis-http2.xml
+++ b/draft-ietf-httpbis-http2.xml
@@ -1340,6 +1340,14 @@ HTTP2-Settings    = token68
             higher than expressed by a peer.
           </t>
           <t>
+            Related streams can be grouped inside a subtree of the dependency tree, with the root of
+            the subtree depending on stream 0. The priority of the whole group can be modified by
+            changing the weight of the dependency of the subtree's root. If the priority information
+            for this root is discarded, the ability to reprioritize the whole group is lost. This
+            can lead to suboptimal prioritization between several groups of streams, as relative
+            priority changes between the groups expressed by a peer are not taken into account.
+          </t>
+          <t>
             To avoid these problems, endpoints SHOULD maintain prioritization state for closed
             streams for a period after streams close.
           </t>


### PR DESCRIPTION
Several editions for new priority description.
Includes a paragraph on the ability to group streams into dependency subtree to allow the reprioritization of a whole group of streams at once.
