### PR TITLE
Fix bit numbering

### DIFF
--- a/draft-ietf-httpbis-http2.xml
+++ b/draft-ietf-httpbis-http2.xml
@@ -1616,12 +1616,12 @@ HTTP2-Settings    = token68
           The DATA frame defines the following flags:
           <list style="hanging">
             <t hangText="END_STREAM (0x1):">
-              Bit 1 being set indicates that this frame is the last that the endpoint will send for
+              Bit 0 being set indicates that this frame is the last that the endpoint will send for
               the identified stream.  Setting this flag causes the stream to enter one of <xref
               target="StreamStates">the "half closed" states or the "closed" state</xref>.
             </t>
             <t hangText="PADDED (0x8):">
-              Bit 4 being set indicates that the Pad Length field and any padding that it describes
+              Bit 3 being set indicates that the Pad Length field and any padding that it describes
               is present.
             </t>
           </list>
@@ -1716,7 +1716,7 @@ HTTP2-Settings    = token68
           <list style="hanging">
             <x:lt hangText="END_STREAM (0x1):">
               <t>
-                Bit 1 being set indicates that the <xref target="HeaderBlock">header block</xref> is
+                Bit 0 being set indicates that the <xref target="HeaderBlock">header block</xref> is
                 the last that the endpoint will send for the identified stream.  Setting this flag
                 causes the stream to enter one of <xref target="StreamStates">"half closed"
                 states</xref>.
@@ -1730,7 +1730,7 @@ HTTP2-Settings    = token68
             </x:lt>
             <x:lt hangText="END_HEADERS (0x4):">
               <t>
-                Bit 3 being set indicates that this frame contains an entire <xref
+                Bit 2 being set indicates that this frame contains an entire <xref
                 target="HeaderBlock">header block</xref> and is not followed by any
                 <x:ref>CONTINUATION</x:ref> frames.
               </t>
@@ -1744,13 +1744,13 @@ HTTP2-Settings    = token68
             </x:lt>
             <x:lt hangText="PADDED (0x8):">
               <t>
-                Bit 4 being set indicates that the Pad Length field and any padding that it
+                Bit 3 being set indicates that the Pad Length field and any padding that it
                 describes is present.
               </t>
             </x:lt>
             <x:lt hangText="PRIORITY (0x20):">
               <t>
-                Bit 6 being set indicates that the Exclusive Flag (E), Stream Dependency, and Weight
+                Bit 5 being set indicates that the Exclusive Flag (E), Stream Dependency, and Weight
                 fields are present; see <xref target="StreamPriority"/>.
               </t>
             </x:lt>
@@ -1947,7 +1947,7 @@ HTTP2-Settings    = token68
           frame defines the following flag:
           <list style="hanging">
             <t hangText="ACK (0x1):">
-              Bit 1 being set indicates that this frame acknowledges receipt and application of the
+              Bit 0 being set indicates that this frame acknowledges receipt and application of the
               peer's SETTINGS frame.  When this bit is set, the payload of the SETTINGS frame MUST
               be empty.  Receipt of a SETTINGS frame with the ACK flag set and a length field value
               other than 0 MUST be treated as a <xref target="ConnectionErrorHandler">connection
@@ -2173,7 +2173,7 @@ HTTP2-Settings    = token68
           <list style="hanging">
             <x:lt hangText="END_HEADERS (0x4):">
               <t>
-                Bit 3 being set indicates that this frame contains an entire <xref
+                Bit 2 being set indicates that this frame contains an entire <xref
                 target="HeaderBlock">header block</xref> and is not followed by any
                 <x:ref>CONTINUATION</x:ref> frames.
               </t>
@@ -2187,7 +2187,7 @@ HTTP2-Settings    = token68
             </x:lt>
             <x:lt hangText="PADDED (0x8):">
               <t>
-                Bit 4 being set indicates that the Pad Length field and any padding that it
+                Bit 3 being set indicates that the Pad Length field and any padding that it
                 describes is present.
               </t>
             </x:lt>
@@ -2287,7 +2287,7 @@ HTTP2-Settings    = token68
           The PING frame defines the following flags:
           <list style="hanging">
             <t hangText="ACK (0x1):">
-              Bit 1 being set indicates that this PING frame is a PING response.  An endpoint MUST
+              Bit 0 being set indicates that this PING frame is a PING response.  An endpoint MUST
               set this flag in PING responses.  An endpoint MUST NOT respond to PING frames
               containing this flag.
             </t>
@@ -2661,7 +2661,7 @@ HTTP2-Settings    = token68
           <list style="hanging">
             <x:lt hangText="END_HEADERS (0x4):">
               <t>
-                Bit 3 being set indicates that this frame ends a <xref target="HeaderBlock">header
+                Bit 2 being set indicates that this frame ends a <xref target="HeaderBlock">header
                 block</xref>.
               </t>
               <t>


### PR DESCRIPTION
Bits seem to be numbered from 1 to N, which is very confusing since
almost every software starts at zero. Also it's common to find macros
like :

  #define BIT(N) (1 << (N))

and here that would introduce mistakes since one constantly has to
think about shifting bits before using the macro (eg: BIT(3) to check
bit called "4" in the spec, corresponding to value 0x8).

Since there are not that many places where this happens, this commit
aims at fixing them. Note that the hexadecimal values for each of them
were already correct and non-ambiguous.
