### PR TITLE
Reference RFC 6973 for fingerprinting

### DIFF
--- a/draft-ietf-httpbis-http2bis.xml
+++ b/draft-ietf-httpbis-http2bis.xml
@@ -3840,8 +3840,7 @@
         </t>
         <t>
           As far as these create observable differences in behavior, they could be used as a basis
-          for fingerprinting a specific client, as defined in
-          <xref target="WEB-INFRA" section="2.4" relative="#tracking-vector"/>.
+          for fingerprinting a specific client, as defined in <xref target="PRIVACY" section="3.2"/>.
         </t>
         <t>
           HTTP/2's preference for using a single TCP connection allows correlation of a user's
@@ -4708,13 +4707,19 @@
             <date year="2006" month="May"/>
           </front>
         </reference>
-        <reference anchor="WEB-INFRA" target="https://infra.spec.whatwg.org/">
+        <reference anchor="PRIVACY">
           <front>
-            <title>Infra</title>
-            <seriesInfo name="WHATWG Standard" value="infra"/>
-            <author fullname="Anne van Kesteren" surname="van Kesteren" initials="A."/>
-            <author fullname="Dominic Denicola" surname="Denicola" initials="D."/>
-            <date year="2020" month="October" day="8"/>
+            <title>Privacy Considerations for Internet Protocols</title>
+            <seriesInfo name="RFC" value="6973"/>
+            <seriesInfo name="DOI" value="10.17487/RFC6973"/>
+            <author initials="A." surname="Cooper" fullname="A. Cooper"/>
+            <author initials="H." surname="Tschofenig" fullname="H. Tschofenig"/>
+            <author initials="B." surname="Aboba" fullname="B. Aboba"/>
+            <author initials="J." surname="Peterson" fullname="J. Peterson"/>
+            <author initials="J." surname="Morris" fullname="J. Morris"/>
+            <author initials="M." surname="Hansen" fullname="M. Hansen"/>
+            <author initials="R." surname="Smith" fullname="R. Smith"/>
+            <date year="2013" month="July"/>
           </front>
         </reference>
         <reference anchor="TALKING" target="http://w2spconf.com/2011/papers/websocket.pdf">

--- a/draft-thomson-httpbis-http2bis.xml
+++ b/draft-thomson-httpbis-http2bis.xml
@@ -3813,7 +3813,7 @@
         <t>
           As far as these create observable differences in behavior, they could be used as a basis
           for fingerprinting a specific client, as defined in
-          <xref target="HTML5" section="1.8" relative="#fingerprint"/>.
+          <xref target="WEB-INFRA" section="2.4" relative="#tracking-vector"/>.
         </t>
         <t>
           HTTP/2's preference for using a single TCP connection allows correlation of a user's
@@ -4680,18 +4680,13 @@
             <date year="2006" month="May"/>
           </front>
         </reference>
-        <reference anchor="HTML5" target="http://www.w3.org/TR/2014/REC-html5-20141028/">
+        <reference anchor="WEB-INFRA" target="https://infra.spec.whatwg.org/">
           <front>
-            <title>HTML5</title>
-            <seriesInfo name="W3C Recommendation" value="REC-html5-20141028"/>
-            <author fullname="Ian Hickson" surname="Hickson" initials="I."/>
-            <author fullname="Robin Berjon" surname="Berjon" initials="R."/>
-            <author fullname="Steve Faulkner" surname="Faulkner" initials="S."/>
-            <author fullname="Travis Leithead" surname="Leithead" initials="T."/>
-            <author fullname="Erika Doyle Navara" surname="Doyle Navara" initials="E."/>
-            <author fullname="Edward O'Connor" surname="O'Connor" initials="E."/>
-            <author fullname="Silvia Pfeiffer" surname="Pfeiffer" initials="S."/>
-            <date year="2014" month="October" day="28"/>
+            <title>Infra</title>
+            <seriesInfo name="WHATWG Standard" value="infra"/>
+            <author fullname="Anne van Kesteren" surname="van Kesteren" initials="A."/>
+            <author fullname="Dominic Denicola" surname="Denicola" initials="D."/>
+            <date year="2020" month="October" day="8"/>
           </front>
         </reference>
         <reference anchor="TALKING" target="http://w2spconf.com/2011/papers/websocket.pdf">


### PR DESCRIPTION
The thinking has evolved considerably since the original reference was
made.  This is the right way to refer to this concept.

Closes #771.