### PR TITLE
Allowing validation of padding bytes

### DIFF
--- a/draft-ietf-httpbis-http2.xml
+++ b/draft-ietf-httpbis-http2.xml
@@ -1603,7 +1603,9 @@ HTTP2-Settings    = token68
             </t>
             <t hangText="Padding:">
               Padding octets that contain no application semantic value.  Padding octets MUST be set
-              to zero when sending and ignored when receiving.
+              to zero when sending.  A receiver is not obligated to verify padding, but MAY treat
+              non-zero padding as a <xref target="ConnectionErrorHandler">connection error</xref> of
+              type <x:ref>PROTOCOL_ERROR</x:ref>.
             </t>
           </list>
         </t>


### PR DESCRIPTION
For #602.  This takes the approach used for the TLS padding extension.
