### PR TITLE
Options for SETTINGS_MAX_CONCURRENT_STREAMS violations

### DIFF
--- a/draft-ietf-httpbis-http2.xml
+++ b/draft-ietf-httpbis-http2.xml
@@ -1121,10 +1121,10 @@ HTTP2-Settings    = token68
             Endpoints MUST NOT exceed the limit set by their peer.  An endpoint that receives a
             <x:ref>HEADERS</x:ref> frame that causes their advertised concurrent stream limit to be
             exceeded MUST treat this as a <xref target="StreamErrorHandler">stream error</xref> of
-            type <x:ref>PROTOCOL_ERROR</x:ref>.  An endpoint that wishes to reduce the value of
-            <x:ref>SETTINGS_MAX_CONCURRENT_STREAMS</x:ref> to a value that is below the current
-            number of open streams can either close streams that exceed the new value or allow
-            streams to complete.
+            type <x:ref>PROTOCOL_ERROR</x:ref> or <x:ref>REFUSED_STREAM</x:ref>.  An endpoint that
+            wishes to reduce the value of <x:ref>SETTINGS_MAX_CONCURRENT_STREAMS</x:ref> to a value
+            that is below the current number of open streams can either close streams that exceed
+            the new value or allow streams to complete.
           </t>
         </section>
       </section>


### PR DESCRIPTION
Rather than just PROTOCOL_ERROR, allow REFUSED_STREAM.

REFUSED_STREAM is a more lenient error.  It allows clients to retry requests.  Servers might also set the GOAWAY stream number to a lower value if they upgraded.

Closes #649.
