### PR TITLE
Forbidding the use of pseudo-header fields

### DIFF
--- a/draft-ietf-httpbis-http2.xml
+++ b/draft-ietf-httpbis-http2.xml
@@ -1486,9 +1486,9 @@ HTTP2-Settings    = token68
         <t>
           Extensions are permitted to use new <xref target="FrameHeader">frame types</xref>, new
           <xref target="SettingValues">settings</xref>, or new <xref target="ErrorCodes">error
-          codes</xref>.  Of these, registries are established for <xref target="iana-frames">frame
-          types</xref>, <xref target="iana-settings">settings</xref> and <xref
-          target="iana-errors">error codes</xref>.
+          codes</xref>.  Registries are established for managing these extension points: <xref
+          target="iana-frames">frame types</xref>, <xref target="iana-settings">settings</xref> and
+          <xref target="iana-errors">error codes</xref>.
         </t>
         <t>
           Implementations MUST ignore unknown or unsupported values in all extensible protocol


### PR DESCRIPTION
Tightening the language around the definition of malformed requests
and responses to support this.
