### PR TITLE
Acknowledgement of unsupported settings

### DIFF
--- a/draft-ietf-httpbis-http2.xml
+++ b/draft-ietf-httpbis-http2.xml
@@ -2033,8 +2033,10 @@ HTTP2-Settings    = token68
             is not set MUST apply the updated parameters as soon as possible upon receipt.
           </t>
           <t>
-            The values in the SETTINGS frame MUST be applied in the order they appear, with no other
-            frame processing between values. Once all values have been applied, the recipient MUST
+            The values in the SETTINGS frame MUST be processed in the order they appear, with no other
+            frame processing between values. A value for a supported SETTINGS parameter MUST be
+            applied. A value for an unsupported SETTINGS parameter MUST be ignored.
+            Once all values have been processed, the recipient MUST
             immediately emit a SETTINGS frame with the ACK flag set. Upon receiving a SETTINGS frame
             with the ACK flag set, the sender of the altered parameters can rely upon their
             application.


### PR DESCRIPTION
An endpoint that receives a SETTINGS frame must acknowledge it.

It still has to do this when the SETTINGS frame contains an unsupported setting parameter (either alone or combined with supported setting parameters), otherwise there is a loss of synchronization between SETTINGS frame and their acknowledgements.

This means that an endpoint has no way of stating whether it supports a new setting or not.

I think this is in line with the sense of the WG regarding extensions. But it should be made clear in the spec.
