### PR TITLE
WGLC editorial pass

### DIFF
--- a/draft-ietf-httpbis-http2.xml
+++ b/draft-ietf-httpbis-http2.xml
@@ -456,18 +456,16 @@ HTTP2-Settings    = token68
             A server decodes and interprets these values as it would any other
             <x:ref>SETTINGS</x:ref> frame.  <xref target="SettingsSync">Acknowledgement of the
             SETTINGS parameters</xref> is not necessary, since a 101 response serves as implicit
-            acknowledgment.  Providing these values in the Upgrade request ensures that the protocol
-            does not require default values for the above SETTINGS parameters, and gives a client an
-            opportunity to provide other parameters prior to receiving any frames from the server.
+            acknowledgment.  Providing these values in the Upgrade request gives a client an
+            opportunity to provide parameters prior to receiving any frames from the server.
           </t>
         </section>
       </section>
 
       <section anchor="discover-https" title="Starting HTTP/2 for &quot;https&quot; URIs">
         <t>
-          A client that makes a request to an "https" URI without prior knowledge about support for
-          HTTP/2 uses <xref target="TLS12">TLS</xref> with the <xref target="TLS-ALPN">application
-          layer protocol negotiation extension</xref>.
+          A client that makes a request to an "https" URI uses <xref target="TLS12">TLS</xref>
+          with the <xref target="TLS-ALPN">application layer protocol negotiation extension</xref>.
         </t>
         <t>
           HTTP/2 over TLS uses the "h2" application token.  The "h2c" token MUST NOT be sent by a
@@ -906,7 +904,8 @@ HTTP2-Settings    = token68
               <t>
                 An endpoint MAY send a <x:ref>PRIORITY</x:ref> frame in this state to reprioritize
                 the reserved stream.  An endpoint MUST NOT send any type of frame other than
-                <x:ref>RST_STREAM</x:ref> or <x:ref>PRIORITY</x:ref> in this state.
+                <x:ref>RST_STREAM</x:ref>, <x:ref>WINDOW_UPDATE</x:ref>, or <x:ref>PRIORITY</x:ref>
+                in this state.
               </t>
               <t>
                 Receiving any type of frame other than <x:ref>HEADERS</x:ref> or
@@ -1171,7 +1170,7 @@ HTTP2-Settings    = token68
               <t>
                 HTTP/2 defines only the format and semantics of the <x:ref>WINDOW_UPDATE</x:ref>
                 frame (<xref target="WINDOW_UPDATE"/>).  This document does not stipulate how a
-                receiver decides when to send this frame or the value that it sends.  Nor does it
+                receiver decides when to send this frame or the value that it sends, nor does it
                 specify how a sender chooses to send packets.  Implementations are able to select
                 any algorithm that suits their needs.
               </t>
@@ -1309,7 +1308,7 @@ HTTP2-Settings    = token68
 
         <section title="Dependency Weighting">
           <t>
-            All dependent streams are allocated an integer weight between 1 to 256 (inclusive).
+            All dependent streams are allocated an integer weight between 1 and 256 (inclusive).
           </t>
           <t>
             Streams with the same parent SHOULD be allocated resources proportionally based on their
@@ -1690,7 +1689,8 @@ HTTP2-Settings    = token68
               A <xref target="HeaderBlock">header block fragment</xref>.
             </t>
             <t hangText="Padding:">
-              Padding octets.
+              Padding octets that contain no application semantic value.  Padding octets MUST be set
+              to zero when sending and ignored when receiving.
             </t>
           </list>
         </t>


### PR DESCRIPTION
A couple nitpicky things that jumped out at me in another readthrough.
- 3.2.1:  Says that the SETTINGS parameters don't need defaults because of HTTP2-Settings, but they _have_ defaults.  Removing this claim.
- 3.3:  Says that ALPN is used for HTTPS _if_ you don't have prior knowledge, but 3.4 says you have to use ALPN even if you do have prior knowledge.  Removing the caveat in 3.3 to reconcile.
- 5.1:  Allowing WINDOW_UPDATE to be send in reserved (remote) state.  This has been discussed in-person and on-list as a reasonable client strategy (low initial window, unchoke the pushes you want), but per the current text this is actually prohibited until after receiving the HEADERS frame.
- 5.2.1:  Fixing sentence fragment.
- 5.3.2:  Possibly just a personal/regional style, but from/to or between/and works for me; between/to doesn't.
- 6.1 and 6.2 use different definitions of the padding field.  Copied 6.1's to 6.2.
