### PR TITLE
Tweaking extensions text

### DIFF
--- a/draft-ietf-httpbis-http2.xml
+++ b/draft-ietf-httpbis-http2.xml
@@ -1458,15 +1458,14 @@ HTTP2-Settings    = token68
         <t>
           Extensions are permitted to use new <xref target="FrameHeader">frame types</xref>, <xref
           target="SettingValues">settings</xref>, <xref target="ErrorCodes">error codes</xref>,
-          header fields that start with a colon (:), or any reserved flags or fields in frames.  Of
+          or header fields that start with a colon (:).  Of
           these, registries are established for <xref target="iana-frames">frame types</xref>, <xref
           target="iana-settings">settings</xref> and <xref target="iana-errors">error codes</xref>.
         </t>
         <t>
           Implementations MUST ignore unknown or unsupported values in all extensible protocol
           elements.  Implementations MUST discard frames that have unknown or unsupported types.
-          Note that only <x:ref>DATA</x:ref> frames can be flow controlled, extensions cannot be
-          flow controlled.  This means that any of these extension points can be safely used by
+          This means that any of these extension points can be safely used by
           extensions without prior arrangement or negotiation.
         </t>
         <t>
@@ -1474,7 +1473,9 @@ HTTP2-Settings    = token68
           existing protocol components.  For example, an extension that changes the layout of the
           <x:ref>HEADERS</x:ref> frame cannot be used until the peer has given a positive signal
           that this is acceptable.  In this case, it could also be necessary to coordinate when
-          the revised layout comes into effect.
+          the revised layout comes into effect.  Note that treating any frame other than
+          <x:ref>DATA</x:ref> frames as flow controlled is such a change in semantics, and can
+          only be done through negotiation.
         </t>
         <t>
           This document doesn't mandate a specific method for negotiating the use of an extension,


### PR DESCRIPTION
Two small changes here.  First, adding unnegotiated semantics to reserved bits in existing frames feels like a REALLY bad idea, since you're almost guaranteed to have collisions, so I'm suggesting we remove that as something that extensions can do unannounced.  Second, we permit negotiated changes to existing semantics, so I'm suggesting that instead of saying only DATA will ever be flow controlled, we say that making anything else flow-controlled is a changed semantic that has to be negotiated.
