### PR TITLE
Clarify the description of priority

### DIFF
--- a/draft-ietf-httpbis-http2.xml
+++ b/draft-ietf-httpbis-http2.xml
@@ -1228,7 +1228,9 @@ HTTP2-Settings    = token68
           </t>
           <t>
             A stream that depends on another stream is a dependent stream.  The stream upon which a
-            stream is dependent is a parent stream.
+            stream is dependent is a parent stream. When the parent stream does not exist in the
+            dependency tree such as its state in the "idle", the stream is assigned a default
+            priority.
           </t>
           <t>
             When assigning a dependency on another stream, the stream is added as a new dependency


### PR DESCRIPTION
Add the following two changes.
- When the default priority is assigned, it is non-exclusive.
- When a parent stream is not in a priority tree, the stream is assigned a default priority
