### PR TITLE
Removing header ordering

### DIFF
--- a/draft-ietf-httpbis-http2.xml
+++ b/draft-ietf-httpbis-http2.xml
@@ -2789,65 +2789,67 @@ HTTP2-Settings    = token68
           </t>
 
           <section anchor="PseudoHeaderFields" title="Pseudo-Header Fields">
-          <t>
-            While HTTP/1.x used the message start-line (see <xref target="RFC7230" x:fmt=","
-            x:rel="#start.line"/>) to convey the target URI and method of the request, and the
-            status code for the response, HTTP/2 uses special pseudo-header fields beginning with
-            ':' character (ASCII 0x3a) for this purpose.
-          </t>
-          <t>
-            Pseudo-header fields are only valid in the HTTP/2 context.  These are not HTTP header
-            fields.  Endpoints MUST NOT generate pseudo-header fields other than those defined in
-            this document.
-          </t>
-          <t>
-            Pseudo-header fields are only valid in the context in which they are defined.
-            Pseudo-header fields defined for requests MUST NOT appear in responses; pseudo-header
-            fields defined for responses MUST NOT appear in requests.  Pseudo-header fields MUST NOT
-            appear in trailers.  Endpoints MUST treat a request or response that contains undefined
-            or invalid pseudo-header fields as <xref target="malformed">malformed</xref>.
-          </t>
-          <t>
-            Just as in HTTP/1.x, header field names are strings of ASCII characters that are
-            compared in a case-insensitive fashion. However, header field names MUST be converted to
-            lowercase prior to their encoding in HTTP/2. A request or response containing uppercase
-            header field names MUST be treated as <xref target="malformed">malformed</xref>.
-          </t>
-          <t>
-            All pseudo-header fields MUST appear in the header block before regular header fields.
-            Any request or response that contains any pseudo-header field that appears in a header
-            block after a regular header field MUST treated as <xref
-            target="malformed">malformed</xref>.
-          </t>
+            <t>
+              While HTTP/1.x used the message start-line (see <xref target="RFC7230" x:fmt=","
+              x:rel="#start.line"/>) to convey the target URI and method of the request, and the
+              status code for the response, HTTP/2 uses special pseudo-header fields beginning with
+              ':' character (ASCII 0x3a) for this purpose.
+            </t>
+            <t>
+              Pseudo-header fields are only valid in the HTTP/2 context.  These are not HTTP header
+              fields.  Endpoints MUST NOT generate pseudo-header fields other than those defined in
+              this document.
+            </t>
+            <t>
+              Pseudo-header fields are only valid in the context in which they are defined.
+              Pseudo-header fields defined for requests MUST NOT appear in responses; pseudo-header
+              fields defined for responses MUST NOT appear in requests.  Pseudo-header fields MUST
+              NOT appear in trailers.  Endpoints MUST treat a request or response that contains
+              undefined or invalid pseudo-header fields as <xref
+              target="malformed">malformed</xref>.
+            </t>
+            <t>
+              Just as in HTTP/1.x, header field names are strings of ASCII characters that are
+              compared in a case-insensitive fashion. However, header field names MUST be converted
+              to lowercase prior to their encoding in HTTP/2. A request or response containing
+              uppercase header field names MUST be treated as <xref
+              target="malformed">malformed</xref>.
+            </t>
+            <t>
+              All pseudo-header fields MUST appear in the header block before regular header fields.
+              Any request or response that contains any pseudo-header field that appears in a header
+              block after a regular header field MUST treated as <xref
+              target="malformed">malformed</xref>.
+            </t>
           </section>
 
           <section title="Hop-by-Hop Header Fields">
-          <t>
-            HTTP/2 does not use the Connection header field to indicate "hop-by-hop" header fields;
-            in this protocol, connection-specific metadata is conveyed by other means. As such, a
-            HTTP/2 message containing Connection MUST be treated as <xref
-            target="malformed">malformed</xref>.
-          </t>
-          <t>
-            This means that an intermediary transforming an HTTP/1.x message to
-            HTTP/2 will need to remove any header fields nominated by the Connection header field,
-            along with the Connection header field itself. Such intermediaries SHOULD also remove
-            other connection-specific header fields, such as Keep-Alive, Proxy-Connection,
-            Transfer-Encoding and Upgrade, even if they are not nominated by Connection.
-          </t>
-          <t>
-            One exception to this is the TE header field, which MAY be present in an HTTP/2 request,
-            but when it is MUST NOT contain any value other than "trailers".
-          </t>
-          <t>
-            <list style="hanging">
-              <t hangText="Note:">
-                HTTP/2 purposefully does not support upgrade to another protocol.  The handshake
-                methods described in <xref target="starting"/> are believed sufficient to negotiate
-                the use of alternative protocols.
-              </t>
-            </list>
-          </t>
+            <t>
+              HTTP/2 does not use the Connection header field to indicate "hop-by-hop" header
+              fields; in this protocol, connection-specific metadata is conveyed by other means. As
+              such, a HTTP/2 message containing Connection MUST be treated as <xref
+              target="malformed">malformed</xref>.
+            </t>
+            <t>
+              This means that an intermediary transforming an HTTP/1.x message to HTTP/2 will need
+              to remove any header fields nominated by the Connection header field, along with the
+              Connection header field itself. Such intermediaries SHOULD also remove other
+              connection-specific header fields, such as Keep-Alive, Proxy-Connection,
+              Transfer-Encoding and Upgrade, even if they are not nominated by Connection.
+            </t>
+            <t>
+              One exception to this is the TE header field, which MAY be present in an HTTP/2
+              request, but when it is MUST NOT contain any value other than "trailers".
+            </t>
+            <t>
+              <list style="hanging">
+                <t hangText="Note:">
+                  HTTP/2 purposefully does not support upgrade to another protocol.  The handshake
+                  methods described in <xref target="starting"/> are believed sufficient to
+                  negotiate the use of alternative protocols.
+                </t>
+              </list>
+            </t>
           </section>
 
           <section anchor="HttpRequest" title="Request Header Fields">


### PR DESCRIPTION
Now that we have decided to remove the reference set, the hacks we added to address header field ordering are no longer entirely necessary.

This change does the following:
- remove the requirement to concatenate with '\0'
- require pseudo-header fields to all appear before regular header fields
- change 'header set' to 'header list'
