### PR TITLE
Removing CONTINUATION frames

### DIFF
--- a/draft-ietf-httpbis-http2.xml
+++ b/draft-ietf-httpbis-http2.xml
@@ -646,9 +646,9 @@ HTTP2-Settings    = token68
           data, the endpoint MUST send a <x:ref>FRAME_SIZE_ERROR</x:ref> error. A frame size error
           in a frame that could alter the state of the entire connection MUST be treated as a <xref
           target="ConnectionErrorHandler">connection error</xref>; this includes any frame carrying
-          a <xref target="HeaderBlock">header block</xref> (that is, <x:ref>HEADERS</x:ref>,
-          <x:ref>PUSH_PROMISE</x:ref>, and <x:ref>CONTINUATION</x:ref>), <x:ref>SETTINGS</x:ref>,
-          and any <x:ref>WINDOW_UPDATE</x:ref> frame with a stream identifier of 0.
+          a <xref target="HeaderBlock">header block</xref> (that is, <x:ref>HEADERS</x:ref> or
+          <x:ref>PUSH_PROMISE</x:ref>), <x:ref>SETTINGS</x:ref>, and any
+          <x:ref>WINDOW_UPDATE</x:ref> frame with a stream identifier of 0.
         </t>
         <t>
           Endpoints are not obligated to use all available space in a frame.  Responsiveness can be
@@ -668,16 +668,14 @@ HTTP2-Settings    = token68
         <t>
           Header sets are collections of zero or more header fields.  When transmitted over a
           connection, a header set is serialized into a header block using <xref
-          target="COMPRESSION">HTTP Header Compression</xref>.  The serialized header block is then
-          divided into one or more octet sequences, called header block fragments, and transmitted
-          within the payload of <xref target="HEADERS">HEADERS</xref>, <xref
-          target="PUSH_PROMISE">PUSH_PROMISE</xref> or <xref
-          target="CONTINUATION">CONTINUATION</xref> frames.
+          target="COMPRESSION">HTTP Header Compression</xref>.  The serialized header block is
+          transmitted within the payload of <xref target="HEADERS">HEADERS</xref> or <xref
+          target="PUSH_PROMISE">PUSH_PROMISE</xref> frames.
         </t>
         <t>
           HTTP Header Compression does not preserve the relative ordering of header fields.  Header
           fields with multiple values are encoded into a single header field using a special
-          delimiter (see <xref target="HeaderOrdering"/>), this preserves the relative order of
+          delimiter (see <xref target="HeaderOrdering"/>).  This preserves the relative order of
           values for that header field.
         </t>
         <t>
@@ -685,41 +683,19 @@ HTTP2-Settings    = token68
           mapping (see <xref target="CompressCookie"/>).
         </t>
         <t>
-          A receiving endpoint reassembles the header block by concatenating its fragments, then
-          decompresses the block to reconstruct the header set.
-        </t>
-        <t>
-          A complete header block consists of either:
-          <list style="symbols">
-            <t>
-              a single <x:ref>HEADERS</x:ref> or <x:ref>PUSH_PROMISE</x:ref> frame,
-              with the END_HEADERS flag set, or
-            </t>
-            <t>
-              a <x:ref>HEADERS</x:ref> or <x:ref>PUSH_PROMISE</x:ref> frame with the END_HEADERS
-              flag cleared and one or more <x:ref>CONTINUATION</x:ref> frames,
-              where the last <x:ref>CONTINUATION</x:ref> frame has the END_HEADERS flag set.
-            </t>
-          </list>
-        </t>
-        <t>
           Header compression is stateful, using a single compression context for the entire
           connection.  Each header block is processed as a discrete unit.  Header blocks MUST be
-          transmitted as a contiguous sequence of frames, with no interleaved frames of any other
-          type or from any other stream.  The last frame in a sequence of <x:ref>HEADERS</x:ref> or
-          <x:ref>CONTINUATION</x:ref> frames MUST have the END_HEADERS flag set.  The last frame in
-          a sequence of <x:ref>PUSH_PROMISE</x:ref> or <x:ref>CONTINUATION</x:ref> frames MUST have
-          the END_HEADERS flag set.  This allows a header block to be logically equivalent to a
-          single frame.
+          entirely contained in a single frame, which means that their compressed size cannot exceed
+          the maximum frame size set by the receiver in <x:ref>SETTINGS_MAX_FRAME_SIZE</x:ref>.
         </t>
         <t>
-          Header block fragments can only be sent as the payload of <x:ref>HEADERS</x:ref>,
-          <x:ref>PUSH_PROMISE</x:ref> or <x:ref>CONTINUATION</x:ref> frames, because these frames
-          carry data that can modify the compression context maintained by a receiver.  An endpoint
-          receiving <x:ref>HEADERS</x:ref>, <x:ref>PUSH_PROMISE</x:ref> or
-          <x:ref>CONTINUATION</x:ref> frames MUST reassemble header blocks and perform decompression
-          even if the frames are to be discarded.  A receiver MUST terminate the connection with a
-          <xref target="ConnectionErrorHandler">connection error</xref> of type
+          Header blocks can only be sent as the payload of <x:ref>HEADERS</x:ref> or
+          <x:ref>PUSH_PROMISE</x:ref> frames.  These frames carry data that can modify the
+          compression context maintained by a receiver.  An endpoint receiving
+          <x:ref>HEADERS</x:ref> or <x:ref>PUSH_PROMISE</x:ref> frames MUST perform decompression to
+          ensure that compression state is updated, even if the frames are to be discarded.  A
+          receiver MUST terminate the connection with a <xref
+          target="ConnectionErrorHandler">connection error</xref> of type
           <x:ref>COMPRESSION_ERROR</x:ref> if it does not decompress a header block.
         </t>
       </section>
@@ -787,20 +763,14 @@ HTTP2-Settings    = token68
      `-------------------->|        |<--------------------'
                            +--------+
 
-       H:  HEADERS frame (with implied CONTINUATIONs)
-       PP: PUSH_PROMISE frame (with implied CONTINUATIONs)
+       H:  HEADERS frame
+       PP: PUSH_PROMISE frame
        ES: END_STREAM flag
        R:  RST_STREAM frame
 ]]>
           </artwork>
         </figure>
 
-        <t>
-          Note that this diagram shows stream state transitions and frames that affect those
-          transitions only.  In this regard, <x:ref>CONTINUATION</x:ref> frames do not result in
-          state transitions and are effectively part of the <x:ref>HEADERS</x:ref> or
-          <x:ref>PUSH_PROMISE</x:ref> that they follow.
-        </t>
         <t>
           Both endpoints have a subjective view of the state of a stream that could be different
           when frames are in transit.  Endpoints do not coordinate the creation of streams; they are
@@ -1645,7 +1615,7 @@ HTTP2-Settings    = token68
  +-+-------------+-----------------------------------------------+
  |  Weight? (8)  |
  +-+-------------+-----------------------------------------------+
- |                   Header Block Fragment (*)                 ...
+ |                        Header Block (*)                     ...
  +---------------------------------------------------------------+
  |                           Padding (*)                       ...
  +---------------------------------------------------------------+
@@ -1673,8 +1643,8 @@ HTTP2-Settings    = token68
               value to obtain a weight between 1 and 256.  This field is optional and is only
               present if the PRIORITY flag is set.
             </t>
-            <t hangText="Header Block Fragment:">
-              A <xref target="HeaderBlock">header block fragment</xref>.
+            <t hangText="Header Block:">
+              A <xref target="HeaderBlock">header block</xref>.
             </t>
             <t hangText="Padding:">
               Padding octets.
@@ -1692,25 +1662,6 @@ HTTP2-Settings    = token68
                 causes the stream to enter one of <xref target="StreamStates">"half closed"
                 states</xref>.
               </t>
-              <t>
-                A HEADERS frame that is followed by <x:ref>CONTINUATION</x:ref> frames carries the
-                END_STREAM flag that signals the end of a stream.  A <x:ref>CONTINUATION</x:ref>
-                frame cannot be used to terminate a stream.
-              </t>
-            </x:lt>
-            <x:lt hangText="END_HEADERS (0x4):">
-              <t>
-                Bit 3 being set indicates that this frame contains an entire <xref
-                target="HeaderBlock">header block</xref> and is not followed by any
-                <x:ref>CONTINUATION</x:ref> frames.
-              </t>
-              <t>
-                A HEADERS frame without the END_HEADERS flag set MUST be followed by a
-                <x:ref>CONTINUATION</x:ref> frame for the same stream.  A receiver MUST treat the
-                receipt of any other type of frame or a frame on a different stream as a <xref
-                target="ConnectionErrorHandler">connection error</xref> of type
-                <x:ref>PROTOCOL_ERROR</x:ref>.
-              </t>
             </x:lt>
             <x:lt hangText="PADDED (0x8):">
               <t>
@@ -1727,9 +1678,8 @@ HTTP2-Settings    = token68
         </t>
 
         <t>
-          The payload of a HEADERS frame contains a <xref target="HeaderBlock">header block
-          fragment</xref>.  A header block that does not fit within a HEADERS frame is continued in
-          a <xref target="CONTINUATION">CONTINUATION frame</xref>.
+          The payload of a HEADERS frame contains a compressed <xref target="HeaderBlock">header
+          block</xref>.
         </t>
 
         <t>
@@ -2066,7 +2016,7 @@ HTTP2-Settings    = token68
  +-+-------------+-----------------------------------------------+
  |R|                  Promised Stream ID (31)                    |
  +-+-----------------------------+-------------------------------+
- |                   Header Block Fragment (*)                 ...
+ |                        Header Block (*)                     ...
  +---------------------------------------------------------------+
  |                           Padding (*)                       ...
  +---------------------------------------------------------------+
@@ -2088,9 +2038,8 @@ HTTP2-Settings    = token68
               next stream sent by the sender (see <xref target="StreamIdentifiers">new stream
               identifier</xref>).
             </t>
-            <t hangText="Header Block Fragment:">
-              A <xref target="HeaderBlock">header block fragment</xref> containing request header
-              fields.
+            <t hangText="Header Block:">
+              A <xref target="HeaderBlock">header block</xref> containing request header fields.
             </t>
             <t hangText="Padding:">
               Padding octets.
@@ -2101,20 +2050,6 @@ HTTP2-Settings    = token68
         <t>
           The PUSH_PROMISE frame defines the following flags:
           <list style="hanging">
-            <x:lt hangText="END_HEADERS (0x4):">
-              <t>
-                Bit 3 being set indicates that this frame contains an entire <xref
-                target="HeaderBlock">header block</xref> and is not followed by any
-                <x:ref>CONTINUATION</x:ref> frames.
-              </t>
-              <t>
-                A PUSH_PROMISE frame without the END_HEADERS flag set MUST be followed by a
-                CONTINUATION frame for the same stream.  A receiver MUST treat the receipt of any
-                other type of frame or a frame on a different stream as a <xref
-                target="ConnectionErrorHandler">connection error</xref> of type
-                <x:ref>PROTOCOL_ERROR</x:ref>.
-              </t>
-            </x:lt>
             <x:lt hangText="PADDED (0x8):">
               <t>
                 Bit 4 being set indicates that the Pad Length field is present.
@@ -2342,12 +2277,12 @@ HTTP2-Settings    = token68
         <t>
           After sending a GOAWAY frame, the sender can discard frames for streams with identifiers
           higher than the identified last stream.  However, any frames that alter connection state
-          cannot be completely ignored.  For instance, <x:ref>HEADERS</x:ref>,
-          <x:ref>PUSH_PROMISE</x:ref> and <x:ref>CONTINUATION</x:ref> frames MUST be minimally
-          processed to ensure the state maintained for header compression is consistent (see <xref
-          target="HeaderBlock"/>); similarly DATA frames MUST be counted toward the connection flow
-          control window.  Failure to process these frames can cause flow control or header
-          compression state to become unsynchronized.
+          cannot be completely ignored.  For instance, <x:ref>HEADERS</x:ref>, and
+          <x:ref>PUSH_PROMISE</x:ref> frames MUST be minimally processed to ensure the state
+          maintained for header compression is consistent (see <xref target="HeaderBlock"/>);
+          similarly DATA frames MUST be counted toward the connection flow control window.  Failure
+          to process these frames can cause flow control or header compression state to become
+          unsynchronized.
         </t>
 
         <t>
@@ -2546,67 +2481,6 @@ HTTP2-Settings    = token68
           </t>
         </section>
       </section>
-
-      <section anchor="CONTINUATION" title="CONTINUATION">
-        <t>
-          The CONTINUATION frame (type=0x9) is used to continue a sequence of <xref
-          target="HeaderBlock">header block fragments</xref>.  Any number of CONTINUATION frames can
-          be sent on an existing stream, as long as the preceding frame is on the same stream and is
-          a <x:ref>HEADERS</x:ref>, <x:ref>PUSH_PROMISE</x:ref> or CONTINUATION frame without the
-          END_HEADERS flag set.
-        </t>
-
-        <figure title="CONTINUATION Frame Payload">
-          <artwork type="inline"><![CDATA[
-  0                   1                   2                   3
-  0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
- +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
- |                   Header Block Fragment (*)                 ...
- +---------------------------------------------------------------+
-]]></artwork>
-        </figure>
-        <t>
-          The CONTINUATION frame payload contains a <xref target="HeaderBlock">header block
-          fragment</xref>.
-        </t>
-
-        <t>
-          The CONTINUATION frame defines the following flag:
-          <list style="hanging">
-            <x:lt hangText="END_HEADERS (0x4):">
-              <t>
-                Bit 3 being set indicates that this frame ends a <xref target="HeaderBlock">header
-                block</xref>.
-              </t>
-              <t>
-                If the END_HEADERS bit is not set, this frame MUST be followed by another
-                CONTINUATION frame.  A receiver MUST treat the receipt of any other type of frame or
-                a frame on a different stream as a <xref target="ConnectionErrorHandler">connection
-                error</xref> of type <x:ref>PROTOCOL_ERROR</x:ref>.
-              </t>
-            </x:lt>
-          </list>
-        </t>
-
-        <t>
-          The CONTINUATION frame changes the connection state as defined in <xref
-          target="HeaderBlock" />.
-        </t>
-
-        <t>
-          CONTINUATION frames MUST be associated with a stream. If a CONTINUATION frame is received
-          whose stream identifier field is 0x0, the recipient MUST respond with a <xref
-          target="ConnectionErrorHandler">connection error</xref> of type PROTOCOL_ERROR.
-        </t>
-
-        <t>
-          A CONTINUATION frame MUST be preceded by a <x:ref>HEADERS</x:ref>,
-          <x:ref>PUSH_PROMISE</x:ref> or CONTINUATION frame without the END_HEADERS flag set.  A
-          recipient that observes violation of this rule MUST respond with a <xref
-          target="ConnectionErrorHandler"> connection error</xref> of type
-          <x:ref>PROTOCOL_ERROR</x:ref>.
-        </t>
-      </section>
     </section>
 
     <section anchor="ErrorCodes" title="Error Codes">
@@ -2706,41 +2580,32 @@ HTTP2-Settings    = token68
           An HTTP message (request or response) consists of:
           <list style="numbers">
             <t>
-              one <x:ref>HEADERS</x:ref> frame (followed by zero or more <x:ref>CONTINUATION</x:ref>
-              frames) containing the message headers (see <xref target="RFC7230" x:fmt=","
-              x:rel="#header.fields"/>), and
+              one <x:ref>HEADERS</x:ref> frame containing header fields (see <xref target="RFC7230"
+              x:fmt="," x:rel="#header.fields"/>), and
             </t>
             <t>
               zero or more <x:ref>DATA</x:ref> frames containing the message payload (see <xref
               target="RFC7230" x:fmt="," x:rel="#message.body"/>), and
             </t>
             <t>
-              optionally, one <x:ref>HEADERS</x:ref> frame, followed by zero or more
-              <x:ref>CONTINUATION</x:ref> frames containing the trailer-part, if present (see <xref
-              target="RFC7230" x:fmt="," x:rel="#chunked.trailer.part"/>).
+              optionally, one <x:ref>HEADERS</x:ref> frame containing the trailer-part, if present
+              (see <xref target="RFC7230" x:fmt="," x:rel="#chunked.trailer.part"/>).
             </t>
           </list>
-          The last frame in the sequence bears an END_STREAM flag, noting that a
-          <x:ref>HEADERS</x:ref> frame bearing the END_STREAM flag can be followed by
-          <x:ref>CONTINUATION</x:ref> frames that carry any remaining portions of the header block.
+          The last frame in the sequence bears an END_STREAM flag.
         </t>
         <t>
-          Other frames (from any stream) MUST NOT occur between either <x:ref>HEADERS</x:ref> frame
-          and any <x:ref>CONTINUATION</x:ref> frames that might follow.
-        </t>
-        <t>
-          A <x:ref>HEADERS</x:ref> frame (and associated <x:ref>CONTINUATION</x:ref> frames) can
-          only appear at the start or end of a stream.  An endpoint that receives a second
-          <x:ref>HEADERS</x:ref> frame without the END_STREAM flag set MUST treat the corresponding
-          request or response as <xref target="malformed">malformed</xref>.
+          A <x:ref>HEADERS</x:ref> frame can only appear at the start or end of a stream.  An
+          endpoint that receives a second <x:ref>HEADERS</x:ref> frame without the END_STREAM flag
+          set MUST treat the corresponding request or response as <xref
+          target="malformed">malformed</xref>.
         </t>
 
         <t>
           Trailing header fields are carried in a header block that also terminates the stream.
-          That is, a sequence starting with a <x:ref>HEADERS</x:ref> frame, followed by zero or more
-          <x:ref>CONTINUATION</x:ref> frames, where the <x:ref>HEADERS</x:ref> frame bears an
-          END_STREAM flag.  Header blocks after the first that do not terminate the stream are not
-          part of an HTTP request or response.
+          That is, a <x:ref>HEADERS</x:ref> frame that bears an END_STREAM flag.  Header blocks
+          after the first that do not terminate the stream are not part of an HTTP request or
+          response.
         </t>
 
         <t>
@@ -3097,38 +2962,33 @@ HTTP2-Settings    = token68
           </t>
           <t>
             An HTTP GET request includes request header fields and no body and is therefore
-            transmitted as a single <x:ref>HEADERS</x:ref> frame, followed by zero or more
-            <x:ref>CONTINUATION</x:ref> frames containing the serialized block of request header
-            fields.  The <x:ref>HEADERS</x:ref> frame in the following has both the END_HEADERS and
-            END_STREAM flags set; no <x:ref>CONTINUATION</x:ref> frames are sent:
+            transmitted as a single <x:ref>HEADERS</x:ref> frame containing the serialized block of
+            request header fields.  The <x:ref>HEADERS</x:ref> frame in the following has the
+            END_STREAM flag set, there is no request body:
           </t>
 
           <figure>
             <artwork type="inline"><![CDATA[
   GET /resource HTTP/1.1           HEADERS
   Host: example.org          ==>     + END_STREAM
-  Accept: image/jpeg                 + END_HEADERS
+  Accept: image/jpeg                   host = example.org
                                        :method = GET
                                        :scheme = https
                                        :path = /resource
-                                       host = example.org
                                        accept = image/jpeg
 ]]></artwork>
           </figure>
 
           <t>
             Similarly, a response that includes only response header fields is transmitted as a
-            <x:ref>HEADERS</x:ref> frame (again, followed by zero or more
-            <x:ref>CONTINUATION</x:ref> frames) containing the serialized block of response header
-            fields.
+            <x:ref>HEADERS</x:ref> frame containing the serialized block of response header fields.
           </t>
 
           <figure>
             <artwork type="inline"><![CDATA[
   HTTP/1.1 304 Not Modified        HEADERS
   ETag: "xyzzy"              ==>     + END_STREAM
-  Expires: Thu, 23 Jan ...           + END_HEADERS
-                                       :status = 304
+  Expires: Thu, 23 Jan ...             :status = 304
                                        etag = "xyzzy"
                                        expires = Thu, 23 Jan ...
 ]]></artwork>
@@ -3136,25 +2996,19 @@ HTTP2-Settings    = token68
 
           <t>
             An HTTP POST request that includes request header fields and payload data is transmitted
-            as one <x:ref>HEADERS</x:ref> frame, followed by zero or more
-            <x:ref>CONTINUATION</x:ref> frames containing the request header fields, followed by one
-            or more <x:ref>DATA</x:ref> frames, with the last <x:ref>CONTINUATION</x:ref> (or
-            <x:ref>HEADERS</x:ref>) frame having the END_HEADERS flag set and the final
-            <x:ref>DATA</x:ref> frame having the END_STREAM flag set:
+            as one <x:ref>HEADERS</x:ref> frame containing the request header fields, followed by
+            one or more <x:ref>DATA</x:ref> frames, with the final <x:ref>DATA</x:ref> frame having
+            the END_STREAM flag set:
           </t>
 
           <figure>
             <artwork type="inline"><![CDATA[
   POST /resource HTTP/1.1          HEADERS
   Host: example.org          ==>     - END_STREAM
-  Content-Type: image/jpeg           - END_HEADERS
+  Content-Type: image/jpeg             host = example.org
   Content-Length: 123                  :method = POST
                                        :path = /resource
   {binary data}                        content-type = image/jpeg
-
-                                   CONTINUATION
-                                     + END_HEADERS
-                                       host = example.org
                                        :scheme = https
                                        content-length = 123
 
@@ -3162,28 +3016,21 @@ HTTP2-Settings    = token68
                                      + END_STREAM
                                    {binary data}
 ]]></artwork>
-            <postamble>
-              Note that data contributing to any given header field could be spread between header
-              block fragments.  The allocation of header fields to frames in this example is
-              illustrative only.
-            </postamble>
           </figure>
 
           <t>
             A response that includes header fields and payload data is transmitted as a
-            <x:ref>HEADERS</x:ref> frame, followed by zero or more <x:ref>CONTINUATION</x:ref>
-            frames, followed by one or more <x:ref>DATA</x:ref> frames, with the last
-            <x:ref>DATA</x:ref> frame in the sequence having the END_STREAM flag set:
+            <x:ref>HEADERS</x:ref> frame, followed by one or more <x:ref>DATA</x:ref> frames, with
+            the last <x:ref>DATA</x:ref> frame in the sequence having the END_STREAM flag set:
           </t>
 
           <figure>
             <artwork type="inline"><![CDATA[
   HTTP/1.1 200 OK                  HEADERS
   Content-Type: image/jpeg   ==>     - END_STREAM
-  Content-Length: 123                + END_HEADERS
-                                       :status = 200
-  {binary data}                        content-type = image/jpeg
-                                       content-length = 123
+  Content-Length: 123                  :status = 200
+                                       content-type = image/jpeg
+  {binary data}                        content-length = 123
 
                                    DATA
                                      + END_STREAM
@@ -3194,27 +3041,25 @@ HTTP2-Settings    = token68
           <t>
             Trailing header fields are sent as a header block after both the request or response
             header block and all the <x:ref>DATA</x:ref> frames have been sent.  The
-            <x:ref>HEADERS</x:ref> frame starting the trailers header block has the END_STREAM flag
-            set.
+            <x:ref>HEADERS</x:ref> frame containing the trailers header block has the END_STREAM
+            flag set.
           </t>
 
           <figure>
             <artwork type="inline"><![CDATA[
   HTTP/1.1 200 OK                  HEADERS
   Content-Type: image/jpeg   ==>     - END_STREAM
-  Transfer-Encoding: chunked         + END_HEADERS
-  Trailer: Foo                         :status = 200
-                                       content-length = 123
-  123                                  content-type = image/jpeg
-  {binary data}                        trailer = Foo
-  0
-  Foo: bar                         DATA
-                                     - END_STREAM
+  Transfer-Encoding: chunked           :status = 200
+  Trailer: Foo                         content-length = 123
+                                       content-type = image/jpeg
+  123                                  trailer = Foo
+  {binary data}
+  0                                DATA
+  Foo: bar                           - END_STREAM
                                    {binary data}
 
                                    HEADERS
                                      + END_STREAM
-                                     + END_HEADERS
                                        foo = bar
 ]]></artwork>
           </figure>
@@ -3320,13 +3165,12 @@ HTTP2-Settings    = token68
           </t>
 
           <t>
-            The header fields in <x:ref>PUSH_PROMISE</x:ref> and any subsequent
-            <x:ref>CONTINUATION</x:ref> frames MUST be a valid and complete set of <xref
-            target="HttpRequest">request header fields</xref>.  The server MUST include a method in
-            the <spanx style="verb">:method</spanx> header field that is safe and cacheable.  If a
-            client receives a <x:ref>PUSH_PROMISE</x:ref> that does not include a complete and valid
-            set of header fields, or the <spanx style="verb">:method</spanx> header field identifies
-            a method that is not safe, it MUST respond with a <xref
+            The header fields in a <x:ref>PUSH_PROMISE</x:ref> frame MUST be a valid and complete
+            set of <xref target="HttpRequest">request header fields</xref>.  The server MUST include
+            a method in the <spanx style="verb">:method</spanx> header field that is safe and
+            cacheable.  If a client receives a <x:ref>PUSH_PROMISE</x:ref> that does not include a
+            complete and valid set of header fields, or the <spanx style="verb">:method</spanx>
+            header field identifies a method that is not safe, it MUST respond with a <xref
             target="StreamErrorHandler">stream error</xref> of type <x:ref>PROTOCOL_ERROR</x:ref>.
           </t>
 
@@ -3353,9 +3197,10 @@ HTTP2-Settings    = token68
             <x:ref>PUSH_PROMISE</x:ref> frames can be sent by the server in response to any
             client-initiated stream, but the stream MUST be in either the "open" or "half closed
             (remote)" state with respect to the server.  <x:ref>PUSH_PROMISE</x:ref> frames are
-            interspersed with the frames that comprise a response, though they cannot be
-            interspersed with <x:ref>HEADERS</x:ref> and <x:ref>CONTINUATION</x:ref> frames that
-            comprise a single header block.
+            interspersed with the frames that comprise a response.  However,
+            <x:ref>PUSH_PROMISE</x:ref> frames do not include an END_STREAM flag and therefore
+            cannot be the last frame on a stream; a zero-length <x:ref>DATA</x:ref> frame can be
+            used for this purpose.
           </t>
           <t>
             Sending a <x:ref>PUSH_PROMISE</x:ref> frame creates a new stream and puts the stream
@@ -3805,8 +3650,7 @@ HTTP2-Settings    = token68
           </t>
           <t>
             This can prevent streaming of the header fields to their ultimate destination, and
-            forces the endpoint to buffer the entire header block.  Since there is no hard limit to
-            the size of a header block, an endpoint could be forced to exhaust available memory.
+            forces the endpoint to buffer the entire header block.
           </t>
           <t>
             A server that receives a larger header block than it is willing to handle can send an
@@ -3972,7 +3816,6 @@ HTTP2-Settings    = token68
           <c>PING</c><c>0x6</c><c><xref target="PING"/></c>
           <c>GOAWAY</c><c>0x7</c><c><xref target="GOAWAY"/></c>
           <c>WINDOW_UPDATE</c><c>0x8</c><c><xref target="WINDOW_UPDATE"/></c>
-          <c>CONTINUATION</c><c>0x9</c><c><xref target="CONTINUATION"/></c>
         </texttable>
       </section>
 
@@ -4650,6 +4493,9 @@ HTTP2-Settings    = token68
     <section title="Change Log (to be removed by RFC Editor before publication)" anchor="change.log">
        <section title="Since draft-ietf-httpbis-http2-13" anchor="changes.since.draft-ietf-httpbis-http2-13">
          <t>
+           Removed CONTINUATION frames.
+         </t>
+         <t>
            Changed frame length field 24-bits.  Expanded frame header to 9 octets.  Added a setting
            to limit the damage.
          </t>
@@ -4681,8 +4527,8 @@ HTTP2-Settings    = token68
            Removed BLOCKED frame.
          </t>
          <t>
-           Reducing the maximum padding size to 256 octets; removing padding from
-           <x:ref>CONTINUATION</x:ref> frames.
+           Reducing the maximum padding size to 256 octets; removing padding from CONTINUATION
+           frames.
          </t>
          <t>
            Removed per-frame GZIP compression.


### PR DESCRIPTION
Supercedes #547 and #548 and invalidates #549 now that increased frame sizes have been committed.  This still depends on the outcome of #550.
