### PR TITLE
Dedupe However, However

### DIFF
--- a/draft-ietf-httpbis-http2.xml
+++ b/draft-ietf-httpbis-http2.xml
@@ -1537,7 +1537,7 @@ HTTP2-Settings    = token68
           <x:ref>PROTOCOL_ERROR</x:ref>.
         </t>
         <t>
-          However, extensions that could change the semantics of existing protocol components MUST
+          Extensions that could change the semantics of existing protocol components MUST
           be negotiated before being used.  For example, an extension that changes the layout of the
           <x:ref>HEADERS</x:ref> frame cannot be used until the peer has given a positive signal
           that this is acceptable.  In this case, it could also be necessary to coordinate when the


### PR DESCRIPTION
The last sentence of the previous paragraph started with However, which made this sentence not read as nicely. Killed the extra However.
