### PR TITLE
Missing article

### DIFF
--- a/draft-ietf-httpbis-http2.xml
+++ b/draft-ietf-httpbis-http2.xml
@@ -3475,7 +3475,7 @@ HTTP2-Settings    = token68
           <t>
             A server that does not wish clients to reuse connections can indicate that it is not
             authoritative for a request by sending a 421 (Not Authoritative) status code in response
-            to request (see <xref target="NotAuthoritative"/>).
+            to the request (see <xref target="NotAuthoritative"/>).
           </t>
         </section>
 


### PR DESCRIPTION
Could have been "a" just as easily, but I felt like a two-character pull request was just overkill.
