### PR TITLE
Indexes/indices and between one thing

### DIFF
--- a/draft-ietf-httpbis-header-compression.xml
+++ b/draft-ietf-httpbis-header-compression.xml
@@ -374,8 +374,8 @@
                     index 1 referring to the beginning of the table.
                 </t>
                 <t>
-                    Indices between one higher than the length of the header
-                    table represent indexes into the static table.  The length
+                    Indices greater than the length of the header
+                    table refer to elements in the static table.  The length
                     of the header table is subtracted to find the index into the
                     static table.
                 </t>


### PR DESCRIPTION
Updating 3.4 to remove the use of "indexes" in the midst of all the "indices," and to not use the word "between" when referring to a single bound.  (Adding the other bound into the same paragraph just looks too verbose.)
