### PR TITLE
Clarify ambiguity in prioritization state management

### DIFF
--- a/draft-ietf-httpbis-http2.xml
+++ b/draft-ietf-httpbis-http2.xml
@@ -1302,9 +1302,10 @@ HTTP2-Settings    = token68
         <section title="Prioritization State Management">
           <t>
             When a stream is removed from the dependency tree, its dependencies can be moved to
-            become dependent on the parent of the closed stream.  The weights of new dependencies
-            are recalculated by distributing the weight of the dependency of the closed stream
-            proportionally based on the weights of its dependencies.
+            become dependent on the parent of the closed stream. The weights of the dependent
+            streams are recalculated by dividing the weight of the closed stream proportionally
+            based on the weights of its dependencies, then rounding each dependency's share to the
+            nearest valid weight.
           </t>
           <t>
             Streams that are removed from the dependency tree cause some prioritization information


### PR DESCRIPTION
The manner in which weights should be redistributed when a node is removed from the priority tree is a little ambiguous. This is a proposed rewording to make the specification more clear.
