### PR TITLE
Fix literal string lengths with Huffman encodings in examples.

### DIFF
--- a/draft-ietf-httpbis-header-compression.xml
+++ b/draft-ietf-httpbis-header-compression.xml
@@ -2522,7 +2522,7 @@ using Huffman encoding for the literal values.
             <figure>
                 <preamble>Hex dump of encoded data:</preamble>
                 <artwork>
-<![CDATA[8287 8644 8ce7 cf9b ebe8 9b6f b16f a9b6 | ...D.......o.o..
+<![CDATA[8287 8644 8fe7 cf9b ebe8 9b6f b16f a9b6 | ...D.......o.o..
 ff                                      | .]]></artwork>
             </figure>
         </t>
@@ -2542,7 +2542,7 @@ ff                                      | .]]></artwork>
 44                                      | == Literal indexed ==
                                         |   Indexed name (idx = 4)
                                         |     :authority
-8c                                      |   Literal value (len = 15)
+8f                                      |   Literal value (len = 15)
                                         |     Huffman encoded:
 e7cf 9beb e89b 6fb1 6fa9 b6ff           | ......o.o...
                                         |     Decoded:
@@ -2603,7 +2603,7 @@ cache-control: no-cache]]></artwork>
             <figure>
                 <preamble>Hex dump of encoded data:</preamble>
                 <artwork>
-<![CDATA[5c86 b9b9 9495 56bf                     | \.....V.]]></artwork>
+<![CDATA[5c88 b9b9 9495 56bf                     | \.....V.]]></artwork>
             </figure>
         </t>
         <t>
@@ -2613,7 +2613,7 @@ cache-control: no-cache]]></artwork>
 <![CDATA[5c                                      | == Literal indexed ==
                                         |   Indexed name (idx = 28)
                                         |     cache-control
-86                                      |   Literal value (len = 8)
+88                                      |   Literal value (len = 8)
                                         |     Huffman encoded:
 b9b9 9495 56bf                          | ....V.
                                         |     Decoded:
@@ -2678,7 +2678,7 @@ custom-key: custom-value]]></artwork>
             <figure>
                 <preamble>Hex dump of encoded data:</preamble>
                 <artwork>
-<![CDATA[3085 8c8b 8440 8857 1c5c db73 7b2f af89 | 0....@.W.\.s{/..
+<![CDATA[3085 8c8b 8440 8a57 1c5c db73 7b2f af8c | 0....@.W.\.s{/..
 571c 5cdb 7372 4d9c 57                  | W.\.srM.W]]></artwork>
             </figure>
         </t>
@@ -2703,12 +2703,12 @@ custom-key: custom-value]]></artwork>
                                         | -> :authority: www.example\
                                         |   .com
 40                                      | == Literal indexed ==
-88                                      |   Literal name (len = 10)
+8a                                      |   Literal name (len = 10)
                                         |     Huffman encoded:
 571c 5cdb 737b 2faf                     | W.\.s{/.
                                         |     Decoded:
                                         | custom-key
-89                                      |   Literal value (len = 12)
+8c                                      |   Literal value (len = 12)
                                         |     Huffman encoded:
 571c 5cdb 7372 4d9c 57                  | W.\.srM.W
                                         |     Decoded:
@@ -3059,9 +3059,9 @@ location: https://www.example.com]]></artwork>
             <figure>
                 <preamble>Hex dump of encoded data:</preamble>
                 <artwork>
-<![CDATA[4882 4017 5985 bf06 724b 9763 93d6 dbb2 | H.@.Y...rK.c....
+<![CDATA[4883 4017 5987 bf06 724b 9763 9dd6 dbb2 | H.@.Y...rK.c....
 9884 de2a 7188 0506 2098 5131 09b5 6ba3 | ...*q... .Q1..k.
-7191 adce bf19 8e7e 7cf9 bebe 89b6 fb16 | q.......|.......
+7197 adce bf19 8e7e 7cf9 bebe 89b6 fb16 | q.......|.......
 fa9b 6f                                 | ..o]]></artwork>
             </figure>
         </t>
@@ -3072,7 +3072,7 @@ fa9b 6f                                 | ..o]]></artwork>
 <![CDATA[48                                      | == Literal indexed ==
                                         |   Indexed name (idx = 8)
                                         |     :status
-82                                      |   Literal value (len = 3)
+83                                      |   Literal value (len = 3)
                                         |     Huffman encoded:
 4017                                    | @.
                                         |     Decoded:
@@ -3081,7 +3081,7 @@ fa9b 6f                                 | ..o]]></artwork>
 59                                      | == Literal indexed ==
                                         |   Indexed name (idx = 25)
                                         |     cache-control
-85                                      |   Literal value (len = 7)
+87                                      |   Literal value (len = 7)
                                         |     Huffman encoded:
 bf06 724b 97                            | ..rK.
                                         |     Decoded:
@@ -3090,7 +3090,7 @@ bf06 724b 97                            | ..rK.
 63                                      | == Literal indexed ==
                                         |   Indexed name (idx = 35)
                                         |     date
-93                                      |   Literal value (len = 29)
+9d                                      |   Literal value (len = 29)
                                         |     Huffman encoded:
 d6db b298 84de 2a71 8805 0620 9851 3109 | ......*q... .Q1.
 b56b a3                                 | .k.
@@ -3102,7 +3102,7 @@ b56b a3                                 | .k.
 71                                      | == Literal indexed ==
                                         |   Indexed name (idx = 49)
                                         |     location
-91                                      |   Literal value (len = 23)
+97                                      |   Literal value (len = 23)
                                         |     Huffman encoded:
 adce bf19 8e7e 7cf9 bebe 89b6 fb16 fa9b | ......|.........
 6f                                      | o
@@ -3238,9 +3238,9 @@ set-cookie: foo=ASDJKHQKBZXOQWEOPIUAXQWEOIU; max-age=3600; version=1]]></artwork
             <figure>
                 <preamble>Hex dump of encoded data:</preamble>
                 <artwork>
-<![CDATA[8484 4393 d6db b298 84de 2a71 8805 0620 | ..C.......*q... 
+<![CDATA[8484 439d d6db b298 84de 2a71 8805 0620 | ..C.......*q... 
 9851 3111 b56b a35e 84ab dd97 ff84 8483 | .Q1..k.^........
-837b b1e0 d6cf 9f6e 8f9f d3e5 f6fa 76fe | .{.....n......v.
+837b b8e0 d6cf 9f6e 8f9f d3e5 f6fa 76fe | .{.....n......v.
 fd3c 7edf 9eff 1f2f 0f3c fe9f 6fcf 7f8f | ......./....o...
 879f 61ad 4f4c c9a9 73a2 200e c372 5e18 | ..a.OL..s. ..r^.
 b1b7 4e3f                               | ..N?]]></artwork>
@@ -3259,7 +3259,7 @@ b1b7 4e3f                               | ..N?]]></artwork>
 43                                      | == Literal indexed ==
                                         |   Indexed name (idx = 3)
                                         |     date
-93                                      |   Literal value (len = 29)
+9d                                      |   Literal value (len = 29)
                                         |     Huffman encoded:
 d6db b298 84de 2a71 8805 0620 9851 3111 | ......*q... .Q1.
 b56b a3                                 | .k.
@@ -3298,7 +3298,7 @@ abdd 97ff                               | ....
 7b                                      | == Literal indexed ==
                                         |   Indexed name (idx = 59)
                                         |     set-cookie
-b1                                      |   Literal value (len = 56)
+b8                                      |   Literal value (len = 56)
                                         |     Huffman encoded:
 e0d6 cf9f 6e8f 9fd3 e5f6 fa76 fefd 3c7e | ....n......v....
 df9e ff1f 2f0f 3cfe 9f6f cf7f 8f87 9f61 | ..../....o.....a


### PR DESCRIPTION
Huffman encoded strings are correct, however, length representations are wrong.
