### PR TITLE
HTTP_1.1_REQUIRED

### DIFF
--- a/draft-ietf-httpbis-http2.xml
+++ b/draft-ietf-httpbis-http2.xml
@@ -2713,6 +2713,9 @@ HTTP2-Settings    = token68
             The underlying transport has properties that do not meet minimum security
             requirements (see <xref target="TLSUsage"/>).
           </t>
+          <t hangText="HTTP_1.1_REQUIRED (0xd):" anchor="HTTP_1.1_REQUIRED">
+            The endpoint requires that HTTP/1.1 be used instead of HTTP/2.
+          </t>
         </list>
       </t>
       <t>
@@ -3610,8 +3613,9 @@ HTTP2-Settings    = token68
           <t>
             This effectively prevents the use of renegotiation in response to a request for a
             specific protected resource.  A future specification might provide a way to support this
-            use case. <!-- <cref> We are tracking this in a non-blocking fashion in issue #496 and
-            with a new draft. -->
+            use case. Alternatively, a server might use a <xref target="ConnectionErrorHandler">
+            connection error</xref> of type <xref>HTTP_1.1_REQUIRED</xref> to request the client
+            use a protocol which supports renegotiation.
           </t>
         </section>
 


### PR DESCRIPTION
Adds a "1.1 Required" error code, and a mention of the error code in the Renegotiation section.  Hopefully addresses #496.
