### PR TITLE
Change error code when window size increment is 0

### DIFF
--- a/draft-ietf-httpbis-http2.xml
+++ b/draft-ietf-httpbis-http2.xml
@@ -2421,7 +2421,7 @@ HTTP2-Settings    = token68
         <t>
           A receiver MUST treat the recipt of a WINDOW_UPDATE frame with an flow control window
           increment of 0 as a <xref target="StreamErrorHandler">stream error</xref> of type
-          <x:ref>PROTOCOL_ERROR</x:ref>; errors on the connection flow control window MUST be
+          <x:ref>FLOW_CONTROL_ERROR</x:ref>; errors on the connection flow control window MUST be
           treated as a <xref target="ConnectionErrorHandler">connection error</xref>.
         </t>
         <t>


### PR DESCRIPTION
It can be consistent with the other error cases of WINDOW_UPDATE such that illegal increment value is above 2^31-1
