### PR TITLE
Clarifications for trailers

### DIFF
--- a/draft-thomson-httpbis-http2bis.xml
+++ b/draft-thomson-httpbis-http2bis.xml
@@ -2725,17 +2725,21 @@
           HTTP/2 uses DATA frames to carry message payloads.  The <tt>chunked</tt> transfer encoding defined in <xref target="RFC7230" section="4.1"/> MUST NOT be used in HTTP/2.
         </t>
         <t>
-          Trailing header fields are carried in a header block that also terminates the stream.
-          Such a header block is a sequence starting with a <xref target="HEADERS" format="none">HEADERS</xref> frame, followed
-          by zero or more <xref target="CONTINUATION" format="none">CONTINUATION</xref> frames, where the <xref target="HEADERS" format="none">HEADERS</xref> frame
-          bears an END_STREAM flag.  Header blocks after the first that do not terminate the stream
-          are not part of an HTTP request or response.
+          Trailer fields are carried in a header block that also terminates the stream.  That is,
+          trailer fields comprise a sequence starting with a <xref target="HEADERS"
+          format="none">HEADERS</xref> frame, followed by zero or more <xref target="CONTINUATION"
+          format="none">CONTINUATION</xref> frames, where the <xref target="HEADERS"
+          format="none">HEADERS</xref> frame bears an END_STREAM flag.  Trailers MUST NOT include
+          <xref target="PseudoHeaderFields">pseudo-header fields</xref>.  An endpoint that receives
+          pseudo-header fields in trailers MUST treat the request or response as <xref
+          target="malformed">malformed</xref>.
         </t>
         <t>
-          A <xref target="HEADERS" format="none">HEADERS</xref> frame (and associated <xref target="CONTINUATION" format="none">CONTINUATION</xref> frames) can
-          only appear at the start or end of a stream.  An endpoint that receives a
-          <xref target="HEADERS" format="none">HEADERS</xref> frame without the END_STREAM flag set after receiving a final
-          (non-informational) status code MUST treat the corresponding request or response as <xref target="malformed">malformed</xref>.
+          An endpoint that receives a <xref target="HEADERS" format="none">HEADERS</xref> frame
+          without the END_STREAM flag set after receiving the <xref target="HEADERS"
+          format="none">HEADERS</xref> frame that opens a request or after receiving a final
+          (non-informational) status code MUST treat the corresponding request or response as <xref
+          target="malformed">malformed</xref>.
         </t>
         <t>
           An HTTP request/response exchange fully consumes a single stream.  A request starts with


### PR DESCRIPTION
Make it clearer that midders leads to the message being invalid.  I
hope.  It was already pretty clear.

I did have to fix the definition for malformed requests, which was
missing.

And no mention was made of pseudo-header fields.

This uses new terminology too.  That might save effort in a larger
cleanup.

Closes #780.