### PR TITLE
Update PUSH_PROMISE text in Section 5.1 and improve Figure 2. ASCII art diagram

### DIFF
--- a/draft-ietf-httpbis-http2.xml
+++ b/draft-ietf-httpbis-http2.xml
@@ -4328,7 +4328,7 @@ HTTP2-Settings    = token68
             (Substantial editorial contributions).
           </t>
           <t>
-            Kari Hurtta, Tatsuhiro Tsujikawa, Greg Wilkins, Poul-Henning Kamp.
+            Kari Hurtta, Tatsuhiro Tsujikawa, Greg Wilkins, Poul-Henning Kamp, Jonathan Thackray.
           </t>
           <t>
             Alexey Melnikov was an editor of this document during 2013.


### PR DESCRIPTION
Hi Martin,

I believe the current text is wrong/confusing for PUSH_PROMISE in the "Section 5.1 Stream states" section, as associated streams aren't marked in any way, and are already in use, rather than "reserve for later use". This caused me confusion when I was implementing as to which stream was "associated" (the new promised stream or the existing stream). I hope my pull request clarifies this text.

I've also improved the ASCII art diagram for Figure 2, albeit at the cost of an extra 4 characters width, which shows whether a frame is being sent, received or both for each transition.

Many thanks,
Jonathan.
