### PR TITLE
PROTOCOL_ERROR for SETTINGS_MAX_CONCURRENT_STREAMS violations

### DIFF
--- a/draft-ietf-httpbis-http2.xml
+++ b/draft-ietf-httpbis-http2.xml
@@ -1120,8 +1120,8 @@ HTTP2-Settings    = token68
           <t>
             Endpoints MUST NOT exceed the limit set by their peer.  An endpoint that receives a
             <x:ref>HEADERS</x:ref> frame that causes their advertised concurrent stream limit to be
-            exceeded MUST treat this as a <xref target="StreamErrorHandler">stream error</xref>.  An
-            endpoint that wishes to reduce the value of
+            exceeded MUST treat this as a <xref target="StreamErrorHandler">stream error</xref> of
+            type <x:ref>PROTOCOL_ERROR</x:ref>.  An endpoint that wishes to reduce the value of
             <x:ref>SETTINGS_MAX_CONCURRENT_STREAMS</x:ref> to a value that is below the current
             number of open streams can either close streams that exceed the new value or allow
             streams to complete.


### PR DESCRIPTION
This one suggests PROTOCOL_ERROR.

Closes #649.
