### PR TITLE
Allows server to prioritize push.

### DIFF
--- a/draft-ietf-httpbis-http2.xml
+++ b/draft-ietf-httpbis-http2.xml
@@ -1162,7 +1162,7 @@ HTTP2-Settings    = token68
 
       <section anchor="StreamPriority" title="Stream priority">
         <t>
-          A client can assign a priority for a new stream by including prioritization information in
+          An endpoint can assign a priority for a new stream by including prioritization information in
           the <xref target="HEADERS">HEADERS frame</xref> that opens the stream.  For an existing
           stream, the <xref target="PRIORITY">PRIORITY frame</xref> can be used to change the
           priority.
@@ -1172,6 +1172,11 @@ HTTP2-Settings    = token68
           peer allocate resources when managing concurrent streams.  Most importantly, priority can
           be used to select streams for transmitting frames when there is limited capacity for
           sending.
+        </t>
+        <t>
+          In addition prioritization can also an endpoint to express how it intends to allocate its
+          own resources when managing concurrent streams. In this way, priority can be used to
+          describe how streams will be selected for transmitting frames.
         </t>
         <t>
           Streams can be prioritized by marking them as dependent on the completion of other streams
@@ -2689,6 +2694,13 @@ HTTP2-Settings    = token68
           stream in the "closed" state.
         </t>
 
+        <t>
+          A client can send priority information for a request to express how it would prefer the
+          server to allocate resources when processing concurrent requests. Priority can be used by
+          the server to determine the processing and transmitting order of responses to client
+          requests.
+        </t>
+
         <section anchor="informational-responses" title="Informational Responses">
           <t>
             The 1xx series of HTTP response status codes (<xref target="RFC7231" x:fmt=","
@@ -3203,6 +3215,11 @@ HTTP2-Settings    = token68
           A server can only push responses that are cacheable (see <xref target="RFC7234" x:fmt=","
           x:rel="#response.cacheability"/>); promised requests MUST be safe (see <xref
           target="RFC7231" x:fmt="," x:rel="#safe.methods"/>) and MUST NOT include a request body.
+        </t>
+        <t>
+          A server can send priority information to the client for a pushed response, to express how
+          it intends to allocate its resources for this pushed response. In particular, the server
+          can use priority to express its intended ordering of concurrent pushed responses.
         </t>
 
         <section title="Push Requests">


### PR DESCRIPTION
A server can send priority for a pushed response. This describes its intend on how to order the pushed response in regards to other responses and in particular other pushed responses.
