### PR TITLE
a HTTP -> an HTTP

### DIFF
--- a/draft-ietf-httpbis-header-compression.xml
+++ b/draft-ietf-httpbis-header-compression.xml
@@ -171,7 +171,7 @@
                             A header list is an ordered collection of header
                             fields that are encoded jointly, and can contain
                             duplicate header fields. A complete list of
-                            key-value pairs contained in a HTTP/2 header block
+                            key-value pairs contained in an HTTP/2 header block
                             is a header list.
                         </t>
                         <t hangText="Header Field Representation:">

--- a/draft-ietf-httpbis-http2.xml
+++ b/draft-ietf-httpbis-http2.xml
@@ -2910,7 +2910,7 @@ HTTP2-Settings    = token68
             <t>
               HTTP/2 does not use the <spanx style="verb">Connection</spanx> header field to
               indicate connection-specific header fields; in this protocol, connection-specific
-              metadata is conveyed by other means.  An endpoint MUST NOT generate a HTTP/2 message
+              metadata is conveyed by other means.  An endpoint MUST NOT generate an HTTP/2 message
               containing connection-specific header fields; any message containing
               connection-specific header fields MUST be treated as <xref
               target="malformed">malformed</xref>.
@@ -3311,7 +3311,7 @@ HTTP2-Settings    = token68
         </t>
         <t>
           Pushed responses that are cacheable (see <xref target="RFC7234" x:fmt=","
-          x:rel="#response.cacheability"/>) can be stored by the client, if it implements a HTTP
+          x:rel="#response.cacheability"/>) can be stored by the client, if it implements an HTTP
           cache.  Pushed responses are considered successfully validated on the origin server (e.g.,
           if the "no-cache" cache response directive <xref target="RFC7234" x:fmt=","
           x:rel="#cache-response-directive"/> is present) while the stream identified by the


### PR DESCRIPTION
I think "an" is correct.
