### PR TITLE
typo: HTTP -> HTTP/2

### DIFF
--- a/draft-ietf-httpbis-http2.xml
+++ b/draft-ietf-httpbis-http2.xml
@@ -3696,7 +3696,7 @@ HTTP2-Settings    = token68
             target="TLS12">ephemeral Diffie-Hellman (DHE)</xref> or the <xref
             target="RFC4492">elliptic curve variant (ECDHE)</xref>.  Ephemeral key exchange MUST
             have a minimum size of 2048 bits for DHE or security level of 128 bits for ECDHE.
-            Clients MUST accept DHE sizes of up to 4096 bits.  HTTP MUST NOT be used with cipher
+            Clients MUST accept DHE sizes of up to 4096 bits.  HTTP/2 MUST NOT be used with cipher
             suites that use stream or block ciphers.  Authenticated Encryption with Additional Data
             (AEAD) modes, such as the <xref target="RFC5288">Galois Counter Model (GCM) mode for
             AES</xref> are acceptable.


### PR DESCRIPTION
I think this is a typo.
