### PR TITLE
shearl: s/GOAWAY/GO_AWAY, s/REFUSED_STREAM/RETRY_STREAM, s/RST_STREAM/TERMINATE_STREAM

### DIFF
--- a/draft-ietf-httpbis-http2.xml
+++ b/draft-ietf-httpbis-http2.xml
@@ -655,7 +655,7 @@ HTTP2-Settings    = token68
         <t>
           Endpoints are not obligated to use all available space in a frame.  Responsiveness can be
           improved by using frames that are smaller than the permitted maximum size.  Sending large
-          frames can result in delays in sending maintenance frames, such <x:ref>RST_STREAM</x:ref>,
+          frames can result in delays in sending maintenance frames, such <x:ref>TERMINATE_STREAM</x:ref>,
           <x:ref>WINDOW_UPDATE</x:ref>, or <x:ref>PRIORITY</x:ref>, which if blocked by the
           transmission of a large frame, could affect performance.
         </t>
@@ -773,20 +773,20 @@ HTTP2-Settings    = token68
      |      v    v         +--------+         v    v      |
      |   +----------+          |           +----------+   |
      |   |   half   |          |           |   half   |   |
-     |   |  closed  |          | R         |  closed  |   |
+     |   |  closed  |          | T         |  closed  |   |
      |   | (remote) |          |           | (local)  |   |
      |   +----------+          |           +----------+   |
      |        |                v                 |        |
-     |        |  ES / R    +--------+  ES / R    |        |
+     |        |  ES / T    +--------+  ES / T    |        |
      |        `----------->|        |<-----------'        |
-     |  R                  | closed |                  R  |
+     |  T                  | closed |                  T  |
      `-------------------->|        |<--------------------'
                            +--------+
 
        H:  HEADERS frame (with implied CONTINUATIONs)
        PP: PUSH_PROMISE frame (with implied CONTINUATIONs)
        ES: END_STREAM flag
-       R:  RST_STREAM frame
+       T:  TERMINATE_STREAM frame
 ]]>
           </artwork>
         </figure>
@@ -801,7 +801,7 @@ HTTP2-Settings    = token68
           Both endpoints have a subjective view of the state of a stream that could be different
           when frames are in transit.  Endpoints do not coordinate the creation of streams; they are
           created unilaterally by either endpoint.  The negative consequences of a mismatch in
-          states are limited to the "closed" state after sending <x:ref>RST_STREAM</x:ref>, where
+          states are limited to the "closed" state after sending <x:ref>TERMINATE_STREAM</x:ref>, where
           frames might be received for some time after closing.
         </t>
         <t>
@@ -853,18 +853,18 @@ HTTP2-Settings    = token68
                     open in a "half closed (remote)" state.
                   </t>
                   <t>
-                    Either endpoint can send a <x:ref>RST_STREAM</x:ref> frame to cause the stream
+                    Either endpoint can send a <x:ref>TERMINATE_STREAM</x:ref> frame to cause the stream
                     to become "closed".  This releases the stream reservation.
                   </t>
                 </list>
               </t>
               <t>
                 An endpoint MUST NOT send frames other than <x:ref>HEADERS</x:ref> or
-                <x:ref>RST_STREAM</x:ref> in this state.
+                <x:ref>TERMINATE_STREAM</x:ref> in this state.
               </t>
               <t>
                 A <x:ref>PRIORITY</x:ref> frame MAY be received in this state.  Receiving any frames
-                other than <x:ref>RST_STREAM</x:ref>, or <x:ref>PRIORITY</x:ref> MUST be treated as
+                other than <x:ref>TERMINATE_STREAM</x:ref>, or <x:ref>PRIORITY</x:ref> MUST be treated as
                 a <xref target="ConnectionErrorHandler">connection error</xref> of type
                 <x:ref>PROTOCOL_ERROR</x:ref>.
               </t>
@@ -883,7 +883,7 @@ HTTP2-Settings    = token68
                     "half closed (local)".
                   </t>
                   <t>
-                    Either endpoint can send a <x:ref>RST_STREAM</x:ref> frame to cause the stream
+                    Either endpoint can send a <x:ref>TERMINATE_STREAM</x:ref> frame to cause the stream
                     to become "closed".  This releases the stream reservation.
                   </t>
                 </list>
@@ -891,11 +891,11 @@ HTTP2-Settings    = token68
               <t>
                 An endpoint MAY send a <x:ref>PRIORITY</x:ref> frame in this state to reprioritize
                 the reserved stream.  An endpoint MUST NOT send any other type of frame other than
-                <x:ref>RST_STREAM</x:ref> or <x:ref>PRIORITY</x:ref>.
+                <x:ref>TERMINATE_STREAM</x:ref> or <x:ref>PRIORITY</x:ref>.
               </t>
               <t>
                 Receiving any other type of frame other than <x:ref>HEADERS</x:ref> or
-                <x:ref>RST_STREAM</x:ref> MUST be treated as a <xref
+                <x:ref>TERMINATE_STREAM</x:ref> MUST be treated as a <xref
                 target="ConnectionErrorHandler">connection error</xref> of type
                 <x:ref>PROTOCOL_ERROR</x:ref>.
               </t>
@@ -916,7 +916,7 @@ HTTP2-Settings    = token68
                 closed (remote)".
               </t>
               <t>
-                Either endpoint can send a <x:ref>RST_STREAM</x:ref> frame from this state, causing
+                Either endpoint can send a <x:ref>TERMINATE_STREAM</x:ref> frame from this state, causing
                 it to transition immediately to "closed".
               </t>
             </x:lt>
@@ -926,11 +926,11 @@ HTTP2-Settings    = token68
                 <vspace blankLines="0"/>
                 A stream that is in the "half closed (local)" state cannot be used for sending
                 frames.  Only <x:ref>WINDOW_UPDATE</x:ref>, <x:ref>PRIORITY</x:ref> and
-                <x:ref>RST_STREAM</x:ref> frames can be sent in this state.
+                <x:ref>TERMINATE_STREAM</x:ref> frames can be sent in this state.
               </t>
               <t>
                 A stream transitions from this state to "closed" when a frame that contains an
-                END_STREAM flag is received, or when either peer sends a <x:ref>RST_STREAM</x:ref>
+                END_STREAM flag is received, or when either peer sends a <x:ref>TERMINATE_STREAM</x:ref>
                 frame.
               </t>
               <t>
@@ -953,7 +953,7 @@ HTTP2-Settings    = token68
               <t>
                 If an endpoint receives additional frames for a stream that is in this state, other
                 than <x:ref>WINDOW_UPDATE</x:ref>, <x:ref>PRIORITY</x:ref> or
-                <x:ref>RST_STREAM</x:ref>, it MUST respond with a <xref
+                <x:ref>TERMINATE_STREAM</x:ref>, it MUST respond with a <xref
                 target="StreamErrorHandler">stream error</xref> of type
                 <x:ref>STREAM_CLOSED</x:ref>.
               </t>
@@ -964,7 +964,7 @@ HTTP2-Settings    = token68
               </t>
               <t>
                 A stream can transition from this state to "closed" by sending a frame that contains
-                an END_STREAM flag, or when either peer sends a <x:ref>RST_STREAM</x:ref> frame.
+                an END_STREAM flag, or when either peer sends a <x:ref>TERMINATE_STREAM</x:ref> frame.
               </t>
             </x:lt>
 
@@ -976,7 +976,7 @@ HTTP2-Settings    = token68
               <t>
                 An endpoint MUST NOT send frames other than <x:ref>PRIORITY</x:ref> on a closed
                 stream.  An endpoint that receives any frame other than <x:ref>PRIORITY</x:ref>
-                after receiving a <x:ref>RST_STREAM</x:ref> MUST treat that as a <xref
+                after receiving a <x:ref>TERMINATE_STREAM</x:ref> MUST treat that as a <xref
                 target="StreamErrorHandler">stream error</xref> of type
                 <x:ref>STREAM_CLOSED</x:ref>.  Similarly, an endpoint that receives any frames after
                 receiving a frame with the END_STREAM flag set MUST treat that as a <xref
@@ -984,12 +984,12 @@ HTTP2-Settings    = token68
                 <x:ref>STREAM_CLOSED</x:ref>, unless the frame is permitted as described below.
               </t>
               <t>
-                <x:ref>WINDOW_UPDATE</x:ref> or <x:ref>RST_STREAM</x:ref> frames can be received in
+                <x:ref>WINDOW_UPDATE</x:ref> or <x:ref>TERMINATE_STREAM</x:ref> frames can be received in
                 this state for a short period after a <x:ref>DATA</x:ref> or <x:ref>HEADERS</x:ref>
                 frame containing an END_STREAM flag is sent.  Until the remote peer receives and
-                processes <x:ref>RST_STREAM</x:ref> or the frame bearing the END_STREAM flag, it
+                processes <x:ref>TERMINATE_STREAM</x:ref> or the frame bearing the END_STREAM flag, it
                 might send frames of these types.  Endpoints MUST ignore
-                <x:ref>WINDOW_UPDATE</x:ref> or <x:ref>RST_STREAM</x:ref> frames received in this
+                <x:ref>WINDOW_UPDATE</x:ref> or <x:ref>TERMINATE_STREAM</x:ref> frames received in this
                 state, though endpoints MAY choose to treat frames that arrive a significant time
                 after sending END_STREAM as a <xref target="ConnectionErrorHandler">connection
                 error</xref> of type <x:ref>PROTOCOL_ERROR</x:ref>.
@@ -1001,26 +1001,26 @@ HTTP2-Settings    = token68
                 removed from the dependency tree (see <xref target="priority-gc"/>).
               </t>
               <t>
-                If this state is reached as a result of sending a <x:ref>RST_STREAM</x:ref> frame,
-                the peer that receives the <x:ref>RST_STREAM</x:ref> might have already sent - or
+                If this state is reached as a result of sending a <x:ref>TERMINATE_STREAM</x:ref> frame,
+                the peer that receives the <x:ref>TERMINATE_STREAM</x:ref> might have already sent - or
                 enqueued for sending - frames on the stream that cannot be withdrawn.  An endpoint
                 MUST ignore frames that it receives on closed streams after it has sent a
-                <x:ref>RST_STREAM</x:ref> frame.  An endpoint MAY choose to limit the period over
+                <x:ref>TERMINATE_STREAM</x:ref> frame.  An endpoint MAY choose to limit the period over
                 which it ignores frames and treat frames that arrive after this time as being in
                 error.
               </t>
               <t>
                 Flow controlled frames (i.e., <x:ref>DATA</x:ref>) received after sending
-                <x:ref>RST_STREAM</x:ref> are counted toward the connection flow control window.
+                <x:ref>TERMINATE_STREAM</x:ref> are counted toward the connection flow control window.
                 Even though these frames might be ignored, because they are sent before the sender
-                receives the <x:ref>RST_STREAM</x:ref>, the sender will consider the frames to count
+                receives the <x:ref>TERMINATE_STREAM</x:ref>, the sender will consider the frames to count
                 against the flow control window.
               </t>
               <t>
                 An endpoint might receive a <x:ref>PUSH_PROMISE</x:ref> frame after it sends
-                <x:ref>RST_STREAM</x:ref>.  <x:ref>PUSH_PROMISE</x:ref> causes a stream to become
-                "reserved" even if the associated stream has been reset.  Therefore, a
-                <x:ref>RST_STREAM</x:ref> is needed to close an unwanted promised stream.
+                <x:ref>TERMINATE_STREAM</x:ref>.  <x:ref>PUSH_PROMISE</x:ref> causes a stream to become
+                "reserved" even if the associated stream has been terminated.  Therefore, a
+                <x:ref>TERMINATE_STREAM</x:ref> is needed to close an unwanted promised stream.
               </t>
             </x:lt>
           </list>
@@ -1453,27 +1453,27 @@ HTTP2-Settings    = token68
             of other streams.
           </t>
           <t>
-            An endpoint that detects a stream error sends a <x:ref>RST_STREAM</x:ref> frame (<xref
-            target="RST_STREAM"/>) that contains the stream identifier of the stream where the error
-            occurred.  The <x:ref>RST_STREAM</x:ref> frame includes an error code that indicates the
+            An endpoint that detects a stream error sends a <x:ref>TERMINATE_STREAM</x:ref> frame (<xref
+            target="TERMINATE_STREAM"/>) that contains the stream identifier of the stream where the error
+            occurred.  The <x:ref>TERMINATE_STREAM</x:ref> frame includes an error code that indicates the
             type of error.
           </t>
           <t>
-            A <x:ref>RST_STREAM</x:ref> is the last frame that an endpoint can send on a stream.
-            The peer that sends the <x:ref>RST_STREAM</x:ref> frame MUST be prepared to receive any
+            A <x:ref>TERMINATE_STREAM</x:ref> is the last frame that an endpoint can send on a stream.
+            The peer that sends the <x:ref>TERMINATE_STREAM</x:ref> frame MUST be prepared to receive any
             frames that were sent or enqueued for sending by the remote peer.  These frames can be
             ignored, except where they modify connection state (such as the state maintained for
             <xref target="HeaderBlock">header compression</xref>, or flow control).
           </t>
           <t>
-            Normally, an endpoint SHOULD NOT send more than one <x:ref>RST_STREAM</x:ref> frame for
-            any stream. However, an endpoint MAY send additional <x:ref>RST_STREAM</x:ref> frames if
+            Normally, an endpoint SHOULD NOT send more than one <x:ref>TERMINATE_STREAM</x:ref> frame for
+            any stream. However, an endpoint MAY send additional <x:ref>TERMINATE_STREAM</x:ref> frames if
             it receives frames on a closed stream after more than a round-trip time.  This behavior
             is permitted to deal with misbehaving implementations.
           </t>
           <t>
-            An endpoint MUST NOT send a <x:ref>RST_STREAM</x:ref> in response to an
-            <x:ref>RST_STREAM</x:ref> frame, to avoid looping.
+            An endpoint MUST NOT send a <x:ref>TERMINATE_STREAM</x:ref> in response to an
+            <x:ref>TERMINATE_STREAM</x:ref> frame, to avoid looping.
           </t>
         </section>
 
@@ -1810,15 +1810,15 @@ HTTP2-Settings    = token68
         </t>
       </section>
 
-      <section anchor="RST_STREAM" title="RST_STREAM">
+      <section anchor="TERMINATE_STREAM" title="TERMINATE_STREAM">
         <t>
-          The RST_STREAM frame (type=0x3) allows for abnormal termination of a stream.  When sent by
+          The TERMINATE_STREAM frame (type=0x3) allows for abnormal termination of a stream.  When sent by
           the initiator of a stream, it indicates that they wish to cancel the stream or that an
           error condition has occurred.  When sent by the receiver of a stream, it indicates that
           either the receiver is rejecting the stream, requesting that the stream be cancelled, or
           that an error condition has occurred.
         </t>
-        <figure title="RST_STREAM Frame Payload">
+        <figure title="TERMINATE_STREAM Frame Payload">
           <artwork type="inline"><![CDATA[
   0                   1                   2                   3
   0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
@@ -1829,32 +1829,32 @@ HTTP2-Settings    = token68
         </figure>
 
         <t>
-          The RST_STREAM frame contains a single unsigned, 32-bit integer identifying the <xref
+          The TERMINATE_STREAM frame contains a single unsigned, 32-bit integer identifying the <xref
           target="ErrorCodes">error code</xref>.  The error code indicates why the stream is being
           terminated.
         </t>
 
         <t>
-          The RST_STREAM frame does not define any flags.
+          The TERMINATE_STREAM frame does not define any flags.
         </t>
 
         <t>
-          The RST_STREAM frame fully terminates the referenced stream and causes it to enter the
-          closed state. After receiving a RST_STREAM on a stream, the receiver MUST NOT send
-          additional frames for that stream. However, after sending the RST_STREAM, the sending
+          The TERMINATE_STREAM frame fully terminates the referenced stream and causes it to enter the
+          closed state. After receiving a TERMINATE_STREAM on a stream, the receiver MUST NOT send
+          additional frames for that stream. However, after sending the TERMINATE_STREAM, the sending
           endpoint MUST be prepared to receive and process additional frames sent on the stream that
-          might have been sent by the peer prior to the arrival of the RST_STREAM.
+          might have been sent by the peer prior to the arrival of the TERMINATE_STREAM.
         </t>
 
         <t>
-          RST_STREAM frames MUST be associated with a stream.  If a RST_STREAM frame is received
+          TERMINATE_STREAM frames MUST be associated with a stream.  If a TERMINATE_STREAM frame is received
           with a stream identifier of 0x0, the recipient MUST treat this as a <xref
           target="ConnectionErrorHandler">connection error</xref> of type
           <x:ref>PROTOCOL_ERROR</x:ref>.
         </t>
 
         <t>
-          RST_STREAM frames MUST NOT be sent for a stream in the "idle" state.  If a RST_STREAM
+          TERMINATE_STREAM frames MUST NOT be sent for a stream in the "idle" state.  If a TERMINATE_STREAM
           frame identifying an idle stream is received, the recipient MUST treat this as a <xref
           target="ConnectionErrorHandler">connection error</xref> of type
           <x:ref>PROTOCOL_ERROR</x:ref>.
@@ -2154,7 +2154,7 @@ HTTP2-Settings    = token68
         </t>
         <t>
           Recipients of PUSH_PROMISE frames can choose to reject promised streams by returning a
-          <x:ref>RST_STREAM</x:ref> referencing the promised stream identifier back to the sender of
+          <x:ref>TERMINATE_STREAM</x:ref> referencing the promised stream identifier back to the sender of
           the PUSH_PROMISE.
         </t>
 
@@ -2475,7 +2475,7 @@ HTTP2-Settings    = token68
             A sender MUST NOT allow a flow control window to exceed 2<x:sup>31</x:sup>-1 bytes.
             If a sender receives a WINDOW_UPDATE that causes a flow control window to exceed this
             maximum it MUST terminate either the stream or the connection, as appropriate.  For
-            streams, the sender sends a <x:ref>RST_STREAM</x:ref> with the error code of
+            streams, the sender sends a <x:ref>TERMINATE_STREAM</x:ref> with the error code of
             <x:ref>FLOW_CONTROL_ERROR</x:ref> code; for the connection, a <x:ref>GO_AWAY</x:ref>
             frame with a <x:ref>FLOW_CONTROL_ERROR</x:ref> code.
           </t>
@@ -2544,7 +2544,7 @@ HTTP2-Settings    = token68
             receiver has two options for handling streams that exceed flow control limits:
             <list style="numbers">
               <t>
-                The receiver can immediately send <x:ref>RST_STREAM</x:ref> with
+                The receiver can immediately send <x:ref>TERMINATE_STREAM</x:ref> with
                 <x:ref>FLOW_CONTROL_ERROR</x:ref> error code for the affected streams.
               </t>
               <t>
@@ -2620,7 +2620,7 @@ HTTP2-Settings    = token68
 
     <section anchor="ErrorCodes" title="Error Codes">
       <t>
-        Error codes are 32-bit fields that are used in <x:ref>RST_STREAM</x:ref> and
+        Error codes are 32-bit fields that are used in <x:ref>TERMINATE_STREAM</x:ref> and
         <x:ref>GO_AWAY</x:ref> frames to convey the reasons for the stream or connection error.
       </t>
 
@@ -2660,7 +2660,7 @@ HTTP2-Settings    = token68
           </t>
           <t hangText="RETRY_STREAM (0x7):" anchor="RETRY_STREAM">
 	    The endpoint closed the stream prior to performing any application processing.  Any 
-	    request that was sent on the reset stream can be safely retried, see 
+	    request that was sent on the terminated stream can be safely retried, see 
             <xref target="Reliability"/> for details.
           </t>
           <t hangText="CANCEL (0x8):" anchor="CANCEL">
@@ -3003,7 +3003,7 @@ HTTP2-Settings    = token68
             </t>
             <t>
               For malformed requests, a server MAY send an HTTP response prior to closing or
-              resetting the stream.  Clients MUST NOT accept a malformed response. Note that these
+              terminating the stream.  Clients MUST NOT accept a malformed response. Note that these
               requirements are intended to protect against several types of common attacks against
               HTTP; they are deliberately strict, because being permissive can expose
               implementations to these vulnerabilities.
@@ -3175,8 +3175,8 @@ HTTP2-Settings    = token68
               </t>
               <t>
                 The <x:ref>RETRY_STREAM</x:ref> error code can be included in a
-                <x:ref>RST_STREAM</x:ref> frame to indicate that the stream is being closed prior to
-                any processing having occurred.  Any request that was sent on the reset stream can
+                <x:ref>TERMINATE_STREAM</x:ref> frame to indicate that the stream is being closed prior to
+                any processing having occurred.  Any request that was sent on the terminated stream can
                 be safely retried.
               </t>
             </list>
@@ -3320,7 +3320,7 @@ HTTP2-Settings    = token68
           <t>
             If the client determines, for any reason, that it does not wish to receive the pushed
             response from the server, or if the server takes too long to begin sending the promised
-            response, the client can send an <x:ref>RST_STREAM</x:ref> frame, using either the
+            response, the client can send an <x:ref>TERMINATE_STREAM</x:ref> frame, using either the
             <x:ref>CANCEL</x:ref> or <x:ref>RETRY_STREAM</x:ref> codes, and referencing the pushed
             stream's identifier.
           </t>
@@ -3329,7 +3329,7 @@ HTTP2-Settings    = token68
             number of responses that can be concurrently pushed by a server.  Advertising a
             <x:ref>SETTINGS_MAX_CONCURRENT_STREAMS</x:ref> value of zero disables server push by
             preventing the server from creating the necessary streams.  This does not prohibit a
-            server from sending PUSH_PROMISE frames; clients need to reset any promised streams that
+            server from sending PUSH_PROMISE frames; clients need to terminate any promised streams that
             are not wanted.
           </t>
 
@@ -3396,7 +3396,7 @@ HTTP2-Settings    = token68
           any <x:ref>DATA</x:ref> frames sent by the client are transmitted by the proxy to the TCP
           server; data received from the TCP server is assembled into <x:ref>DATA</x:ref> frames by
           the proxy.  Frame types other than <x:ref>DATA</x:ref> or stream management frames
-          (<x:ref>RST_STREAM</x:ref>, <x:ref>WINDOW_UPDATE</x:ref>, and <x:ref>PRIORITY</x:ref>)
+          (<x:ref>TERMINATE_STREAM</x:ref>, <x:ref>WINDOW_UPDATE</x:ref>, and <x:ref>PRIORITY</x:ref>)
           MUST NOT be sent on a connected stream, and MUST be treated as a <xref
           target="StreamErrorHandler">stream error</xref> if received.
         </t>
@@ -3411,7 +3411,7 @@ HTTP2-Settings    = token68
           or <x:ref>DATA</x:ref> frame could be empty.
         </t>
         <t>
-          A TCP connection error is signaled with <x:ref>RST_STREAM</x:ref>.  A proxy treats any
+          A TCP connection error is signaled with <x:ref>TERMINATE_STREAM</x:ref>.  A proxy treats any
           error in the TCP connection, which includes receiving a TCP segment with the RST bit set,
           as a <xref target="StreamErrorHandler">stream error</xref> of type
           <x:ref>CONNECT_ERROR</x:ref>.  Correspondingly, a proxy MUST send a TCP segment with the
@@ -3921,7 +3921,7 @@ HTTP2-Settings    = token68
           <c>DATA</c><c>0x0</c><c><xref target="DATA"/></c>
           <c>HEADERS</c><c>0x1</c><c><xref target="HEADERS"/></c>
           <c>PRIORITY</c><c>0x2</c><c><xref target="PRIORITY"/></c>
-          <c>RST_STREAM</c><c>0x3</c><c><xref target="RST_STREAM"/></c>
+          <c>TERMINATE_STREAM</c><c>0x3</c><c><xref target="TERMINATE_STREAM"/></c>
           <c>SETTINGS</c><c>0x4</c><c><xref target="SETTINGS"/></c>
           <c>PUSH_PROMISE</c><c>0x5</c><c><xref target="PUSH_PROMISE"/></c>
           <c>PING</c><c>0x6</c><c><xref target="PING"/></c>


### PR DESCRIPTION
renamed GOAWAY to GO_AWAY to be consistent with the naming for other two-word frame types ie RST_STREAM, PUSH_PROMISE and WINDOW_UPDATE

s/REFUSED_STREAM/RETRY_STREAM The definition of REFUSED_STREAM is somewhat contradictory with the definition of the word refused. The word refused is defined as: indicate or show that one is _not willing_ to do something (https://www.google.at/).  The definition of REFUSED_STREAM in Section 7 references section 8.1.4 which says that a REFUSED_STREAM is safe to retry.  In other words the server is actually _willing_ to process the stream, but _currently unable_ (e.g. because the client overran settings and so the client needs to retry the stream with the new settings.)

s/RST_STREAM/TERMINATE_STREAM The definition of RST_STREAM doesn't match the meaning of the word reset.  The word reset generally means: "cause (a binary device) to enter the state representing the numeral 0." [http://www.oxforddictionaries.com/definition/english/reset] In other words, the word reset implies that the stream should be reset back to its _original_ state (i.e. IDLE), but RST_STREAM immediately takes a stream to its _terminal_ state (i.e. CLOSED).
