### PR TITLE
Add "gzip, deflate" as value for accept-encoding in static table

### DIFF
--- a/draft-ietf-httpbis-header-compression.xml
+++ b/draft-ietf-httpbis-header-compression.xml
@@ -1602,7 +1602,7 @@ else
                     <c>13</c><c>:status</c><c>404</c>
                     <c>14</c><c>:status</c><c>500</c>
                     <c>15</c><c>accept-charset</c><c></c>
-                    <c>16</c><c>accept-encoding</c><c></c>
+                    <c>16</c><c>accept-encoding</c><c>gzip, deflate</c>
                     <c>17</c><c>accept-language</c><c></c>
                     <c>18</c><c>accept-ranges</c><c></c>
                     <c>19</c><c>accept</c><c></c>


### PR DESCRIPTION
Now that the WG has removed implicit accept-encoding: gzip, let's make that part of the static table.
