### PR TITLE
Proposed text for #458

### DIFF
--- a/draft-ietf-httpbis-http2.xml
+++ b/draft-ietf-httpbis-http2.xml
@@ -2280,6 +2280,17 @@ HTTP2-Settings    = token68
           stream identifier, since this would cause clients to abandon automatic retry of requests
           if a GOAWAY frame is lost.
         </t>
+        <t>
+          A client that is unable to retry requests loses all requests that are in flight when the
+          server closes the connection.  This is especially true for intermediaries that might
+          not be serving clients using HTTP/2.  A server that is attempting to gracefully shut down
+          a connection SHOULD send an initial GOAWAY frame with the last stream identifier set to
+          2<x:sup>31</x:sup>-1 and a <x:ref>NO_ERROR</x:ref> code.  This signals to the client that
+          a shutdown is imminent and that no further requests can be initiated.  After waiting at
+          least one round trip time, the server can send another GOAWAY frame with an updated last
+          stream identifier.  This ensures that a connection can be cleanly shut down without losing
+          requests.
+        </t>
 
         <t>
           After sending a GOAWAY frame, the sender can discard frames for streams with identifiers


### PR DESCRIPTION
We left #458 open pending some explicit text about the double GOAWAY graceful shutdown. Here is some proposed text that we can iterate on. One difference from what we discussed is the first GOAWAY has last-stream-id of 2^31 - 1. The calculation based on MAX_CONCURRENT_STREAMS isn't really needed and just opens up implementations to bugs.
