### PR TITLE
Use "name = value" consistently for headers

### DIFF
--- a/draft-ietf-httpbis-http2.xml
+++ b/draft-ietf-httpbis-http2.xml
@@ -2963,8 +2963,8 @@ HTTP2-Settings    = token68
   ETag: "xyzzy"              ==>     + END_STREAM
   Expires: Thu, 23 Jan ...           + END_HEADERS
                                        :status = 304
-                                       etag: "xyzzy"
-                                       expires: Thu, 23 Jan ...
+                                       etag = "xyzzy"
+                                       expires = Thu, 23 Jan ...
 ]]></artwork>
           </figure>
 
@@ -3049,7 +3049,7 @@ HTTP2-Settings    = token68
                                    HEADERS
                                      + END_STREAM
                                      + END_HEADERS
-                                       foo: bar
+                                       foo = bar
 ]]></artwork>
         </figure>
       </section>
@@ -3220,8 +3220,8 @@ HTTP2-Settings    = token68
           </t>
           <figure>
             <artwork type="inline"><![CDATA[
-              cache-control: max-age=60, private\0must-revalidate
-              content-type: text/html
+              cache-control = max-age=60, private\0must-revalidate
+              content-type = text/html
 ]]></artwork></figure>
           <t>
             Note here that the ordering between Content-Type and Cache-Control is not preserved, but


### PR DESCRIPTION
There has been some inconsistency in the format used for headers, with some
using `name: value` and others using `name = value`. As these are only
approximations, either is fine, but internal consistency is desirable.

With the colon-prefixed names now extant, `:name = value` is subjectively
clearer than `:name: value`; for this reason, I have normalised headers to
`name = value` rather than `name: value`.
