### PR TITLE
Adding mandatory cipher suites

### DIFF
--- a/draft-ietf-httpbis-http2.xml
+++ b/draft-ietf-httpbis-http2.xml
@@ -3616,14 +3616,17 @@ HTTP2-Settings    = token68
             AES</xref> are acceptable.
           </t>
           <t>
-            Implementations MUST support TLS_DHE_RSA_WITH_AES_128_GCM_SHA256
-            <xref target="TLS12"/> and TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
-            <xref target="TLS-ECDHE"/> with P256 <xref target="FIPS186"/>.
+            The effect of these restrictions is that TLS 1.2 implementations could have
+            non-intersecting sets of available cipher suites, since these prevent the use of the
+            cipher suite that TLS 1.2 makes mandatory.  To avoid this problem, implementations of
+            HTTP/2 that use TLS 1.2 MUST support TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256 <xref
+            target="TLS-ECDHE"/> with P256 <xref target="FIPS186"/>.
           </t>
           <t>
-            Clients MAY advertise support of other cipher suites in order to allow for connection to
-            servers that do not support HTTP/2 to complete without the additional latency imposed by
-            using a separate connection for fallback.
+            Clients MAY advertise support of cipher suites that are prohibited by the above
+            restrictions in order to allow for connection to servers that do not support HTTP/2.
+            This enables a fallback to protocols without these constraints without the additional
+            latency imposed by using a separate connection for fallback.
           </t>
           <t>
             An implementation SHOULD NOT negotiate a TLS connection for HTTP/2 without also


### PR DESCRIPTION
Closes #498.  Note: adds downref to Informational spec.
