### PR TITLE
Remove use of "payload" for message bodies.

### DIFF
--- a/draft-thomson-httpbis-http2bis.xml
+++ b/draft-thomson-httpbis-http2bis.xml
@@ -2705,7 +2705,7 @@
               frames) containing the message headers (see <xref target="RFC7230" section="3.2"/>),
             </li>
           <li>
-              zero or more <xref target="DATA" format="none">DATA</xref> frames containing the content (see <xref target="draft-ietf-httpbis-semantics-14" section="6.4"/>), and
+              zero or more <xref target="DATA" format="none">DATA</xref> frames containing the message content (see <xref target="draft-ietf-httpbis-semantics-14" section="6.4"/>), and
             </li>
           <li>
               optionally, one <xref target="HEADERS" format="none">HEADERS</xref> frame, followed by zero or more

--- a/draft-thomson-httpbis-http2bis.xml
+++ b/draft-thomson-httpbis-http2bis.xml
@@ -4781,48 +4781,18 @@
                     surname="Fielding"
                     role="editor">
               <organization>Adobe</organization>
-              <address>
-                <postal>
-                  <street>345 Park Ave</street>
-                  <city>San Jose</city>
-                  <region>CA</region>
-                  <code>95110</code>
-                  <country>United States of America</country>
-                </postal>
-                <email>fielding@gbiv.com</email>
-                <uri>https://roy.gbiv.com/</uri>
-              </address>
             </author>
             <author fullname="Mark Nottingham"
                     initials="M."
                     surname="Nottingham"
                     role="editor">
               <organization>Fastly</organization>
-              <address>
-                <postal>
-                  <city>Prahran</city>
-                  <region>VIC</region>
-                  <country>Australia</country>
-                </postal>
-                <email>mnot@mnot.net</email>
-                <uri>https://www.mnot.net/</uri>
-              </address>
             </author>
             <author fullname="Julian Reschke"
                     initials="J."
                     surname="Reschke"
                     role="editor">
               <organization abbrev="greenbytes">greenbytes GmbH</organization>
-              <address>
-                <postal>
-                  <street>Hafenweg 16</street>
-                  <city>Münster</city>
-                  <code>48155</code>
-                  <country>Germany</country>
-                </postal>
-                <email>julian.reschke@greenbytes.de</email>
-                <uri>https://greenbytes.de/tech/webdav/</uri>
-              </address>
             </author>
             <date year="2021" month="January" day="13"/>
           </front>

--- a/draft-thomson-httpbis-http2bis.xml
+++ b/draft-thomson-httpbis-http2bis.xml
@@ -238,7 +238,7 @@
           and server at different times.
         </t>
         <t>
-          The term "payload body" is defined in <xref target="RFC7230" section="3.3"/>.
+          The term "content" as it applies to message bodies is defined in <xref target="draft-ietf-httpbis-semantics-14" section="6.4"/>.
         </t>
       </section>
     </section>
@@ -307,11 +307,11 @@
   Host: server.example.com
   Connection: Upgrade, HTTP2-Settings
   Upgrade: h2c
-  HTTP2-Settings: <base64url encoding of HTTP/2 SETTINGS payload>
+  HTTP2-Settings: <base64url encoding of HTTP/2 SETTINGS frame payload>
 
 ]]></artwork>
         <t>
-          Requests that contain a payload body MUST be sent in their entirety before the client can
+          Requests that contain message content MUST be sent in their entirety before the client can
           send HTTP/2 frames.  This means that a large request can block the use of the connection
           until it is completely sent.
         </t>
@@ -381,7 +381,7 @@
           </t>
           <t>
             The content of the <tt>HTTP2-Settings</tt> header field is the
-            payload of a <xref target="SETTINGS" format="none">SETTINGS</xref> frame (<xref target="SETTINGS"/>), encoded as a
+            frame payload of a <xref target="SETTINGS" format="none">SETTINGS</xref> frame (<xref target="SETTINGS"/>), encoded as a
             base64url string (that is, the URL- and filename-safe Base64 encoding described in
             <xref target="RFC4648" section="5"/>, with any trailing '=' characters omitted).  The
             <xref target="RFC5234">ABNF</xref> production for <tt>token68</tt> is
@@ -507,7 +507,7 @@
       <section anchor="FrameHeader">
         <name>Frame Format</name>
         <t>
-          All frames begin with a fixed 9-octet header followed by a variable-length payload.
+          All frames begin with a fixed 9-octet header followed by a variable-length frame payload.
         </t>
         <figure anchor="FrameLayout">
           <name>Frame Layout</name>
@@ -592,7 +592,7 @@
         </t>
         <aside>
           <t>Note: Certain frame types, such as <xref target="PING">PING</xref>, impose additional limits
-            on the amount of payload data allowed.
+            on the amount of frame payload data allowed.
           </t>
         </aside>
         <t>
@@ -623,7 +623,7 @@
           Header lists are collections of zero or more header fields.  When transmitted over a
           connection, a header list is serialized into a header block using <xref target="COMPRESSION">HTTP header compression</xref>.  The serialized header block is then
           divided into one or more octet sequences, called header block fragments, and transmitted
-          within the payload of <xref target="HEADERS">HEADERS</xref>, <xref target="PUSH_PROMISE">PUSH_PROMISE</xref>, or <xref target="CONTINUATION">CONTINUATION</xref> frames.
+          within the frame payload of <xref target="HEADERS">HEADERS</xref>, <xref target="PUSH_PROMISE">PUSH_PROMISE</xref>, or <xref target="CONTINUATION">CONTINUATION</xref> frames.
         </t>
         <t>
           The <xref target="COOKIE">Cookie header field</xref> is treated specially by the HTTP
@@ -663,7 +663,7 @@
           equivalent to a single frame.
         </t>
         <t>
-          Header block fragments can only be sent as the payload of <xref target="HEADERS" format="none">HEADERS</xref>,
+          Header block fragments can only be sent as the frame payload of <xref target="HEADERS" format="none">HEADERS</xref>,
           <xref target="PUSH_PROMISE" format="none">PUSH_PROMISE</xref>, or <xref target="CONTINUATION" format="none">CONTINUATION</xref> frames because these frames
           carry data that can modify the compression context maintained by a receiver.  An endpoint
           receiving <xref target="HEADERS" format="none">HEADERS</xref>, <xref target="PUSH_PROMISE" format="none">PUSH_PROMISE</xref>, or
@@ -1537,7 +1537,7 @@
         <t>
           DATA frames (type=0x0) convey arbitrary, variable-length sequences of octets associated
           with a stream. One or more DATA frames are used, for instance, to carry HTTP request or
-          response payloads.
+          response message contents.
         </t>
         <t>
           DATA frames MAY also contain padding.  Padding can be added to DATA frames to obscure the
@@ -1719,7 +1719,7 @@
           </dd>
         </dl>
         <t>
-          The payload of a HEADERS frame contains a <xref target="HeaderBlock">header block
+          The frame payload of a HEADERS frame contains a <xref target="HeaderBlock">header block
           fragment</xref>.  A header block that does not fit within a HEADERS frame is continued in
           a <xref target="CONTINUATION">CONTINUATION frame</xref>.
         </t>
@@ -1763,7 +1763,7 @@
 ]]></artwork>
         </figure>
         <t>
-          The payload of a PRIORITY frame contains the following fields:
+          The frame payload of a PRIORITY frame contains the following fields:
         </t>
         <dl newline="false" spacing="normal">
           <dt>E:</dt>
@@ -1887,7 +1887,7 @@
           <dt>ACK (0x1):</dt>
           <dd>
               When set, bit 0 indicates that this frame acknowledges receipt and application of the
-              peer's SETTINGS frame.  When this bit is set, the payload of the SETTINGS frame MUST
+              peer's SETTINGS frame.  When this bit is set, the frame payload of the SETTINGS frame MUST
               be empty.  Receipt of a SETTINGS frame with the ACK flag set and a length field value
               other than 0 MUST be treated as a <xref target="ConnectionErrorHandler">connection
               error</xref> of type <xref target="FRAME_SIZE_ERROR" format="none">FRAME_SIZE_ERROR</xref>.  For more information, see <xref target="SettingsSync"/> ("<xref target="SettingsSync" format="title"/>").
@@ -1912,7 +1912,7 @@
         <section anchor="SettingFormat">
           <name>SETTINGS Format</name>
           <t>
-            The payload of a SETTINGS frame consists of zero or more parameters, each consisting of
+            The frame payload of a SETTINGS frame consists of zero or more parameters, each consisting of
             an unsigned 16-bit setting identifier and an unsigned 32-bit value.
           </t>
           <figure anchor="SettingFormatFigure">
@@ -2054,7 +2054,7 @@
           thorough description of the use of PUSH_PROMISE frames.
         </t>
         <figure anchor="PUSH_PROMISEPayloadFormat">
-          <name>PUSH_PROMISE Payload Format</name>
+          <name>PUSH_PROMISE Frame Payload</name>
           <artwork type="inline"><![CDATA[
  +---------------+
  |Pad Length? (8)|
@@ -2178,7 +2178,7 @@
           frames can be sent from any endpoint.
         </t>
         <figure anchor="PINGPayloadFormat">
-          <name>PING Payload Format</name>
+          <name>PING Frame Payload</name>
           <artwork type="inline"><![CDATA[
  +---------------------------------------------------------------+
  |                                                               |
@@ -2188,12 +2188,12 @@
 ]]></artwork>
         </figure>
         <t>
-          In addition to the frame header, PING frames MUST contain 8 octets of opaque data in the payload.
+          In addition to the frame header, PING frames MUST contain 8 octets of opaque data in the frame payload.
           A sender can include any value it chooses and use those octets in any fashion.
         </t>
         <t>
           Receivers of a PING frame that does not include an ACK flag MUST send a PING frame with
-          the ACK flag set in response, with an identical payload.  PING responses SHOULD be given
+          the ACK flag set in response, with an identical frame payload.  PING responses SHOULD be given
           higher priority than any other frame.
         </t>
         <t>
@@ -2263,7 +2263,7 @@
           terminating the connection.
         </t>
         <figure anchor="GOAWAYPayloadFormat">
-          <name>GOAWAY Payload Format</name>
+          <name>GOAWAY Frame Payload</name>
           <artwork type="inline"><![CDATA[
  +-+-------------------------------------------------------------+
  |R|                  Last-Stream-ID (31)                        |
@@ -2347,7 +2347,7 @@
           contains the reason for closing the connection.
         </t>
         <t>
-          Endpoints MAY append opaque data to the payload of any GOAWAY frame.  Additional debug
+          Endpoints MAY append opaque data to the frame payload of any GOAWAY frame.  Additional debug
           data is intended for diagnostic purposes only and carries no semantic value.  Debug
           information could contain security- or privacy-sensitive data.  Logged or otherwise
           persistently stored debug data MUST have adequate safeguards to prevent unauthorized
@@ -2378,7 +2378,7 @@
           <xref target="FLOW_CONTROL_ERROR" format="none">FLOW_CONTROL_ERROR</xref> if it is unable to accept a frame.
         </t>
         <figure anchor="WINDOW_UPDATEPayloadFormat">
-          <name>WINDOW_UPDATE Payload Format</name>
+          <name>WINDOW_UPDATE Frame Payload</name>
           <artwork type="inline"><![CDATA[
  +-+-------------------------------------------------------------+
  |R|              Window Size Increment (31)                     |
@@ -2386,7 +2386,7 @@
 ]]></artwork>
         </figure>
         <t>
-          The payload of a WINDOW_UPDATE frame is one reserved bit plus an unsigned 31-bit integer
+          The frame payload of a WINDOW_UPDATE frame is one reserved bit plus an unsigned 31-bit integer
           indicating the number of octets that the sender can transmit in addition to the existing
           flow-control window.  The legal range for the increment to the flow-control window is 1 to
           2<sup>31</sup>-1 (2,147,483,647) octets.
@@ -2705,7 +2705,7 @@
               frames) containing the message headers (see <xref target="RFC7230" section="3.2"/>),
             </li>
           <li>
-              zero or more <xref target="DATA" format="none">DATA</xref> frames containing the payload body (see <xref target="RFC7230" section="3.3"/>), and
+              zero or more <xref target="DATA" format="none">DATA</xref> frames containing the content (see <xref target="draft-ietf-httpbis-semantics-14" section="6.4"/>), and
             </li>
           <li>
               optionally, one <xref target="HEADERS" format="none">HEADERS</xref> frame, followed by zero or more
@@ -2722,7 +2722,7 @@
           and any <xref target="CONTINUATION" format="none">CONTINUATION</xref> frames that might follow.
         </t>
         <t>
-          HTTP/2 uses DATA frames to carry message payloads.  The <tt>chunked</tt> transfer encoding defined in <xref target="RFC7230" section="4.1"/> MUST NOT be used in HTTP/2.
+          HTTP/2 uses DATA frames to carry message content.  The <tt>chunked</tt> transfer encoding defined in <xref target="RFC7230" section="4.1"/> MUST NOT be used in HTTP/2.
         </t>
         <t>
           Trailing header fields are carried in a header block that also terminates the stream.
@@ -2954,10 +2954,10 @@
               header field names.
             </t>
             <t>
-              A request or response that includes a payload body can include a <tt>content-length</tt> header field.  A request or response is also
+              A request or response that includes message content can include a <tt>content-length</tt> header field.  A request or response is also
               malformed if the value of a <tt>content-length</tt> header field
               does not equal the sum of the <xref target="DATA" format="none">DATA</xref> frame payload lengths that form the
-              body.  A response that is defined to have no payload, as described in <xref target="RFC7230"/>, can have a non-zero
+              content.  A response that is defined to have no content, as described in <xref target="RFC7230"/>, can have a non-zero
               <tt>content-length</tt> header field, even though no content is
               included in <xref target="DATA" format="none">DATA</xref> frames.
             </t>
@@ -2982,7 +2982,7 @@
             HTTP/2 requests and responses.
           </t>
           <t>
-            An HTTP GET request includes request header fields and no payload body and is therefore
+            An HTTP GET request includes request header fields and no message content and is therefore
             transmitted as a single <xref target="HEADERS" format="none">HEADERS</xref> frame, followed by zero or more
             <xref target="CONTINUATION" format="none">CONTINUATION</xref> frames containing the serialized block of request header
             fields.  The <xref target="HEADERS" format="none">HEADERS</xref> frame in the following has both the END_HEADERS and
@@ -3013,7 +3013,7 @@
                                        expires = Thu, 23 Jan ...
 ]]></artwork>
           <t>
-            An HTTP POST request that includes request header fields and payload data is transmitted
+            An HTTP POST request that includes request header fields and message content is transmitted
             as one <xref target="HEADERS" format="none">HEADERS</xref> frame, followed by zero or more
             <xref target="CONTINUATION" format="none">CONTINUATION</xref> frames containing the request header fields, followed by one
             or more <xref target="DATA" format="none">DATA</xref> frames, with the last <xref target="CONTINUATION" format="none">CONTINUATION</xref> (or
@@ -3044,7 +3044,7 @@
               illustrative only.
           </t>
           <t>
-            A response that includes header fields and payload data is transmitted as a
+            A response that includes header fields and message content is transmitted as a
             <xref target="HEADERS" format="none">HEADERS</xref> frame, followed by zero or more <xref target="CONTINUATION" format="none">CONTINUATION</xref>
             frames, followed by one or more <xref target="DATA" format="none">DATA</xref> frames, with the last
             <xref target="DATA" format="none">DATA</xref> frame in the sequence having the END_STREAM flag set:
@@ -3163,9 +3163,9 @@
         </t>
         <t>
           Promised requests MUST be cacheable (see <xref target="RFC7231" section="4.2.3"/>), MUST be safe
-          (see <xref target="RFC7231" section="4.2.1"/>), and MUST NOT include a request body. Clients that receive a
+          (see <xref target="RFC7231" section="4.2.1"/>), and MUST NOT include any content. Clients that receive a
           promised request that is not cacheable, that is not known to be safe, or that indicates the
-          presence of a request body MUST reset the promised stream with a <xref target="StreamErrorHandler">stream error</xref> of type <xref target="PROTOCOL_ERROR" format="none">PROTOCOL_ERROR</xref>.
+          presence of request content MUST reset the promised stream with a <xref target="StreamErrorHandler">stream error</xref> of type <xref target="PROTOCOL_ERROR" format="none">PROTOCOL_ERROR</xref>.
           Note this could result in the promised stream being reset if the client does not recognize
           a newly defined method as being safe.
         </t>
@@ -3208,7 +3208,7 @@
           <t>
             The <xref target="PUSH_PROMISE" format="none">PUSH_PROMISE</xref> frame includes a header block that contains a complete
             set of request header fields that the server attributes to the request. It is not
-            possible to push a response to a request that includes a request body.
+            possible to push a response to a request that includes message content.
           </t>
           <t>
             Promised requests are always associated with an explicit request from the client. The
@@ -3342,7 +3342,7 @@
         </t>
         <t>
           After the initial <xref target="HEADERS" format="none">HEADERS</xref> frame sent by each peer, all subsequent
-          <xref target="DATA" format="none">DATA</xref> frames correspond to data sent on the TCP connection.  The payload of
+          <xref target="DATA" format="none">DATA</xref> frames correspond to data sent on the TCP connection.  The frame payload of
           any <xref target="DATA" format="none">DATA</xref> frames sent by the client is transmitted by the proxy to the TCP
           server; data received from the TCP server is assembled into <xref target="DATA" format="none">DATA</xref> frames by
           the proxy.  Frame types other than <xref target="DATA" format="none">DATA</xref> or stream management frames
@@ -3790,8 +3790,8 @@
           best, padding only makes it more difficult for an attacker to infer length information by
           increasing the number of frames an attacker has to observe.  Incorrectly implemented
           padding schemes can be easily defeated.  In particular, randomized padding with a
-          predictable distribution provides very little protection; similarly, padding payloads to a
-          fixed size exposes information as payload sizes cross the fixed-sized boundary, which could
+          predictable distribution provides very little protection; similarly, padding frame payloads to a
+          fixed size exposes information as frame payload sizes cross the fixed-sized boundary, which could
           be possible if an attacker can control plaintext.
         </t>
         <t>
@@ -4772,6 +4772,61 @@
             </author>
             <date year="2016" month="April"/>
           </front>
+        </reference>
+        <reference anchor="draft-ietf-httpbis-semantics-14">
+          <front>
+            <title>HTTP Semantics</title>
+            <author fullname="Roy T. Fielding"
+                    initials="R."
+                    surname="Fielding"
+                    role="editor">
+              <organization>Adobe</organization>
+              <address>
+                <postal>
+                  <street>345 Park Ave</street>
+                  <city>San Jose</city>
+                  <region>CA</region>
+                  <code>95110</code>
+                  <country>United States of America</country>
+                </postal>
+                <email>fielding@gbiv.com</email>
+                <uri>https://roy.gbiv.com/</uri>
+              </address>
+            </author>
+            <author fullname="Mark Nottingham"
+                    initials="M."
+                    surname="Nottingham"
+                    role="editor">
+              <organization>Fastly</organization>
+              <address>
+                <postal>
+                  <city>Prahran</city>
+                  <region>VIC</region>
+                  <country>Australia</country>
+                </postal>
+                <email>mnot@mnot.net</email>
+                <uri>https://www.mnot.net/</uri>
+              </address>
+            </author>
+            <author fullname="Julian Reschke"
+                    initials="J."
+                    surname="Reschke"
+                    role="editor">
+              <organization abbrev="greenbytes">greenbytes GmbH</organization>
+              <address>
+                <postal>
+                  <street>Hafenweg 16</street>
+                  <city>Münster</city>
+                  <code>48155</code>
+                  <country>Germany</country>
+                </postal>
+                <email>julian.reschke@greenbytes.de</email>
+                <uri>https://greenbytes.de/tech/webdav/</uri>
+              </address>
+            </author>
+            <date year="2021" month="January" day="13"/>
+          </front>
+          <seriesInfo name="Internet-Draft" value="draft-ietf-httpbis-semantics-14"/>
         </reference>
       </references>
     </references>


### PR DESCRIPTION
This patch also changes our text to be consistent in using "frame
payload" as a two-word phrase.

Note that this patch now sometimes leaves us with the text "frame payload of an X frame". Shout if that seems too clumsy and I can remove the last word "frame", though I think it has the advantage of being extremely clear.

Resolves #803.