### PR TITLE
 HTTP_1.1_REQUIRED

### DIFF
--- a/draft-ietf-httpbis-http2.xml
+++ b/draft-ietf-httpbis-http2.xml
@@ -2756,7 +2756,7 @@ HTTP2-Settings    = token68
             The underlying transport has properties that do not meet minimum security
             requirements (see <xref target="TLSUsage"/>).
           </t>
-          <t hangText="HTTP_1.1_REQUIRED (0xd):" anchor="HTTP_1.1_REQUIRED">
+          <t hangText="HTTP_1_1_REQUIRED (0xd):" anchor="HTTP_1_1_REQUIRED">
             The endpoint requires that HTTP/1.1 be used instead of HTTP/2.
           </t>
         </list>
@@ -3674,7 +3674,7 @@ HTTP2-Settings    = token68
             This effectively prevents the use of renegotiation in response to a request for a
             specific protected resource.  A future specification might provide a way to support this
             use case. Alternatively, a server might use a <xref target="ConnectionErrorHandler">
-            connection error</xref> of type <xref>HTTP_1.1_REQUIRED</xref> to request the client
+            connection error</xref> of type <xref>HTTP_1_1_REQUIRED</xref> to request the client
             use a protocol which supports renegotiation.
           </t>
         </section>
@@ -4156,6 +4156,9 @@ HTTP2-Settings    = token68
           <c><xref target="ErrorCodes"/></c>
           <c>INADEQUATE_SECURITY</c><c>0xc</c>
           <c>Negotiated TLS parameters not acceptable</c>
+          <c><xref target="ErrorCodes"/></c>
+          <c>HTTP_1_1_REQUIRED</c><c>0xc</c>
+          <c>Use HTTP/1.1 for the request</c>
           <c><xref target="ErrorCodes"/></c>
         </texttable>
 


### PR DESCRIPTION
This is an update of #599:

> Adds a "1.1 Required" error code, and a mention of the error code in the Renegotiation section.

Closes #496.
