### PR TITLE
Fix typo (s/sever/server/)

### DIFF
--- a/draft-ietf-httpbis-http2.xml
+++ b/draft-ietf-httpbis-http2.xml
@@ -493,7 +493,7 @@ HTTP2-Settings    = token68
           HTTP/2 over TLS MUST use <xref target="TLS-ALPN">protocol negotiation in TLS</xref>.
         </t>
         <t>
-          Likewise, the sever MUST send a <xref target="ConnectionHeader">connection preface</xref>.
+          Likewise, the server MUST send a <xref target="ConnectionHeader">connection preface</xref>.
         </t>
         <t>
           Without additional information, prior support for HTTP/2 is not a strong signal that a


### PR DESCRIPTION
Hi Martin,

Fixed a small typo in -16.

Cheers,
Jonathan.
