### PR TITLE
Fix description for SETTING_MAX_FRAME_SIZE.

### DIFF
--- a/draft-ietf-httpbis-http2.xml
+++ b/draft-ietf-httpbis-http2.xml
@@ -2013,8 +2013,8 @@ HTTP2-Settings    = token68
               <x:lt hangText="SETTINGS_MAX_FRAME_SIZE (0x5):"
                     anchor="SETTINGS_MAX_FRAME_SIZE">
                 <t>
-                  Indicates the size of the largest frame payload that a receiver is willing to
-                  accept.
+                  Indicates the size of the largest frame payload that the sender is willing to
+                  receive.
                 </t>
                 <t>
                   The initial value is 2<x:sup>14</x:sup> (16,384) octets.  The value advertised by


### PR DESCRIPTION
The _sender_ advertises it's acceptable max size.
Incorporated @bagder 's suggestion on #580.
