### PR TITLE
make sentence coherent

### DIFF
--- a/draft-ietf-httpbis-http2.xml
+++ b/draft-ietf-httpbis-http2.xml
@@ -3722,9 +3722,9 @@ HTTP2-Settings    = token68
           <t>
             Endpoints MAY choose to generate a <xref target="ConnectionErrorHandler">connection
             error</xref> of type <x:ref>INADEQUATE_SECURITY</x:ref> if one of the prohibited cipher
-            suites are negotiated.  Thus, if a deployment chooses to use a prohibited cipher suite,
-            that risks of triggering a connection error, unless the set of potential peers is known
-            to accept that cipher suite.
+            suites are negotiated.  A deployment that chooses to use a prohibited cipher suite
+            risks triggering a connection error unless the set of potential peers is known to
+            accept that cipher suite.
           </t>
           <t>
             Implementations MUST NOT generate this error in reaction to the negotiation of a cipher


### PR DESCRIPTION
Fix severe grammatical issues describing risk of using prohibited cipher suites.
