### PR TITLE
ALTSVC frame changes

### DIFF
--- a/draft-ietf-httpbis-alt-svc.xml
+++ b/draft-ietf-httpbis-alt-svc.xml
@@ -483,7 +483,6 @@ Alt-Svc: h2c=8000; ma=60
 <t>
   The ALTSVC HTTP/2 frame (<xref target="HTTP2" x:fmt="," x:rel="#FramingLayer"/>)
   advertises the availability of an alternative service to an HTTP/2 client.
-  <cref anchor="frameno">need to assign the number and ref the IANA registry</cref>
 </t>
 <t>
   The ALTSVC frame is a non-critical extension to HTTP/2.  Endpoints that do
@@ -498,6 +497,9 @@ Alt-Svc: h2c=8000; ma=60
   associated with the origin contained in the Origin field of the frame. An
   association with an origin that the client does not consider authoritative for
   the current connection &MUST; be ignored.
+</t>
+<t>
+  The ALTSVC frame type is 0xa (decimal 10).
 </t>
 <figure title="ALTSVC Frame Payload">
   <artwork type="drawing"><![CDATA[
@@ -672,7 +674,7 @@ Alt-Svc-Used: 1
   registry <xref target="HTTP2"/>.<!-- need to reference -13 with the iana registry ref -->
   <list style="hanging">
     <t hangText="Frame Type:">ALTSVC</t>
-    <t hangText="Code:">[to be assigned]</t>
+    <t hangText="Code:">0xa</t>
     <t hangText="Specification:"><xref target="frame"/></t>
   </list>
 </t>


### PR DESCRIPTION
Two minor things here:
- more strongly recommend the use of the frame type in HTTP/2 over the header field
- add a frame type number (no need to defer the choice now, this lets people build code based on this)
