### PR TITLE
Large Frame Proposal

### DIFF
--- a/draft-ietf-httpbis-http2.xml
+++ b/draft-ietf-httpbis-http2.xml
@@ -646,7 +646,7 @@ HTTP2-Settings    = token68
         </t>
         <t>
           A peer MAY advertise the maximum frame payload size it is willing to receive by 
-          any/all of:
+          either of:
           <list style="symbols">
           <t>
             the <x:ref>SETTINGS_FRAME_SIZE</x:ref> parameter within a 
@@ -655,10 +655,6 @@ HTTP2-Settings    = token68
           <t>
             the <x:ref>SETTINGS_HEADER_FRAME_SIZE</x:ref> parameter within a 
             <x:ref>SETTINGS</x:ref> frame (see <xref target="SettingValues"/>),
-          </t>
-          <t>
-            the Max Frame Size field in a <x:ref>WINDOW_UPDATE</x:ref> frame 
-            (see <xref target="MaxFrameSize"/>).
           </t>
           </list>
         </t>
@@ -2405,8 +2401,6 @@ HTTP2-Settings    = token68
  +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
  |R|              Window Size Increment (31)                     |
  +-+-------------------------------------------------------------+
- |R|                 Max Frame Size? (31)                        |
- +-+-------------------------------------------------------------+
 ]]></artwork>
         </figure>
         <t>
@@ -2420,26 +2414,10 @@ HTTP2-Settings    = token68
               flow control window.  The legal range for the increment to the flow control window is 1 to
               2<x:sup>31</x:sup> - 1 (0x7fffffff) bytes.
             </t>
-            <t hangText="R:">
-              A Reserved bit, which is present only if the FRAME_SIZE flag is set.
-            </t>
-            <t hangText="Max Frame Size:">
-              An optional unsigned 31-bit integer which is present only if the FRAME_SIZE flag is set,
-              indicating the maximum frame size in octets that the peer can use to transmit frames
-              on this stream.  The legal range for this value is 256 to
-              2<x:sup>31</x:sup> - 1 (0x7fffffff) bytes. This value overrides the <x:ref>SETTINGS_FRAME_SIZE</x:ref> 
-              set for the connection.
-            </t>
           </list>
         </t>
         <t>
-          The WINDOW_UPDATE frame defines the following flags:
-          <list style="hanging">
-            <t hangText="FRAME_SIZE (0x1):">
-              Bit 1 being set indicates that this WINDOW_UPDATE frame contains a Max Data Frame Size field. 
-              This flag MUST NOT be set on a WINDOW_UPDATE with a stream ID of 0.
-            </t>
-          </list>
+          The WINDOW_UPDATE frame does not defines any flags.
         </t>
         <t>
           The WINDOW_UPDATE frame can be specific to a stream or to the entire connection.  In the
@@ -2577,52 +2555,6 @@ HTTP2-Settings    = token68
               <t>
                 The receiver can accept the streams and tolerate the resulting head of line
                 blocking, sending WINDOW_UPDATE frames as it consumes data.
-              </t>
-            </list>
-          </t>
-        </section>
-        <section anchor="MaxFrameSize" title="Setting the Stream Max Frame Size">
-          <t>
-            A receiver that wishes to allow a different max frame size in a specific stream 
-            that are different to <x:ref>SETTINGS_FRAME_SIZE</x:ref> for the connection, can send a Max Frame Size field in 
-            a WINDOW_UPDATE frame to indicate the size of frame that it wishes to 
-            receive in that stream. 
-          </t>
-          <t>
-            A peer that receives a Max Frame Size field can send frames on the indicated stream 
-            with lengths that:
-            <list style="symbols">
-              <t>MUST NOT exceed the larger of the <x:ref>SETTINGS_FRAME_SIZE</x:ref> and the Max Frame Size.</t>
-              <t>MAY exceed the <x:ref>SETTINGS_FRAME_SIZE</x:ref> if the Max Frame Size is larger.</t>
-              <t>SHOULD NOT exceed the Max Frame Size even if the <x:ref>SETTINGS_FRAME_SIZE</x:ref> is larger.</t>
-              <t>MUST NOT exceed the connection flow control window size.</t>
-              <t>MUST NOT exceed the stream flow control window size.</t>
-            </list>
-          </t>
-          <t>
-            A sender MAY choose to ignore a received Max Frame Size, thus a receiver MUST always be 
-            prepared to receive a frame up to the size set in the <x:ref>SETTINGS_FRAME_SIZE</x:ref> for the 
-            connection (or the default if not set), even if it has sent a Max Frame Size field 
-            that is smaller.
-          </t>
-          <t>
-            Increasing frame size may increase the efficiency of data transport 
-            for a single stream at the cost of quality of service of multiplexing multiple 
-            streams. This document does not stipulate if or how a receiver decides to change the 
-            Max Frame Size for a stream, but implementations that do MAY consider in their algorithm:
-            <list style="symbols">
-              <t>
-                The number of streams currently open or reserved.
-              </t>
-              <t>
-                The priority of the stream contents in relation to any other open or reserved streams.
-              </t>
-              <t>
-                The content-length of the stream.
-              </t>
-              <t>
-                Latency and throughput estimates derived from the timing of the frames previously received on
-                the stream.
               </t>
             </list>
           </t>


### PR DESCRIPTION
## Background

The HTTP2 protocol has a requirement to be able to transport large headers, that exceed the payload size of a single frame at the current 16KB maximum size.

To address this requirement, the current draft (13) includes the CONTINUATION frames, 0 or more of which may be sent after a HEADERS or PUSH_PROMISE frame to contain the large headers.  There has been significant criticism of the CONTINUATION design, including:
- The total length of a HEADERS+CONTINUATION\* sequence is not known until the last frame in the sequence is processed.  A receiver that wishes to reject streams headers larger than a specific limit may have to process many frames and hold the results in memory before it discovers the header is too large.
- The size of header that an endpoint is prepared to receive is not known in advance. The only way a sender can know if a header too large is by attempting to send it and receiving an error in response. Error handling of headers may be difficult for an endpoint to handle efficiently and can result in the closure of the entire connection.
- The END_STREAM flag is not present on the CONTINUATION frame, thus it is possible for a stream to send CONTINUATION frames after a HEADERS frame that has the END_STREAM flag set.  This is confusing and increases the complexity of the state machine required to process streams.  It is highly desirable that a set END_STREAM flag truly indicates the last non control frame of a stream.
- There is a significant discontinuity in the code path required to process headers.  Headers up to an indeterminate size (roughly 20-something KB) can be handled in a single frame. Headers that exceed this size must be handled in multiple frames of different types with different frame flags and stream control logic. Because the vast majority of headers sent (>99.99%) are below this indeterminate size, implementations will have a code path that is seldom executed and probably insufficiently tested. This invites poor and/or partial and/or incorrect implementation.
- Because of the HPACK compression algorithm, a sequence of HEADERS+CONTINUATIONS frames may not be interleaved with any other frame. This effectively makes the sequence a single large frame.  Because of the simplicity of description and implementation it is proposed that it would be far simpler to meet the requirement of large headers by supporting large frames.

This proposal has been prepared as it is possible to meet the requirements of CONTINUATIONS without the complications and criticisms above.

> This proposal addresses the issue of sending/receiving large HTTP headers without giving endpoints and intermediaries unlimited resource commitments nor unknown limits
## Additional Frame Size Issues Addressed

The current draft (13) has maximum frame size of 16KB, which is an arbitrary value that has been selected on the basis of experience to provide a reasonable compromise between the efficiency of transmitting data vs the quality of service for multiplexed channels.

Whilst this educated guess may be near optimal for today's networks and traffic, it is entirely possible that some current and/or future networks may require a different value to achieve an optimal balance. There have already been proposals [1] put to the WG to reduce the frame size to optimise multiplexing , as well as discussion that high capacity, low latency networks can achieve satisfactory multiplexing quality of service with large frame sizes.

> This proposal addresses the issue that a fixed frame size does  not allow tuning multiplexing performance based on current/future experience.

It has also been noted that 16KB is near the middle of the peak of the current HTTP Object size histogram [2], so that a small change in the frame size may have a significant impact on the number of HTTP messages that can be sent in a single frame, without significant impacts on QoS. The HTTP Object size histogram has changed significantly over time and is expected to continue to do so.

> This proposal addresses the issue of tuning the frame size based on experience of actual payload sizes.

There have also been issues raised that a 16KB frame size does not allow efficient data transfer [3] even when the end points are aware that only a single stream is likely to be required for the imminent future, or
that a particular stream is of high priority.

> This proposal addresses the issue of tuning the frame size for transport efficiency for specific streams in specific situations.
## Large Frame Header Proposal

This proposal is to alter the core http2 protocol to address the issues identified above by supporting a variable length maximum frame size controlled by peer limits.

This proposal increases the length field in the frame header to 31 bits, to match the maximum flow control window size.  However, implementations will not be able to use the full frame size without explicit consent from peers using newly defined SETTINGS.
## Frame Size Settings

Two settings parameters are proposed: SETTINGS_HEADER_FRAME_SIZE for the maximum header size and SETTINGS_FRAME_SIZE for all other frames.

The SETTINGS_HEADER_FRAME_SIZE parameter supports the current behaviour where large headers can be sent without changing the frame size allowed for other frame types. ie A large header size limit can be set without affecting the multiplexing efficiency of DATA frames.

The SETTINGS_FRAME_SIZE applies to all other frames including DATA frames and any other frame that may be defined by an extension.  The use of this parameter is intended to tune/optimise the connection for the general case of multiple streams over the specific connection.
## Minimal Compliance

A minimally compliant implementation MUST handle the SETTING_FRAME_SIZE and SETTINGS_HEADER_SIZE and ensure that no frame sent exceeds the applicable limit.   However no implementation is required to send frames at or near these limits when set above the default 16KB.
## Anticipated Feedback

> It is too late in the process to change the framing layer and to do so after so much discussion is an implicit fail of the WG

To not consider issues and proposal brought to the WG would be a fail of the process.   This proposal is based on all the hard work to date done by the WG and contributors to identify issues and test solutions.

> These issues can be handled in extensions.

Optimising data transfers for large content could possibly be done in an extension, however:
- It is not yet clear if extensions will be a viable way to enhance the  http2 protocol. There are significant hurdle to overcome to deploy  extensions.
- Many of the issues are aimed at complexity and tuning of the core  protocol, and these cannot be addressed in an extension.
- It is asymmetric to support large headers with one mechanism and large data with another.

> The proposed header costs 2 extra bytes per frame

There is a small data cost to adopt this proposal, however this is mitigated as:
- The proposal may be able to reduce the number of frames needed for some content, thus saving 8 bytes.  Whilst not likely to be a 25% frame saving required to break even, it will still reduce cost to below 2 bytes.
- There are options to have variable length headers or optional extended headers that will preserve the semantics of this proposal and keep an 8 byte header for small frames.  If the 2 byte cost is considered prohibitive, then these alterations can be considered.

> The header is 10 bytes long and not 32bit word aligned.

Frames sent after arbitrary data will not be word aligned anyway. If alignment is important, then padding could changed to be part of the base frame format, 2 header bytes used for a padding length (giving an aligned 12 byte header) and all frames padded to a word boundary.

> 31 bits is also an arbitrary length

It is true that a 31 bit large frame length is also an arbitrary limit to the size of a frame. However, it is believed that 31 bits is sufficiently large to efficiently handle almost all conceivable present and future use cases.   It would be possible to implement an unlimited size length field, but this would also need changes to the flow control mechanism, which currently also has a 31 bit maximum size.

> It does not support unlimited response headers

A SETTINGS_HEADER_FRAME_SIZE of 2^31-1 is effectively unlimited for all foreseeable response headers.

> This was tried with SPDY and rejected

SPDY did not have the settings to allow peers to set limits on the max frame size.  This proposal will not change to default behaviour of http2 with regards to frame size.

> Intermediaries will destroy multiplexing by setting frame size to 2^31-1

Large frames require the participation of both sender and receiver.  A receiver may advise that it is willing to accept large frames, but a sender is under no obligation to send them.  Thus intermediaries nor any end point can unilaterally change multiplexing QoS.

> Cannot be hardware accelerated.

Hardware acceleration is not part of the WG brief to support, nor is it clear that this proposal is any less suitable than others for hardware acceleration.
## Contributors

This proposal was prepare by:
- Amos Jeffries squid3@treenet.co.nz
- Greg Wilkins gregw@intalio.com
- Jason Greene jgreene@redhat.com
- Keith Morgan K.Morgan@iaea.org
- Poul-Henning Kamp phk@phk.freebsd.dk 

[1] http://lists.w3.org/Archives/Public/ietf-http-wg/2013AprJun/0926.html
[2] http://httparchive.org/interesting.php
[3] http://lists.w3.org/Archives/Public/ietf-http-wg/2014AprJun/1664.html
