### PR TITLE
Remove priority

### DIFF
--- a/draft-ietf-httpbis-http2bis.xml
+++ b/draft-ietf-httpbis-http2bis.xml
@@ -1200,7 +1200,7 @@
         <t>
           In a multiplexed protocol like HTTP/2, prioritizing allocation of bandwidth and
           computation resources to streams can be critical to attaining good performance.  A poor
-          prioritization scheme can result in HTTP/2 providing poor performance.  With no parallism
+          prioritization scheme can result in HTTP/2 providing poor performance.  With no parallelism
           at the TCP layer, performance could be significantly worse than HTTP/1.1.
         </t>
         <t>

--- a/draft-ietf-httpbis-http2bis.xml
+++ b/draft-ietf-httpbis-http2bis.xml
@@ -888,9 +888,10 @@
                   </li>
             </ul>
             <t>
-                An endpoint MAY send a <xref target="PRIORITY" format="none">PRIORITY</xref> frame in this state.  An endpoint MUST NOT send any type of frame other than
-                <xref target="RST_STREAM" format="none">RST_STREAM</xref>, <xref target="WINDOW_UPDATE" format="none">WINDOW_UPDATE</xref>, or <xref target="PRIORITY" format="none">PRIORITY</xref>
-                in this state.
+                An endpoint MUST NOT send any type of frame other than <xref target="RST_STREAM"
+                format="none">RST_STREAM</xref>, <xref target="WINDOW_UPDATE"
+                format="none">WINDOW_UPDATE</xref>, or <xref target="PRIORITY"
+                format="none">PRIORITY</xref> in this state.
             </t>
             <t>
                 Receiving any type of frame other than <xref target="HEADERS" format="none">HEADERS</xref>,

--- a/draft-ietf-httpbis-http2bis.xml
+++ b/draft-ietf-httpbis-http2bis.xml
@@ -1629,7 +1629,7 @@
         <t>
           The HEADERS frame can include padding.  Padding fields and flags are identical to those
           defined for <xref target="DATA">DATA frames</xref>.  Padding that exceeds the size
-          remaining for the header block fragment MUST be treated as a
+          remaining for the field block fragment MUST be treated as a
           <xref target="PROTOCOL_ERROR" format="none">PROTOCOL_ERROR</xref>.
         </t>
       </section>
@@ -1679,7 +1679,7 @@
           Sending or receiving a PRIORITY frame does not affect the state of any stream (<xref
           target="StreamStates"/>).  The PRIORITY frame can be sent on a stream in any state,
           including "idle" or "closed".  A PRIORITY frame cannot be sent between consecutive frames
-          that comprise a single <xref target="HeaderBlock">header block</xref>.
+          that comprise a single <xref target="FieldBlock">field block</xref>.
         </t>
         <t>
           A PRIORITY frame with a length other than 5 octets MUST be treated as a <xref
@@ -3149,7 +3149,7 @@
             image links ensures that the client is able to see that a resource will be pushed
             before discovering embedded links. Similarly, if the server pushes responses referenced by the field block
             (for instance, in Link header fields), sending a <xref target="PUSH_PROMISE" format="none">PUSH_PROMISE</xref> before sending the
-            header block ensures that clients do not request those resources.
+            header ensures that clients do not request those resources.
           </t>
           <t><xref target="PUSH_PROMISE" format="none">PUSH_PROMISE</xref> frames MUST NOT be sent by the client.
           </t>

--- a/draft-ietf-httpbis-http2bis.xml
+++ b/draft-ietf-httpbis-http2bis.xml
@@ -1636,8 +1636,8 @@
       <section anchor="PRIORITY">
         <name>PRIORITY</name>
         <t>
-          The PRIORITY frame (type=0x2) is deprecated; see <xref target="PriorityHere"/> A PRIORITY
-          frame can be sent in any stream state, including idle or closed streams.
+          The PRIORITY frame (type=0x2) is deprecated; see <xref target="PriorityHere"/>.  A
+          PRIORITY frame can be sent in any stream state, including idle or closed streams.
         </t>
         <figure anchor="PRIORITYFramePayload">
           <name>PRIORITY Frame Payload</name>

--- a/draft-ietf-httpbis-http2bis.xml
+++ b/draft-ietf-httpbis-http2bis.xml
@@ -1249,7 +1249,7 @@
           <t>
             Though the priority signaling from RFC 7540 was not widely adopted, the information it
             provides can still be useful in the absence of better information.  Endpoints that
-            receive priority signals <xref target="HEADERS" format="none">HEADERS</xref> or <xref
+            receive priority signals in <xref target="HEADERS" format="none">HEADERS</xref> or <xref
             target="PRIORITY" format="none">PRIORITY</xref> frames can benefit from applying that
             information.  In particular, implementations that consume these signals would not
             benefit from discarding these priority signals in the absence of alternatives.

--- a/draft-ietf-httpbis-http2bis.xml
+++ b/draft-ietf-httpbis-http2bis.xml
@@ -367,10 +367,10 @@
         </t>
         <t>
           The HTTP/1.1 request that is sent prior to upgrade is assigned a stream identifier of 1
-          (see <xref target="StreamIdentifiers"/>) with <xref target="pri-default">default priority
-          values</xref>.  Stream 1 is implicitly "half-closed" from the client toward the server
-          (see <xref target="StreamStates"/>), since the request is completed as an HTTP/1.1
-          request.  After commencing the HTTP/2 connection, stream 1 is used for the response.
+          (see <xref target="StreamIdentifiers"/>).  Stream 1 is implicitly "half-closed" from the
+          client toward the server (see <xref target="StreamStates"/>), since the request is
+          completed as an HTTP/1.1 request.  After commencing the HTTP/2 connection, stream 1 is
+          used for the response.
         </t>
         <section anchor="Http2SettingsHeader">
           <name>HTTP2-Settings Header Field</name>
@@ -888,8 +888,7 @@
                   </li>
             </ul>
             <t>
-                An endpoint MAY send a <xref target="PRIORITY" format="none">PRIORITY</xref> frame in this state to reprioritize
-                the reserved stream.  An endpoint MUST NOT send any type of frame other than
+                An endpoint MAY send a <xref target="PRIORITY" format="none">PRIORITY</xref> frame in this state.  An endpoint MUST NOT send any type of frame other than
                 <xref target="RST_STREAM" format="none">RST_STREAM</xref>, <xref target="WINDOW_UPDATE" format="none">WINDOW_UPDATE</xref>, or <xref target="PRIORITY" format="none">PRIORITY</xref>
                 in this state.
             </t>
@@ -940,8 +939,7 @@
                 which might arrive for a short period after a frame bearing the
                 END_STREAM flag is sent.
             </t>
-            <t><xref target="PRIORITY" format="none">PRIORITY</xref> frames received in this state are used to reprioritize
-                streams that depend on the identified stream.
+            <t><xref target="PRIORITY" format="none">PRIORITY</xref> frames can be received in this state.
             </t>
           </dd>
           <dt>half-closed (remote):</dt>
@@ -991,10 +989,7 @@
                 after sending END_STREAM as a <xref target="ConnectionErrorHandler">connection
                 error</xref> of type <xref target="PROTOCOL_ERROR" format="none">PROTOCOL_ERROR</xref>.
             </t>
-            <t><xref target="PRIORITY" format="none">PRIORITY</xref> frames can be sent on closed streams to prioritize streams
-                that are dependent on the closed stream.  Endpoints SHOULD process
-                <xref target="PRIORITY" format="none">PRIORITY</xref> frames, though they can be ignored if the stream has been
-                removed from the dependency tree (see <xref target="priority-gc"/>).
+            <t><xref target="PRIORITY" format="none">PRIORITY</xref> frames can be sent on closed streams.
             </t>
             <t>
                 If this state is reached as a result of sending a <xref target="RST_STREAM" format="none">RST_STREAM</xref> frame,
@@ -1162,10 +1157,10 @@
               </li>
           </ol>
           <t>
-            Implementations are also responsible for managing how requests and responses are sent
-            based on priority, choosing how to avoid head-of-line blocking for requests, and
-            managing the creation of new streams.  Algorithm choices for these could interact with
-            any flow-control algorithm.
+            Implementations are also responsible for prioritizing the sending of requests and
+            responses, choosing how to avoid head-of-line blocking for requests, and managing the
+            creation of new streams.  Algorithm choices for these could interact with any
+            flow-control algorithm.
           </t>
         </section>
         <section anchor="DisableFlowControl">
@@ -1198,231 +1193,77 @@
           </t>
         </section>
       </section>
+
       <section anchor="StreamPriority">
-        <name>Stream Priority</name>
+        <name>Prioritization</name>
         <t>
-          A client can assign a priority for a new stream by including prioritization information in
-          the <xref target="HEADERS">HEADERS frame</xref> that opens the stream.  At any other time,
-          the <xref target="PRIORITY">PRIORITY frame</xref> can be used to change the priority of a
-          stream.
+          In a multiplexed protocol like HTTP/2, prioritizing allocation of resources to streams can
+          be critical to attaining good performance.  A poor prioritization scheme can result in
+          HTTP/2 providing poor performance.  With no parallism at the TCP layer, this could be
+          significantly worse than HTTP/1.1.
         </t>
         <t>
-          The purpose of prioritization is to allow an endpoint to express how it would prefer its
-          peer to allocate resources when managing concurrent streams.  Most importantly, priority can
-          be used to select streams for transmitting frames when there is limited capacity for
-          sending.
+          A good prioritization scheme benefits from the application of contextual knowledge such as
+          the content of resources, how resources are interrelated, and how those resources will be
+          used by a peer.  In particular, clients can possess knowledge about the priority of
+          requests that is relevant to server prioritization.  In those cases, having clients
+          provide priority information can improve performance.
         </t>
-        <t>
-          Streams can be prioritized by marking them as dependent on the completion of other streams
-          (<xref target="pri-depend"/>).  Each dependency is assigned a relative weight, a number
-          that is used to determine the relative proportion of available resources that are assigned
-          to streams dependent on the same stream.
-        </t>
-        <!--
-          Note that stream dependencies have not yet been validated in practice.  The theory
-          might be fairly sound, but there are no implementations currently sending these.  If it
-          turns out that they are not useful, or actively harmful, implementations will be requested
-          to avoid creating stream dependencies.
-        -->
-        <t>
-          Explicitly setting the priority for a stream is input to a prioritization process.  It
-          does not guarantee any particular processing or transmission order for the stream relative
-          to any other stream.  An endpoint cannot force a peer to process concurrent streams in a
-          particular order using priority.  Expressing priority is therefore only a suggestion.
-        </t>
-        <t>
-          Prioritization information can be omitted from messages.  Defaults are used prior to any
-          explicit values being provided (<xref target="pri-default"/>).
-        </t>
-        <t>
-          The information that an endpoint maintains for stream priority is separate from other
-          state. Importantly, this includes <xref target="StreamStates">stream states</xref>. A
-          stream in any state can have its priority changed with a PRIORITY frame. The state of a
-          stream is not changed as a result of changing its priority. The number of streams for
-          which state is remembered is at the discretion of an endpoint, see
-          <xref target="priority-gc"/> for details.
-        </t>
-        <section anchor="pri-depend">
-          <name>Stream Dependencies</name>
+        <section anchor="PriorityHistory">
+          <name>Background of Priority in HTTP/2</name>
           <t>
-            Each stream can be given an explicit dependency on another stream.  Including a
-            dependency expresses a preference to allocate resources to the identified stream rather
-            than to the dependent stream.
+            HTTP/2 included a rich system for signaling priority of requests.  However, this system
+            proved to be complex and it was not widely implemented.
           </t>
           <t>
-            A stream that is not dependent on any other stream is given a stream dependency of 0x0.
-            In other words, the non-existent stream 0 forms the root of the tree.
+            The flexible scheme meant that it was possible for clients to express priorities in very
+            different ways, with little consistency in the approaches that were adopted.  For
+            servers, implementing generic support for the scheme was complex.  Implementation of
+            priorities was uneven in both clients and servers.  Many server deployments ignored
+            client signals when prioritizing their handling of requests.
           </t>
           <t>
-            A stream that depends on another stream is a dependent stream. The stream upon which a
-            stream is dependent is a parent stream. A dependency on a stream that is not currently
-            in the tree -- such as a stream in the "idle" state -- results in that stream being given
-            a <xref target="pri-default">default priority</xref>.
-          </t>
-          <t>
-            When assigning a dependency on another stream, the stream is added as a new dependency
-            of the parent stream.  Dependent streams that share the same parent are not ordered with
-            respect to each other.  For example, if streams B and C are dependent on stream A, and
-            if stream D is created with a dependency on stream A, this results in a dependency order
-            of A followed by B, C, and D in any order.
-          </t>
-          <figure anchor="ExampleofDefaultDependencyCreation">
-            <name>Example of Default Dependency Creation</name>
-            <artwork type="inline"><![CDATA[
-    A                 A
-   / \      ==>      /|\
-  B   C             B D C
-]]></artwork>
-          </figure>
-          <t>
-            An exclusive flag allows for the insertion of a new level of dependencies.  The
-            exclusive flag causes the stream to become the sole dependency of its parent stream,
-            causing other dependencies to become dependent on the exclusive stream.  In the
-            previous example, if stream D is created with an exclusive dependency on stream A, this
-            results in D becoming the dependency parent of B and C.
-          </t>
-          <figure anchor="ExampleofExclusiveDependencyCreation">
-            <name>Example of Exclusive Dependency Creation</name>
-            <artwork type="inline"><![CDATA[
-                      A
-    A                 |
-   / \      ==>       D
-  B   C              / \
-                    B   C
-]]></artwork>
-          </figure>
-          <t>
-            Inside the dependency tree, a dependent stream SHOULD only be allocated resources if
-            either all of the streams that it depends on (the chain of parent streams up to 0x0)
-            are closed or it is not possible to make progress on them.
-          </t>
-          <t>
-            A stream cannot depend on itself.  An endpoint MUST treat this as a <xref target="StreamErrorHandler">stream error</xref> of type <xref target="PROTOCOL_ERROR" format="none">PROTOCOL_ERROR</xref>.
+            In short, the prioritization signaling in <xref target="RFC7540">RFC7540</xref> was not
+            successful.
           </t>
         </section>
-        <section>
-          <name>Dependency Weighting</name>
+        <section anchor="PriorityHere">
+          <name>Priority Signaling in this Document</name>
           <t>
-            All dependent streams are allocated an integer weight between 1 and 256 (inclusive).
+            This update to HTTP/2 deprecates the priority signaling defined in <xref
+            target="RFC7540">RFC 7540</xref>.  The bulk of the text related to priority signals is
+            not included in this document.  The description of frame fields and some of the
+            mandatory handling is retained to ensure that implementations of this document remain
+            interoperable with implementations that use the priority signaling described in RFC
+            7540.
           </t>
           <t>
-            Streams with the same parent SHOULD be allocated resources proportionally based on their
-            weight.  Thus, if stream B depends on stream A with weight 4, stream C depends on stream A
-            with weight 12, and no progress can be made on stream A, stream B ideally receives one-third
-            of the resources allocated to stream C.
-          </t>
-        </section>
-        <section anchor="reprioritize">
-          <name>Reprioritization</name>
-          <t>
-            Stream priorities are changed using the <xref target="PRIORITY" format="none">PRIORITY</xref> frame.  Setting a
-            dependency causes a stream to become dependent on the identified parent stream.
+            A thorough description of the RFC 7540 priority scheme remains in <xref target="RFC7540"
+            section="5.3"/>.
           </t>
           <t>
-            Dependent streams move with their parent stream if the parent is reprioritized.  Setting
-            a dependency with the exclusive flag for a reprioritized stream causes all the
-            dependencies of the new parent stream to become dependent on the reprioritized stream.
+            Signaling priority information could still be necessary to attain good performance.
+            Where signaling priority information is important, endpoints are encouraged to use an
+            alternative scheme, such as <xref target="I-D.ietf-httpbis-priority"/>.
           </t>
           <t>
-            If a stream is made dependent on one of its own dependencies, the formerly dependent
-            stream is first moved to be dependent on the reprioritized stream's previous parent.
-            The moved dependency retains its weight.
-          </t>
-          <t keepWithNext="true">
-              For example, consider an original dependency tree where B and C depend on A, D and E
-              depend on C, and F depends on D.  If A is made dependent on D, then D takes the place
-              of A.  All other dependency relationships stay the same, except for F, which becomes
-              dependent on A if the reprioritization is exclusive.
-          </t>
-          <figure anchor="ExampleofDependencyReordering">
-            <name>Example of Dependency Reordering</name>
-            <artwork type="inline"><![CDATA[
-    x                x                x                 x
-    |               / \               |                 |
-    A              D   A              D                 D
-   / \            /   / \            / \                |
-  B   C     ==>  F   B   C   ==>    F   A       OR      A
-     / \                 |             / \             /|\
-    D   E                E            B   C           B C F
-    |                                     |             |
-    F                                     E             E
-               (intermediate)   (non-exclusive)    (exclusive)
-]]></artwork>
-          </figure>
-        </section>
-        <section anchor="priority-gc">
-          <name>Prioritization State Management</name>
-          <t>
-            When a stream is removed from the dependency tree, its dependencies can be moved to
-            become dependent on the parent of the closed stream.  The weights of new dependencies
-            are recalculated by distributing the weight of the dependency of the closed stream
-            proportionally based on the weights of its dependencies.
+            Though the priority signaling from RFC 7540 was not widely adopted, the information it
+            provides can still be useful in the absence of better information.  Endpoints that
+            receive <xref target="HEADERS" format="none">HEADERS</xref> or <xref target="PRIORITY"
+            format="none">PRIORITY</xref> frames can benefit from applying any priority that is
+            present.  In particular, implementations that consume these signals would not benefit
+            from discarding these priority signals in the absence of alternatives.
           </t>
           <t>
-            Streams that are removed from the dependency tree cause some prioritization information
-            to be lost.  Resources are shared between streams with the same parent stream, which
-            means that if a stream in that set closes or becomes blocked, any spare capacity
-            allocated to a stream is distributed to the immediate neighbors of the stream.  However,
-            if the common dependency is removed from the tree, those streams share resources with
-            streams at the next highest level.
-          </t>
-          <t>
-            For example, assume streams A and B share a parent, and streams C and D both depend on
-            stream A. Prior to the removal of stream A, if streams A and D are unable to proceed,
-            then stream C receives all the resources dedicated to stream A.  If stream A is removed
-            from the tree, the weight of stream A is divided between streams C and D.  If stream D
-            is still unable to proceed, this results in stream C receiving a reduced proportion of
-            resources.  For equal starting weights, C receives one third, rather than one half, of
-            available resources.
-          </t>
-          <t>
-            It is possible for a stream to become closed while prioritization information that
-            creates a dependency on that stream is in transit.  If a stream identified in a
-            dependency has no associated priority information, then the dependent stream is instead
-            assigned a <xref target="pri-default">default priority</xref>.  This potentially creates
-            suboptimal prioritization, since the stream could be given a priority that is different
-            from what is intended.
-          </t>
-          <t>
-            To avoid these problems, an endpoint SHOULD retain stream prioritization state for a
-            period after streams become closed.  The longer state is retained, the lower the chance
-            that streams are assigned incorrect or default priority values.
-          </t>
-          <t>
-            Similarly, streams that are in the "idle" state can be assigned priority or become a
-            parent of other streams.  This allows for the creation of a grouping node in the
-            dependency tree, which enables more flexible expressions of priority.  Idle streams
-            begin with a <xref target="pri-default">default priority</xref>.
-          </t>
-          <t>
-            The retention of priority information for streams that are not counted toward the limit
-            set by <xref target="SETTINGS_MAX_CONCURRENT_STREAMS" format="none">SETTINGS_MAX_CONCURRENT_STREAMS</xref> could create a large state burden
-            for an endpoint.  Therefore, the amount of prioritization state that is retained MAY be
-            limited.
-          </t>
-          <t>
-            The amount of additional state an endpoint maintains for prioritization could be
-            dependent on load; under high load, prioritization state can be discarded to limit
-            resource commitments.  In extreme cases, an endpoint could even discard prioritization
-            state for active or reserved streams. If a limit is applied, endpoints SHOULD maintain
-            state for at least as many streams as allowed by their setting for
-            <xref target="SETTINGS_MAX_CONCURRENT_STREAMS" format="none">SETTINGS_MAX_CONCURRENT_STREAMS</xref>.  Implementations SHOULD also attempt to
-            retain state for streams that are in active use in the priority tree.
-          </t>
-          <t>
-            If it has retained enough state to do so, an endpoint receiving a
-            <xref target="PRIORITY" format="none">PRIORITY</xref> frame that changes the priority of a
-            closed stream SHOULD alter the dependencies of the streams that depend on it.
-          </t>
-        </section>
-        <section anchor="pri-default">
-          <name>Default Priorities</name>
-          <t>
-            All streams are initially assigned a non-exclusive dependency on stream 0x0.  <xref target="PushResources">Pushed streams</xref> initially depend on their associated
-            stream.  In both cases, streams are assigned a default weight of 16.
+            Servers SHOULD use other contextual information in determining priority of requests in
+            the absence of any priority signals.  In particular, servers might need to decide
+            whether to interpret the complete absence of signals as an indication that the client
+            has not implemented the feature or that the client that has deliberately chosen to rely
+            on the defaults described in <xref target="RFC7540" section="5.3.5"/>.
           </t>
         </section>
       </section>
+
       <section anchor="ErrorHandler">
         <name>Error Handling</name>
         <t>
@@ -1703,22 +1544,21 @@
         <dl newline="false" spacing="normal">
           <dt>Pad Length:</dt>
           <dd>
-              An 8-bit field containing the length of the frame padding in units of octets.  This
-              field is only present if the PADDED flag is set.
-            </dd>
+            An 8-bit field containing the length of the frame padding in units of octets.  This
+            field is only present if the PADDED flag is set.
+          </dd>
           <dt>E:</dt>
           <dd>
-              A single-bit flag indicating that the stream dependency is exclusive (see <xref target="StreamPriority"/>).  This field is only present if the PRIORITY flag is set.
-            </dd>
+            A single-bit flag.  This field is only present if the PRIORITY flag is set.
+          </dd>
           <dt>Stream Dependency:</dt>
           <dd>
-              A 31-bit stream identifier for the stream that this stream depends on (see <xref target="StreamPriority"/>).  This field is only present if the PRIORITY flag is set.
-            </dd>
+            A 31-bit stream identifier.  This field is only present if the PRIORITY flag is set.
+          </dd>
           <dt>Weight:</dt>
           <dd>
-              An unsigned 8-bit integer representing a priority weight for the stream (see <xref target="StreamPriority"/>).  Add one to the value to obtain a weight between 1 and 256.
-              This field is only present if the PRIORITY flag is set.
-            </dd>
+            An unsigned 8-bit integer.  This field is only present if the PRIORITY flag is set.
+          </dd>
           <dt>Field Block Fragment:</dt>
           <dd>
               A <xref target="FieldBlock">field block fragment</xref>.
@@ -1768,8 +1608,8 @@
           <dt>PRIORITY (0x20):</dt>
           <dd>
             <t>
-                When set, bit 5 indicates that the Exclusive Flag (E), Stream Dependency, and Weight
-                fields are present; see <xref target="StreamPriority"/>.
+              When set, bit 5 indicates that the Exclusive Flag (E), Stream Dependency, and Weight
+              fields are present.
             </t>
           </dd>
         </dl>
@@ -1792,20 +1632,12 @@
           remaining for the header block fragment MUST be treated as a
           <xref target="PROTOCOL_ERROR" format="none">PROTOCOL_ERROR</xref>.
         </t>
-        <t>
-          Prioritization information in a HEADERS frame is logically equivalent to a separate
-          <xref target="PRIORITY" format="none">PRIORITY</xref> frame, but inclusion in HEADERS avoids the potential for churn in
-          stream prioritization when new streams are created.  Prioritization fields in HEADERS
-          frames subsequent to the first on a stream <xref target="reprioritize">reprioritize the
-          stream</xref>.
-        </t>
       </section>
       <section anchor="PRIORITY">
         <name>PRIORITY</name>
         <t>
-          The PRIORITY frame (type=0x2) specifies the <xref target="StreamPriority">sender-advised
-          priority of a stream</xref>.  It can be sent in any stream state, including idle or closed
-          streams.
+          The PRIORITY frame (type=0x2) is deprecated; see <xref target="PriorityHere"/> A PRIORITY
+          frame can be sent in any stream state, including idle or closed streams.
         </t>
         <figure anchor="PRIORITYFramePayload">
           <name>PRIORITY Frame Payload</name>
@@ -1823,44 +1655,36 @@
         <dl newline="false" spacing="normal">
           <dt>E:</dt>
           <dd>
-              A single-bit flag indicating that the stream dependency is exclusive (see <xref target="StreamPriority"/>).
-            </dd>
+            A single-bit flag.
+          </dd>
           <dt>Stream Dependency:</dt>
           <dd>
-              A 31-bit stream identifier for the stream that this stream depends on (see <xref target="StreamPriority"/>).
-            </dd>
+            A 31-bit stream identifier.
+          </dd>
           <dt>Weight:</dt>
           <dd>
-              An unsigned 8-bit integer representing a priority weight for the stream (see <xref target="StreamPriority"/>).  Add one to the value to obtain a weight between 1 and 256.
-            </dd>
+            An unsigned 8-bit integer.
+          </dd>
         </dl>
         <t>
           The PRIORITY frame does not define any flags.
         </t>
         <t>
-          The PRIORITY frame always identifies a stream. If a PRIORITY frame is received with a
-          stream identifier of 0x0, the recipient MUST respond with a <xref target="ConnectionErrorHandler">connection error</xref> of type
-          <xref target="PROTOCOL_ERROR" format="none">PROTOCOL_ERROR</xref>.
+          The PRIORITY frame always identifies a stream.  If a PRIORITY frame is received with a
+          stream identifier of 0x0, the recipient MUST respond with a <xref
+          target="ConnectionErrorHandler">connection error</xref> of type <xref
+          target="PROTOCOL_ERROR" format="none">PROTOCOL_ERROR</xref>.
         </t>
         <t>
-          Sending or receiving a PRIORITY frame does not affect the state of any stream
-          (<xref target="StreamStates"/>), only the priority of streams is altered.
+          Sending or receiving a PRIORITY frame does not affect the state of any stream (<xref
+          target="StreamStates"/>).  The PRIORITY frame can be sent on a stream in any state,
+          including "idle" or "closed".  A PRIORITY frame cannot be sent between consecutive frames
+          that comprise a single <xref target="HeaderBlock">header block</xref>.
         </t>
         <t>
-          The PRIORITY frame can be sent on a stream in any state, though it cannot be sent between
-          consecutive frames that comprise a single <xref target="FieldBlock">field block</xref>.
-          Note that this frame could arrive after processing or frame sending has completed, which
-          would cause it to have no effect on the identified stream.  For a stream that is in the
-          "half-closed (remote)" or "closed" state, this frame can only affect processing of the
-          identified stream and its dependent streams; it does not affect frame transmission on that stream.
-        </t>
-        <t>
-           The PRIORITY frame can be sent for a stream in the "idle" or "closed" state.  This
-           allows for the reprioritization of a group of dependent streams by altering the priority
-           of an unused or closed parent stream.
-        </t>
-        <t>
-          A PRIORITY frame with a length other than 5 octets MUST be treated as a <xref target="StreamErrorHandler">stream error</xref> of type <xref target="FRAME_SIZE_ERROR" format="none">FRAME_SIZE_ERROR</xref>.
+          A PRIORITY frame with a length other than 5 octets MUST be treated as a <xref
+          target="StreamErrorHandler">stream error</xref> of type <xref target="FRAME_SIZE_ERROR"
+          format="none">FRAME_SIZE_ERROR</xref>.
         </t>
       </section>
       <section anchor="RST_STREAM">
@@ -4693,8 +4517,20 @@
           </front>
         </reference>
       </references>
+
       <references>
         <name>Informative References</name>
+        <reference anchor="RFC7540">
+          <front>
+            <title>Hypertext Transfer Protocol Version 2 (HTTP/2)</title>
+            <seriesInfo name="RFC" value="7540"/>
+            <seriesInfo name="DOI" value="10.17487/RFC7540"/>
+            <author initials="M." surname="Belshe" fullname="M. Belshe"/>
+            <author initials="R." surname="Peon" fullname="R. Peon"/>
+            <author initials="M." surname="Thomson" fullname="M. Thomson" role="editor"/>
+            <date year="2015" month="May" />
+          </front>
+        </reference>
         <reference anchor="RFC7323">
           <front>
             <title>
@@ -4854,6 +4690,7 @@
             <date year="2019" month="August" day="13"/>
           </front>
         </reference>
+        <xi:include href="https://xml2rfc.tools.ietf.org/public/rfc/bibxml3/reference.I-D.ietf-httpbis-priority.xml"/>
       </references>
     </references>
     <section anchor="BadCipherSuites">

--- a/draft-ietf-httpbis-http2bis.xml
+++ b/draft-ietf-httpbis-http2bis.xml
@@ -1197,10 +1197,10 @@
       <section anchor="StreamPriority">
         <name>Prioritization</name>
         <t>
-          In a multiplexed protocol like HTTP/2, prioritizing allocation of resources to streams can
-          be critical to attaining good performance.  A poor prioritization scheme can result in
-          HTTP/2 providing poor performance.  With no parallism at the TCP layer, this could be
-          significantly worse than HTTP/1.1.
+          In a multiplexed protocol like HTTP/2, prioritizing allocation of bandwidth and
+          computation resources to streams can be critical to attaining good performance.  A poor
+          prioritization scheme can result in HTTP/2 providing poor performance.  With no parallism
+          at the TCP layer, performance could be significantly worse than HTTP/1.1.
         </t>
         <t>
           A good prioritization scheme benefits from the application of contextual knowledge such as
@@ -1213,7 +1213,7 @@
           <name>Background of Priority in HTTP/2</name>
           <t>
             HTTP/2 included a rich system for signaling priority of requests.  However, this system
-            proved to be complex and it was not widely implemented.
+            proved to be complex and it was not uniformly implemented.
           </t>
           <t>
             The flexible scheme meant that it was possible for clients to express priorities in very
@@ -1242,24 +1242,24 @@
             section="5.3"/>.
           </t>
           <t>
-            Signaling priority information could still be necessary to attain good performance.
+            Signaling priority information is necessary to attain good performance in many cases.
             Where signaling priority information is important, endpoints are encouraged to use an
             alternative scheme, such as <xref target="I-D.ietf-httpbis-priority"/>.
           </t>
           <t>
             Though the priority signaling from RFC 7540 was not widely adopted, the information it
             provides can still be useful in the absence of better information.  Endpoints that
-            receive <xref target="HEADERS" format="none">HEADERS</xref> or <xref target="PRIORITY"
-            format="none">PRIORITY</xref> frames can benefit from applying any priority that is
-            present.  In particular, implementations that consume these signals would not benefit
-            from discarding these priority signals in the absence of alternatives.
+            receive priority signals <xref target="HEADERS" format="none">HEADERS</xref> or <xref
+            target="PRIORITY" format="none">PRIORITY</xref> frames can benefit from applying that
+            information.  In particular, implementations that consume these signals would not
+            benefit from discarding these priority signals in the absence of alternatives.
           </t>
           <t>
             Servers SHOULD use other contextual information in determining priority of requests in
-            the absence of any priority signals.  In particular, servers might need to decide
-            whether to interpret the complete absence of signals as an indication that the client
-            has not implemented the feature or that the client that has deliberately chosen to rely
-            on the defaults described in <xref target="RFC7540" section="5.3.5"/>.
+            the absence of any priority signals.  Servers MAY interpret the complete absence of
+            signals as an indication that the client has not implemented the feature.  The defaults
+            described in <xref target="RFC7540" section="5.3.5"/> are known to have poor performance
+            under most conditions and their use is unlikely to be deliberate.
           </t>
         </section>
       </section>


### PR DESCRIPTION
This doesn't completely remove it, but it only keeps those pieces
necessary for interoperability with existing implementations: the rules
for sending PRIORITY frames in different stream states, the format of
the HEADERS and PRIORITY frames, and the error handling.

It replaces the exposition about how priority works with a deprecation
notice and the little advice that we currently understand to be
accurate.

Closes #773.