### PR TITLE
Tweaks for client certs

### DIFF
--- a/draft-ietf-httpbis-http2.xml
+++ b/draft-ietf-httpbis-http2.xml
@@ -1430,7 +1430,7 @@ HTTP2-Settings    = token68
         </section>
       </section>
 
-      <section title="Error Handling">
+      <section anchor="ErrorHandler" title="Error Handling">
         <t>
           HTTP/2 framing permits two classes of error:
           <list style="symbols">
@@ -3665,7 +3665,7 @@ HTTP2-Settings    = token68
             underlying cipher suite can encipher.
           </t>
           <t>
-            A client MAY use renegotiation to provide confidentiality protection for client
+            An endpoint MAY use renegotiation to provide confidentiality protection for client
             credentials offered in the handshake, but any renegotiation MUST occur prior to sending
             the connection preface.  A server SHOULD request a client certificate if it sees a
             renegotiation request immediately after establishing a connection.
@@ -3673,8 +3673,8 @@ HTTP2-Settings    = token68
           <t>
             This effectively prevents the use of renegotiation in response to a request for a
             specific protected resource.  A future specification might provide a way to support this
-            use case. Alternatively, a server might use a <xref target="ConnectionErrorHandler">
-            connection error</xref> of type <x:ref>HTTP_1_1_REQUIRED</x:ref> to request the client
+            use case. Alternatively, a server might use an <xref target="ErrorHandler">
+            error</xref> of type <x:ref>HTTP_1_1_REQUIRED</x:ref> to request the client
             use a protocol which supports renegotiation.
           </t>
         </section>


### PR DESCRIPTION
Two changes here, one editorial and one probably-editorial:
- The endpoint might send a connection _or_ a stream error of HTTP_1_1_REQUIRED, depending on the scope of the requirement.  Note that this was non-normative language, so removing the implication that it would always be a connection error simply makes clearer what was already permitted.
- The server might know as soon as the connection is established that it will want the cert, but want it protected by the handshake.  Either endpoint, not just the client, may choose to renegotiate before sending their preface.
