### PR TITLE
First pass on references to updated documents

### DIFF
--- a/draft-ietf-httpbis-http2bis.xml
+++ b/draft-ietf-httpbis-http2bis.xml
@@ -620,12 +620,13 @@
         </t>
       </section>
       <section anchor="FieldBlock">
-        <name>Header Compression and Decompression</name>
+        <name>Field Section Compression and Decompression</name>
         <t>
-          The term "header compression", or its inverse of "header decompression", is used to refer
-          to the process of compressing, or decompressing, a set of field lines to form a field
-          block.  The process HTTP/2 uses for header compression and decompression is defined in
-          <xref target="COMPRESSION"/>.
+          Field section compression is the process of compressing a set of field lines to form a
+          field block.  Field section decompression is the process of decoding a field block into a
+          set of field lines.  Details of HTTP/2 field section compression and decompression is
+          defined in <xref target="COMPRESSION"/>, which, for historical reasons, refers to these
+          processes as header compression and decompression.
         </t>
         <t>
           Field blocks carry the compressed bytes of a field section, with header sections
@@ -1480,7 +1481,7 @@
             The peer that sends the <xref target="RST_STREAM" format="none">RST_STREAM</xref> frame MUST be prepared to receive any
             frames that were sent or enqueued for sending by the remote peer.  These frames can be
             ignored, except where they modify connection state (such as the state maintained for
-            <xref target="FieldBlock">header compression</xref> or flow control).
+            <xref target="FieldBlock">field section compression</xref> or flow control).
           </t>
           <t>
             Normally, an endpoint SHOULD NOT send more than one <xref target="RST_STREAM" format="none">RST_STREAM</xref> frame for
@@ -2183,7 +2184,7 @@
         </t>
         <t>
           A PUSH_PROMISE frame modifies the connection state in two ways.  First, the inclusion of a <xref target="FieldBlock">field block</xref> potentially modifies the state maintained for
-          header compression.  Second, PUSH_PROMISE also reserves a stream for later use, causing the
+          field section compression.  Second, PUSH_PROMISE also reserves a stream for later use, causing the
           promised stream to enter the "reserved" state.  A sender MUST NOT send a PUSH_PROMISE on a
           stream unless that stream is either "open" or "half-closed (remote)"; the sender MUST
           ensure that the promised stream is a valid choice for a <xref target="StreamIdentifiers">new stream identifier</xref> (that is, the promised stream MUST
@@ -2375,10 +2376,10 @@
           receiver with identifiers higher than the identified last stream.  However, any frames
           that alter connection state cannot be completely ignored.  For instance,
           <xref target="HEADERS" format="none">HEADERS</xref>, <xref target="PUSH_PROMISE" format="none">PUSH_PROMISE</xref>, and <xref target="CONTINUATION" format="none">CONTINUATION</xref> frames
-          MUST be minimally processed to ensure the state maintained for header compression is
+          MUST be minimally processed to ensure the state maintained for field section compression is
           consistent (see <xref target="FieldBlock"/>); similarly, DATA frames MUST be counted
           toward the connection flow-control window.  Failure to process these frames can cause flow
-          control or header compression state to become unsynchronized.
+          control or field section compression state to become unsynchronized.
         </t>
         <t>
           The GOAWAY frame also contains a 32-bit <xref target="ErrorCodes">error code</xref> that
@@ -2681,7 +2682,8 @@
           </dd>
         <dt>COMPRESSION_ERROR (0x9):</dt>
         <dd anchor="COMPRESSION_ERROR">
-            The endpoint is unable to maintain the header compression context for the connection.
+            The endpoint is unable to maintain the field section compression context for the
+            connection.
           </dd>
         <dt>CONNECT_ERROR (0xa):</dt>
         <dd anchor="CONNECT_ERROR">
@@ -3709,7 +3711,7 @@
         <name>Denial-of-Service Considerations</name>
         <t>
           An HTTP/2 connection can demand a greater commitment of resources to operate than an
-          HTTP/1.1 connection.  The use of header compression and flow control depend on a
+          HTTP/1.1 connection.  The use of field section compression and flow control depend on a
           commitment of resources for storing a greater amount of state.  Settings for these
           features ensure that memory commitments for these features are strictly bounded.
         </t>
@@ -3737,7 +3739,7 @@
           end of a stream.
         </t>
         <t>
-          Header compression also offers some opportunities to waste processing resources; see
+          Field section compression also offers some opportunities to waste processing resources; see
           <xref target="COMPRESSION" section="7"/> for more details on potential abuses.
         </t>
         <t>
@@ -3747,9 +3749,9 @@
           known to clients and could be exceeded without being an obvious protocol violation.
         </t>
         <t>
-          All these features -- i.e., <xref target="SETTINGS" format="none">SETTINGS</xref> changes, small frames, header
-          compression -- have legitimate uses.  These features become a burden only when they are
-          used unnecessarily or to excess.
+          All these features -- i.e., <xref target="SETTINGS" format="none">SETTINGS</xref> changes,
+          small frames, field section compression -- have legitimate uses.  These features become a
+          burden only when they are used unnecessarily or to excess.
         </t>
         <t>
           An endpoint that doesn't monitor this behavior exposes itself to a risk of denial-of-service

--- a/draft-ietf-httpbis-http2bis.xml
+++ b/draft-ietf-httpbis-http2bis.xml
@@ -141,7 +141,7 @@
       </t>
       <t>
         Because HTTP header fields used in a connection can contain large amounts of redundant
-        data, frames that contain them are <xref target="HeaderBlock">compressed</xref>. This has
+        data, frames that contain them are <xref target="FieldBlock">compressed</xref>. This has
         especially advantageous impact upon request sizes in the common case, allowing many
         requests to be compressed into one packet.
       </t>
@@ -607,7 +607,7 @@
           defined in <xref target="SETTINGS_MAX_FRAME_SIZE" format="none">SETTINGS_MAX_FRAME_SIZE</xref>, exceeds any limit defined for the frame type,
           or is too small to contain mandatory frame data. A frame size error in a frame that
           could alter the state of the entire connection MUST be treated as a <xref target="ConnectionErrorHandler">connection error</xref>; this includes any frame carrying
-          a <xref target="HeaderBlock">header block</xref> (that is, <xref target="HEADERS" format="none">HEADERS</xref>,
+          a <xref target="FieldBlock">field block</xref> (that is, <xref target="HEADERS" format="none">HEADERS</xref>,
           <xref target="PUSH_PROMISE" format="none">PUSH_PROMISE</xref>, and <xref target="CONTINUATION" format="none">CONTINUATION</xref>), <xref target="SETTINGS" format="none">SETTINGS</xref>,
           and any frame with a stream identifier of 0.
         </t>
@@ -619,18 +619,40 @@
           which, if blocked by the transmission of a large frame, could affect performance.
         </t>
       </section>
-      <section anchor="HeaderBlock">
-        <name>Field Section Compression and Decompression</name>
+      <section anchor="FieldBlock">
+        <name>Header Compression and Decompression</name>
         <t>
-          A field in HTTP is a name with one or more associated values.
-          Field lines carry each value and are used within HTTP/2 request and response messages as well as in server push operations
-          (see <xref target="PushResources"/>).
+          The term "header compression", or its inverse of "header decompression", is used to refer
+          to the process of compressing, or decompressing, a set of field lines to form a field
+          block.  The process HTTP/2 uses for header compression and decompression is defined in
+          <xref target="COMPRESSION"/>.
         </t>
         <t>
-          A field section is a collection of zero or more field lines.  When transmitted over a
-          connection, a field section is serialized into a field block using <xref target="COMPRESSION">HTTP header compression</xref> (previous versions of this specification used the term "header block").  The serialized field block is then
-          divided into one or more octet sequences, called field block fragments, and transmitted
-          within the frame payload of <xref target="HEADERS">HEADERS</xref>, <xref target="PUSH_PROMISE">PUSH_PROMISE</xref>, or <xref target="CONTINUATION">CONTINUATION</xref> frames.
+          Field blocks carry the compressed bytes of a field section, with header sections
+          also carrying control data associated with the message in the form of <xref
+          target="PseudoHeaderFields">pseudo-header fields</xref> that use the same format as a
+          field line.
+        </t>
+        <aside>
+          <t>
+            Note: Previous versions of this specification used the term "header block" in place of
+            the more generic "field block".
+          </t>
+        </aside>
+        <t>
+          Field blocks carry control data and header sections for requests, responses, promised
+          requests, and pushed responses (see <xref target="PushResources"/>).  All these messages,
+          except for interim responses and requests contained in <xref
+          target="PUSH_PROMISE">PUSH_PROMISE</xref> frames can optionally include a field block that
+          carries a trailer section.
+        </t>
+        <t>
+          A field section is a collection of zero or more field lines.  Each of the field lines in a
+          field block carry a single value.  The serialized field block is then divided into one or
+          more octet sequences, called field block fragments, and transmitted within the frame
+          payload of <xref target="HEADERS">HEADERS</xref> or <xref
+          target="PUSH_PROMISE">PUSH_PROMISE</xref>, each of which could be followed by <xref
+          target="CONTINUATION">CONTINUATION</xref> frames.
         </t>
         <t>
           The <xref target="COOKIE">Cookie header field</xref> is treated specially by the HTTP
@@ -1458,7 +1480,7 @@
             The peer that sends the <xref target="RST_STREAM" format="none">RST_STREAM</xref> frame MUST be prepared to receive any
             frames that were sent or enqueued for sending by the remote peer.  These frames can be
             ignored, except where they modify connection state (such as the state maintained for
-            <xref target="HeaderBlock">header compression</xref> or flow control).
+            <xref target="FieldBlock">header compression</xref> or flow control).
           </t>
           <t>
             Normally, an endpoint SHOULD NOT send more than one <xref target="RST_STREAM" format="none">RST_STREAM</xref> frame for
@@ -1503,7 +1525,7 @@
           elements.  Implementations MUST discard frames that have unknown or unsupported types.
           This means that any of these extension points can be safely used by extensions without
           prior arrangement or negotiation.  However, extension frames that appear in the middle of
-          a <xref target="HeaderBlock">field block</xref> are not permitted; these MUST be treated
+          a <xref target="FieldBlock">field block</xref> are not permitted; these MUST be treated
           as a <xref target="ConnectionErrorHandler">connection error</xref> of type
           <xref target="PROTOCOL_ERROR" format="none">PROTOCOL_ERROR</xref>.
         </t>
@@ -1682,7 +1704,7 @@
             </dd>
           <dt>Field Block Fragment:</dt>
           <dd>
-              A <xref target="HeaderBlock">field block fragment</xref>.
+              A <xref target="FieldBlock">field block fragment</xref>.
             </dd>
           <dt>Padding:</dt>
           <dd>
@@ -1696,7 +1718,7 @@
           <dt>END_STREAM (0x1):</dt>
           <dd>
             <t>
-                When set, bit 0 indicates that the <xref target="HeaderBlock">field block</xref> is
+                When set, bit 0 indicates that the <xref target="FieldBlock">field block</xref> is
                 the last that the endpoint will send for the identified stream.
             </t>
             <t>
@@ -1709,7 +1731,7 @@
           <dt>END_HEADERS (0x4):</dt>
           <dd>
             <t>
-                When set, bit 2 indicates that this frame contains an entire <xref target="HeaderBlock">field block</xref> and is not followed by any
+                When set, bit 2 indicates that this frame contains an entire <xref target="FieldBlock">field block</xref> and is not followed by any
                 <xref target="CONTINUATION" format="none">CONTINUATION</xref> frames.
             </t>
             <t>
@@ -1735,7 +1757,7 @@
           </dd>
         </dl>
         <t>
-          The frame payload of a HEADERS frame contains a <xref target="HeaderBlock">field block
+          The frame payload of a HEADERS frame contains a <xref target="FieldBlock">field block
           fragment</xref>.  A field block that does not fit within a HEADERS frame is continued in
           a <xref target="CONTINUATION">CONTINUATION frame</xref>.
         </t>
@@ -1745,7 +1767,7 @@
           <xref target="PROTOCOL_ERROR" format="none">PROTOCOL_ERROR</xref>.
         </t>
         <t>
-          The HEADERS frame changes the connection state as described in <xref target="HeaderBlock"/>.
+          The HEADERS frame changes the connection state as described in <xref target="FieldBlock"/>.
         </t>
         <t>
           The HEADERS frame can include padding.  Padding fields and flags are identical to those
@@ -1809,7 +1831,7 @@
         </t>
         <t>
           The PRIORITY frame can be sent on a stream in any state, though it cannot be sent between
-          consecutive frames that comprise a single <xref target="HeaderBlock">field block</xref>.
+          consecutive frames that comprise a single <xref target="FieldBlock">field block</xref>.
           Note that this frame could arrive after processing or frame sending has completed, which
           would cause it to have no effect on the identified stream.  For a stream that is in the
           "half-closed (remote)" or "closed" state, this frame can only affect processing of the
@@ -2022,7 +2044,7 @@
             <dt anchor="SETTINGS_MAX_HEADER_LIST_SIZE">SETTINGS_MAX_HEADER_LIST_SIZE (0x6):</dt>
             <dd>
               <t>
-                  This advisory setting informs a peer of the maximum size of header section that the
+                  This advisory setting informs a peer of the maximum size of field section that the
                   sender is prepared to accept, in octets. The value is based on the uncompressed
                   size of field lines, including the length of the name and value in octets plus
                   an overhead of 32 octets for each field line.
@@ -2104,7 +2126,7 @@
             </dd>
           <dt>Field Block Fragment:</dt>
           <dd>
-              A <xref target="HeaderBlock">field block fragment</xref> containing request control data and
+              A <xref target="FieldBlock">field block fragment</xref> containing request control data and
               header section.
             </dd>
           <dt>Padding:</dt>
@@ -2119,7 +2141,7 @@
           <dt>END_HEADERS (0x4):</dt>
           <dd>
             <t>
-                When set, bit 2 indicates that this frame contains an entire <xref target="HeaderBlock">field block</xref> and is not followed by any
+                When set, bit 2 indicates that this frame contains an entire <xref target="FieldBlock">field block</xref> and is not followed by any
                 <xref target="CONTINUATION" format="none">CONTINUATION</xref> frames.
             </t>
             <t>
@@ -2160,7 +2182,7 @@
           the PUSH_PROMISE.
         </t>
         <t>
-          A PUSH_PROMISE frame modifies the connection state in two ways.  First, the inclusion of a <xref target="HeaderBlock">field block</xref> potentially modifies the state maintained for
+          A PUSH_PROMISE frame modifies the connection state in two ways.  First, the inclusion of a <xref target="FieldBlock">field block</xref> potentially modifies the state maintained for
           header compression.  Second, PUSH_PROMISE also reserves a stream for later use, causing the
           promised stream to enter the "reserved" state.  A sender MUST NOT send a PUSH_PROMISE on a
           stream unless that stream is either "open" or "half-closed (remote)"; the sender MUST
@@ -2354,7 +2376,7 @@
           that alter connection state cannot be completely ignored.  For instance,
           <xref target="HEADERS" format="none">HEADERS</xref>, <xref target="PUSH_PROMISE" format="none">PUSH_PROMISE</xref>, and <xref target="CONTINUATION" format="none">CONTINUATION</xref> frames
           MUST be minimally processed to ensure the state maintained for header compression is
-          consistent (see <xref target="HeaderBlock"/>); similarly, DATA frames MUST be counted
+          consistent (see <xref target="FieldBlock"/>); similarly, DATA frames MUST be counted
           toward the connection flow-control window.  Failure to process these frames can cause flow
           control or header compression state to become unsynchronized.
         </t>
@@ -2552,7 +2574,7 @@
       <section anchor="CONTINUATION">
         <name>CONTINUATION</name>
         <t>
-          The CONTINUATION frame (type=0x9) is used to continue a sequence of <xref target="HeaderBlock">field block fragments</xref>.  Any number of CONTINUATION frames can
+          The CONTINUATION frame (type=0x9) is used to continue a sequence of <xref target="FieldBlock">field block fragments</xref>.  Any number of CONTINUATION frames can
           be sent, as long as the preceding frame is on the same stream and is a
           <xref target="HEADERS" format="none">HEADERS</xref>, <xref target="PUSH_PROMISE" format="none">PUSH_PROMISE</xref>, or CONTINUATION frame without the
           END_HEADERS flag set.
@@ -2566,7 +2588,7 @@
 ]]></artwork>
         </figure>
         <t>
-          The CONTINUATION frame payload contains a <xref target="HeaderBlock">field block
+          The CONTINUATION frame payload contains a <xref target="FieldBlock">field block
           fragment</xref>.
         </t>
         <t>
@@ -2576,7 +2598,7 @@
           <dt>END_HEADERS (0x4):</dt>
           <dd>
             <t>
-                When set, bit 2 indicates that this frame ends a <xref target="HeaderBlock">field
+                When set, bit 2 indicates that this frame ends a <xref target="FieldBlock">field
                 block</xref>.
             </t>
             <t>
@@ -2588,7 +2610,7 @@
           </dd>
         </dl>
         <t>
-          The CONTINUATION frame changes the connection state as defined in <xref target="HeaderBlock"/>.
+          The CONTINUATION frame changes the connection state as defined in <xref target="FieldBlock"/>.
         </t>
         <t>
           CONTINUATION frames MUST be associated with a stream. If a CONTINUATION frame is received
@@ -3735,10 +3757,10 @@
           their use.  An endpoint MAY treat activity that is suspicious as a <xref target="ConnectionErrorHandler">connection error</xref> of type
           <xref target="ENHANCE_YOUR_CALM" format="none">ENHANCE_YOUR_CALM</xref>.
         </t>
-        <section anchor="MaxHeaderBlock">
+        <section anchor="MaxFieldBlock">
           <name>Limits on Field Block Size</name>
           <t>
-            A large <xref target="HeaderBlock">field block</xref> can cause an implementation to
+            A large <xref target="FieldBlock">field block</xref> can cause an implementation to
             commit a large amount of state.  Field lines that are critical for routing can appear
             toward the end of a field block, which prevents streaming of fields to their
             ultimate destination.  This ordering and other reasons, such as ensuring cache
@@ -3748,7 +3770,7 @@
           </t>
           <t>
             An endpoint can use the <xref target="SETTINGS_MAX_HEADER_LIST_SIZE" format="none">SETTINGS_MAX_HEADER_LIST_SIZE</xref> to advise peers of
-            limits that might apply on the size of field blocks.  This setting is only advisory, so
+            limits that might apply on the size of uncompressed field blocks.  This setting is only advisory, so
             endpoints MAY choose to send field blocks that exceed this limit and risk having the
             request or response being treated as malformed.  This setting is specific to a
             connection, so any request or response could encounter a hop with a lower, unknown
@@ -3780,7 +3802,7 @@
         <t>
           Compression can allow an attacker to recover secret data when it is compressed in the same
           context as data under attacker control.  HTTP/2 enables compression of field lines
-          (<xref target="HeaderBlock"/>); the following concerns also apply to the use of HTTP
+          (<xref target="FieldBlock"/>); the following concerns also apply to the use of HTTP
           compressed content-codings (<xref target="HTTP" section="8.4.1"/>).
         </t>
         <t>

--- a/draft-ietf-httpbis-http2bis.xml
+++ b/draft-ietf-httpbis-http2bis.xml
@@ -2729,7 +2729,7 @@
           <li>
               one <xref target="HEADERS" format="none">HEADERS</xref> frame (followed by zero or
               more <xref target="CONTINUATION" format="none">CONTINUATION</xref> frames) containing
-              the header section (see <xref target="HTTP" section="5"/>),
+              the header section (see <xref target="HTTP" section="6.3"/>),
             </li>
           <li>
               zero or more <xref target="DATA" format="none">DATA</xref> frames containing the
@@ -3005,7 +3005,7 @@
               A request or response that includes message content can include a <tt>content-length</tt> header field.  A request or response is also
               malformed if the value of a <tt>content-length</tt> header field
               does not equal the sum of the <xref target="DATA" format="none">DATA</xref> frame payload lengths that form the
-              content.  A response that is defined to have no content, as described in <xref target="HTTP"/>, can have a non-zero
+              content.  A response that is defined to have no content, as described in <xref target="HTTP" section="6.4"/>, can have a non-zero
               <tt>content-length</tt> header field, even though no content is
               included in <xref target="DATA" format="none">DATA</xref> frames.
             </t>
@@ -3221,7 +3221,7 @@
         <t>
           Pushed responses that are cacheable (see <xref target="CACHE" section="3"/>) can be stored by the client, if it implements an HTTP
           cache.  Pushed responses are considered successfully validated on the origin server (e.g.,
-          if the "no-cache" cache response directive is present; see <xref target="CACHE" section="5.2.2.4"/>) while the stream identified by the
+          if the "no-cache" cache response directive is present; see <xref target="CACHE" section="5.2.2.3"/>) while the stream identified by the
           promised stream ID is still open.
         </t>
         <t>

--- a/draft-ietf-httpbis-http2bis.xml
+++ b/draft-ietf-httpbis-http2bis.xml
@@ -2702,12 +2702,6 @@
         </t>
         <ol spacing="normal" type="1">
           <li>
-              for a response only, zero or more <xref target="HEADERS" format="none">HEADERS</xref>
-              frames (each followed by zero or more <xref target="CONTINUATION"
-              format="none">CONTINUATION</xref> frames) containing the control data and header
-              section of interim (1xx) HTTP responses (see <xref target="HTTP" section="15"/>),
-            </li>
-          <li>
               one <xref target="HEADERS" format="none">HEADERS</xref> frame (followed by zero or
               more <xref target="CONTINUATION" format="none">CONTINUATION</xref> frames) containing
               the header section (see <xref target="HTTP" section="5"/>),
@@ -2723,6 +2717,17 @@
               section="6.5"/>).
             </li>
         </ol>
+        <t>
+          For a response only, a server MAY send any number of interim responses before the <xref
+          target="HEADERS" format="none">HEADERS</xref> frame containing a final response.  An
+          interim response consists of a <xref target="HEADERS" format="none">HEADERS</xref> frames
+          (which might be followed by zero or more <xref target="CONTINUATION"
+          format="none">CONTINUATION</xref> frames) containing the control data and header section
+          of an interim (1xx) HTTP responses (see <xref target="HTTP" section="15"/>).  A <xref
+          target="HEADERS" format="none">HEADERS</xref> frame with an END_STREAM flag that carries
+          an informational status code is <xref target="malformed">malformed</xref>.
+        </t>
+
         <t>
           The last frame in the sequence bears an END_STREAM flag, noting that a
           <xref target="HEADERS" format="none">HEADERS</xref> frame bearing the END_STREAM flag can be followed by

--- a/draft-ietf-httpbis-http2bis.xml
+++ b/draft-ietf-httpbis-http2bis.xml
@@ -109,7 +109,7 @@
       <name>HTTP/2 Protocol Overview</name>
       <t>
         HTTP/2 provides an optimized transport for HTTP semantics.  HTTP/2 supports all of the core
-        features of HTTP/1.1 but aims to be more efficient in several ways.
+        features of HTTP but aims to be more efficient than HTTP/1.1.
       </t>
       <t>
         The basic protocol unit in HTTP/2 is a <xref target="FrameHeader">frame</xref>.  Each frame
@@ -256,7 +256,7 @@
         (<xref target="TCP"/>). The client is the TCP connection initiator.
       </t>
       <t>
-        HTTP/2 uses the same "http" and "https" URI schemes used by HTTP/1.1. HTTP/2 shares the same
+        HTTP/2 uses the "http" and "https" URI schemes defined in <xref target="HTTP" section="4.2"/>. HTTP/2 shares the same
         default port numbers: 80 for "http" URIs and 443 for "https" URIs.  As a result,
         implementations processing requests for target resource URIs like <tt>http://example.org/foo</tt> or <tt>https://example.com/bar</tt> are required to first discover whether the
         upstream server (the immediate peer to which the client wishes to establish a connection)
@@ -620,16 +620,16 @@
         </t>
       </section>
       <section anchor="HeaderBlock">
-        <name>Header Compression and Decompression</name>
+        <name>Field Section Compression and Decompression</name>
         <t>
-          Just as in HTTP/1, a header field in HTTP/2 is a name with one or more associated values.
-          Header fields are used within HTTP request and response messages as well as in server push operations
+          A field in HTTP is a name with one or more associated values.
+          Field lines carry each value and are used within HTTP/2 request and response messages as well as in server push operations
           (see <xref target="PushResources"/>).
         </t>
         <t>
-          Header lists are collections of zero or more header fields.  When transmitted over a
-          connection, a header list is serialized into a header block using <xref target="COMPRESSION">HTTP header compression</xref>.  The serialized header block is then
-          divided into one or more octet sequences, called header block fragments, and transmitted
+          A field section is a collection of zero or more field lines.  When transmitted over a
+          connection, a field section is serialized into a field block using <xref target="COMPRESSION">HTTP header compression</xref> (previous versions of this specification used the term "header block").  The serialized field block is then
+          divided into one or more octet sequences, called field block fragments, and transmitted
           within the frame payload of <xref target="HEADERS">HEADERS</xref>, <xref target="PUSH_PROMISE">PUSH_PROMISE</xref>, or <xref target="CONTINUATION">CONTINUATION</xref> frames.
         </t>
         <t>
@@ -637,11 +637,11 @@
           mapping (see <xref target="CompressCookie"/>).
         </t>
         <t>
-          A receiving endpoint reassembles the header block by concatenating its fragments and then
-          decompresses the block to reconstruct the header list.
+          A receiving endpoint reassembles the field block by concatenating its fragments and then
+          decompresses the block to reconstruct the field section.
         </t>
         <t>
-          A complete header block consists of either:
+          A complete field section consists of either:
         </t>
         <ul spacing="normal">
           <li>
@@ -655,29 +655,29 @@
             </li>
         </ul>
         <t>
-          Header compression is stateful.  One compression context and one decompression context are
-          used for the entire connection.  A decoding error in a header block MUST be treated as a
+          Field compression is stateful.  One compression context and one decompression context are
+          used for the entire connection.  A decoding error in a field block MUST be treated as a
           <xref target="ConnectionErrorHandler">connection error</xref> of type
           <xref target="COMPRESSION_ERROR" format="none">COMPRESSION_ERROR</xref>.
         </t>
         <t>
-          Each header block is processed as a discrete unit.
-          Header blocks MUST be transmitted as a contiguous sequence of frames, with no interleaved
+          Each field block is processed as a discrete unit.
+          Field blocks MUST be transmitted as a contiguous sequence of frames, with no interleaved
           frames of any other type or from any other stream.  The last frame in a sequence of
           <xref target="HEADERS" format="none">HEADERS</xref> or <xref target="CONTINUATION" format="none">CONTINUATION</xref> frames has the END_HEADERS flag set.
           The last frame in a sequence of <xref target="PUSH_PROMISE" format="none">PUSH_PROMISE</xref> or <xref target="CONTINUATION" format="none">CONTINUATION</xref>
-          frames has the END_HEADERS flag set.  This allows a header block to be logically
+          frames has the END_HEADERS flag set.  This allows a field block to be logically
           equivalent to a single frame.
         </t>
         <t>
-          Header block fragments can only be sent as the frame payload of <xref target="HEADERS" format="none">HEADERS</xref>,
+          Field block fragments can only be sent as the frame payload of <xref target="HEADERS" format="none">HEADERS</xref>,
           <xref target="PUSH_PROMISE" format="none">PUSH_PROMISE</xref>, or <xref target="CONTINUATION" format="none">CONTINUATION</xref> frames because these frames
           carry data that can modify the compression context maintained by a receiver.  An endpoint
           receiving <xref target="HEADERS" format="none">HEADERS</xref>, <xref target="PUSH_PROMISE" format="none">PUSH_PROMISE</xref>, or
-          <xref target="CONTINUATION" format="none">CONTINUATION</xref> frames needs to reassemble header blocks and perform
+          <xref target="CONTINUATION" format="none">CONTINUATION</xref> frames needs to reassemble field blocks and perform
           decompression even if the frames are to be discarded.  A receiver MUST terminate the
           connection with a <xref target="ConnectionErrorHandler">connection error</xref> of type
-          <xref target="COMPRESSION_ERROR" format="none">COMPRESSION_ERROR</xref> if it does not decompress a header block.
+          <xref target="COMPRESSION_ERROR" format="none">COMPRESSION_ERROR</xref> if it does not decompress a field block.
         </t>
       </section>
     </section>
@@ -754,7 +754,7 @@
        R:  RST_STREAM frame
        PP: PUSH_PROMISE frame (with implied CONTINUATIONs)
            Note: State transitions are for the promised stream.
-          ]]></artwork>
+]]></artwork>
         </figure>
         <t>
           Note that this diagram shows stream state transitions and the frames and flags that affect
@@ -1489,8 +1489,8 @@
         </t>
         <t>
           This applies to the protocol elements defined in this document.  This does not affect the
-          existing options for extending HTTP, such as defining new methods, status codes, or header
-          fields.
+          existing options for extending HTTP, such as defining new methods, status codes, or fields
+          (see <xref target="HTTP" section="16"/>).
         </t>
         <t>
           Extensions are permitted to use new <xref target="FrameHeader">frame types</xref>, new
@@ -1503,7 +1503,7 @@
           elements.  Implementations MUST discard frames that have unknown or unsupported types.
           This means that any of these extension points can be safely used by extensions without
           prior arrangement or negotiation.  However, extension frames that appear in the middle of
-          a <xref target="HeaderBlock">header block</xref> are not permitted; these MUST be treated
+          a <xref target="HeaderBlock">field block</xref> are not permitted; these MUST be treated
           as a <xref target="ConnectionErrorHandler">connection error</xref> of type
           <xref target="PROTOCOL_ERROR" format="none">PROTOCOL_ERROR</xref>.
         </t>
@@ -1638,7 +1638,8 @@
         <name>HEADERS</name>
         <t>
           The HEADERS frame (type=0x1) is used to <xref target="StreamStates">open a stream</xref>,
-          and additionally carries a header block fragment. HEADERS frames can be sent on a stream
+          and additionally carries a field block fragment. Despite the name, a HEADERS frame can carry
+          a header section or a trailer section. HEADERS frames can be sent on a stream
           in the "idle", "reserved (local)", "open", or "half-closed (remote)" state.
         </t>
         <figure anchor="HEADERSFramePayload">
@@ -1651,7 +1652,7 @@
  +-+-------------+-----------------------------------------------+
  |  Weight? (8)  |
  +-+-------------+-----------------------------------------------+
- |                   Header Block Fragment (*)                 ...
+ |                    Field Block Fragment (*)                 ...
  +---------------------------------------------------------------+
  |                           Padding (*)                       ...
  +---------------------------------------------------------------+
@@ -1679,9 +1680,9 @@
               An unsigned 8-bit integer representing a priority weight for the stream (see <xref target="StreamPriority"/>).  Add one to the value to obtain a weight between 1 and 256.
               This field is only present if the PRIORITY flag is set.
             </dd>
-          <dt>Header Block Fragment:</dt>
+          <dt>Field Block Fragment:</dt>
           <dd>
-              A <xref target="HeaderBlock">header block fragment</xref>.
+              A <xref target="HeaderBlock">field block fragment</xref>.
             </dd>
           <dt>Padding:</dt>
           <dd>
@@ -1695,7 +1696,7 @@
           <dt>END_STREAM (0x1):</dt>
           <dd>
             <t>
-                When set, bit 0 indicates that the <xref target="HeaderBlock">header block</xref> is
+                When set, bit 0 indicates that the <xref target="HeaderBlock">field block</xref> is
                 the last that the endpoint will send for the identified stream.
             </t>
             <t>
@@ -1708,7 +1709,7 @@
           <dt>END_HEADERS (0x4):</dt>
           <dd>
             <t>
-                When set, bit 2 indicates that this frame contains an entire <xref target="HeaderBlock">header block</xref> and is not followed by any
+                When set, bit 2 indicates that this frame contains an entire <xref target="HeaderBlock">field block</xref> and is not followed by any
                 <xref target="CONTINUATION" format="none">CONTINUATION</xref> frames.
             </t>
             <t>
@@ -1734,8 +1735,8 @@
           </dd>
         </dl>
         <t>
-          The frame payload of a HEADERS frame contains a <xref target="HeaderBlock">header block
-          fragment</xref>.  A header block that does not fit within a HEADERS frame is continued in
+          The frame payload of a HEADERS frame contains a <xref target="HeaderBlock">field block
+          fragment</xref>.  A field block that does not fit within a HEADERS frame is continued in
           a <xref target="CONTINUATION">CONTINUATION frame</xref>.
         </t>
         <t>
@@ -1808,7 +1809,7 @@
         </t>
         <t>
           The PRIORITY frame can be sent on a stream in any state, though it cannot be sent between
-          consecutive frames that comprise a single <xref target="HeaderBlock">header block</xref>.
+          consecutive frames that comprise a single <xref target="HeaderBlock">field block</xref>.
           Note that this frame could arrive after processing or frame sending has completed, which
           would cause it to have no effect on the identified stream.  For a stream that is in the
           "half-closed (remote)" or "closed" state, this frame can only affect processing of the
@@ -1950,10 +1951,10 @@
             <dt anchor="SETTINGS_HEADER_TABLE_SIZE">SETTINGS_HEADER_TABLE_SIZE (0x1):</dt>
             <dd>
               <t>
-                  Allows the sender to inform the remote endpoint of the maximum size of the header
-                  compression table used to decode header blocks, in octets. The encoder can select
+                  Allows the sender to inform the remote endpoint of the maximum size of the
+                  compression table used to decode field blocks, in octets. The encoder can select
                   any size equal to or less than this value by using signaling specific to the
-                  header compression format inside a header block (see <xref target="COMPRESSION"/>). The initial value is 4,096 octets.
+                  compression format inside a field block (see <xref target="COMPRESSION"/>). The initial value is 4,096 octets.
               </t>
             </dd>
             <dt anchor="SETTINGS_ENABLE_PUSH">SETTINGS_ENABLE_PUSH (0x2):</dt>
@@ -2021,10 +2022,10 @@
             <dt anchor="SETTINGS_MAX_HEADER_LIST_SIZE">SETTINGS_MAX_HEADER_LIST_SIZE (0x6):</dt>
             <dd>
               <t>
-                  This advisory setting informs a peer of the maximum size of header list that the
+                  This advisory setting informs a peer of the maximum size of header section that the
                   sender is prepared to accept, in octets. The value is based on the uncompressed
-                  size of header fields, including the length of the name and value in octets plus
-                  an overhead of 32 octets for each header field.
+                  size of field lines, including the length of the name and value in octets plus
+                  an overhead of 32 octets for each field line.
               </t>
               <t>
                   For any given request, a lower limit than what is advertised MAY be enforced.  The
@@ -2064,8 +2065,8 @@
         <t>
           The PUSH_PROMISE frame (type=0x5) is used to notify the peer endpoint in advance of
           streams the sender intends to initiate.  The PUSH_PROMISE frame includes the unsigned
-          31-bit identifier of the stream the endpoint plans to create along with a set of headers
-          that provide additional context for the stream.  <xref target="PushResources"/> contains a
+          31-bit identifier of the stream the endpoint plans to create along with a field section
+          that provides additional context for the stream.  <xref target="PushResources"/> contains a
           thorough description of the use of PUSH_PROMISE frames.
         </t>
         <figure anchor="PUSH_PROMISEPayloadFormat">
@@ -2076,7 +2077,7 @@
  +-+-------------+-----------------------------------------------+
  |R|                  Promised Stream ID (31)                    |
  +-+-----------------------------+-------------------------------+
- |                   Header Block Fragment (*)                 ...
+ |                    Field Block Fragment (*)                 ...
  +---------------------------------------------------------------+
  |                           Padding (*)                       ...
  +---------------------------------------------------------------+
@@ -2101,10 +2102,10 @@
               PUSH_PROMISE.  The promised stream identifier MUST be a valid choice for the next
               stream sent by the sender (see "new stream identifier" in <xref target="StreamIdentifiers"/>).
             </dd>
-          <dt>Header Block Fragment:</dt>
+          <dt>Field Block Fragment:</dt>
           <dd>
-              A <xref target="HeaderBlock">header block fragment</xref> containing request header
-              fields.
+              A <xref target="HeaderBlock">field block fragment</xref> containing request control data and
+              header section.
             </dd>
           <dt>Padding:</dt>
           <dd>
@@ -2118,7 +2119,7 @@
           <dt>END_HEADERS (0x4):</dt>
           <dd>
             <t>
-                When set, bit 2 indicates that this frame contains an entire <xref target="HeaderBlock">header block</xref> and is not followed by any
+                When set, bit 2 indicates that this frame contains an entire <xref target="HeaderBlock">field block</xref> and is not followed by any
                 <xref target="CONTINUATION" format="none">CONTINUATION</xref> frames.
             </t>
             <t>
@@ -2159,7 +2160,7 @@
           the PUSH_PROMISE.
         </t>
         <t>
-          A PUSH_PROMISE frame modifies the connection state in two ways.  First, the inclusion of a <xref target="HeaderBlock">header block</xref> potentially modifies the state maintained for
+          A PUSH_PROMISE frame modifies the connection state in two ways.  First, the inclusion of a <xref target="HeaderBlock">field block</xref> potentially modifies the state maintained for
           header compression.  Second, PUSH_PROMISE also reserves a stream for later use, causing the
           promised stream to enter the "reserved" state.  A sender MUST NOT send a PUSH_PROMISE on a
           stream unless that stream is either "open" or "half-closed (remote)"; the sender MUST
@@ -2551,7 +2552,7 @@
       <section anchor="CONTINUATION">
         <name>CONTINUATION</name>
         <t>
-          The CONTINUATION frame (type=0x9) is used to continue a sequence of <xref target="HeaderBlock">header block fragments</xref>.  Any number of CONTINUATION frames can
+          The CONTINUATION frame (type=0x9) is used to continue a sequence of <xref target="HeaderBlock">field block fragments</xref>.  Any number of CONTINUATION frames can
           be sent, as long as the preceding frame is on the same stream and is a
           <xref target="HEADERS" format="none">HEADERS</xref>, <xref target="PUSH_PROMISE" format="none">PUSH_PROMISE</xref>, or CONTINUATION frame without the
           END_HEADERS flag set.
@@ -2560,12 +2561,12 @@
           <name>CONTINUATION Frame Payload</name>
           <artwork type="inline"><![CDATA[
  +---------------------------------------------------------------+
- |                   Header Block Fragment (*)                 ...
+ |                    Field Block Fragment (*)                 ...
  +---------------------------------------------------------------+
 ]]></artwork>
         </figure>
         <t>
-          The CONTINUATION frame payload contains a <xref target="HeaderBlock">header block
+          The CONTINUATION frame payload contains a <xref target="HeaderBlock">field block
           fragment</xref>.
         </t>
         <t>
@@ -2575,7 +2576,7 @@
           <dt>END_HEADERS (0x4):</dt>
           <dd>
             <t>
-                When set, bit 2 indicates that this frame ends a <xref target="HeaderBlock">header
+                When set, bit 2 indicates that this frame ends a <xref target="HeaderBlock">field
                 block</xref>.
             </t>
             <t>
@@ -2723,7 +2724,7 @@
           interim response consists of a <xref target="HEADERS" format="none">HEADERS</xref> frames
           (which might be followed by zero or more <xref target="CONTINUATION"
           format="none">CONTINUATION</xref> frames) containing the control data and header section
-          of an interim (1xx) HTTP responses (see <xref target="HTTP" section="15"/>).  A <xref
+          of an interim (1xx) HTTP response (see <xref target="HTTP" section="15"/>).  A <xref
           target="HEADERS" format="none">HEADERS</xref> frame with an END_STREAM flag that carries
           an informational status code is <xref target="malformed">malformed</xref>.
         </t>
@@ -2731,7 +2732,7 @@
         <t>
           The last frame in the sequence bears an END_STREAM flag, noting that a
           <xref target="HEADERS" format="none">HEADERS</xref> frame bearing the END_STREAM flag can be followed by
-          <xref target="CONTINUATION" format="none">CONTINUATION</xref> frames that carry any remaining portions of the header block.
+          <xref target="CONTINUATION" format="none">CONTINUATION</xref> frames that carry any remaining fragments of the field block.
         </t>
         <t>
           Other frames (from any stream) MUST NOT occur between the <xref target="HEADERS" format="none">HEADERS</xref> frame
@@ -2742,7 +2743,7 @@
           defined in <xref target="HTTP11" section="7.1"/> cannot be used in HTTP/2.
         </t>
         <t>
-          Trailer fields are carried in a header block that also terminates the stream.  That is,
+          Trailer fields are carried in a field block that also terminates the stream.  That is,
           trailer fields comprise a sequence starting with a <xref target="HEADERS"
           format="none">HEADERS</xref> frame, followed by zero or more <xref target="CONTINUATION"
           format="none">CONTINUATION</xref> frames, where the <xref target="HEADERS"
@@ -2762,14 +2763,14 @@
           An HTTP request/response exchange fully consumes a single stream.  A request starts with
           the <xref target="HEADERS" format="none">HEADERS</xref> frame that puts the stream into an "open" state. The request
           ends with a frame bearing END_STREAM, which causes the stream to become "half-closed
-          (local)" for the client and "half-closed (remote)" for the server.  A response starts with
-          a <xref target="HEADERS" format="none">HEADERS</xref> frame and ends with a frame bearing END_STREAM, which places the
-          stream in the "closed" state.
+          (local)" for the client and "half-closed (remote)" for the server.  A response stream starts with
+          zero or more interim responses in <xref target="HEADERS" format="none">HEADERS</xref> frames or
+          a <xref target="HEADERS" format="none">HEADERS</xref> frame containing a final status code.
         </t>
         <t>
           An HTTP response is complete after the server sends -- or the client receives -- a frame
           with the END_STREAM flag set (including any <xref target="CONTINUATION" format="none">CONTINUATION</xref> frames needed to
-          complete a header block).  A server can send a complete response prior to the client
+          complete a field block).  A server can send a complete response prior to the client
           sending an entire request if the response does not depend on any portion of the request
           that has not been sent and received.  When this is true, a server MAY request that the
           client abort transmission of a request without error by sending a
@@ -2791,14 +2792,14 @@
           </t>
         </section>
         <section anchor="HttpHeaders">
-          <name>HTTP Header Fields</name>
+          <name>HTTP Fields</name>
           <t>
-            HTTP header fields carry information as a series of key-value pairs. For a listing of
-            registered HTTP headers, see the "Message Header Field" registry maintained at <eref target="https://www.iana.org/assignments/message-headers"/>.
+            HTTP fields carry information as a series of field lines, which are key-value pairs. For a listing of
+            registered HTTP fields, see the "Hypertext Transfer Protocol (HTTP) Field Name Registry" registry maintained at <eref target="https://www.iana.org/assignments/http-fields/"/>.
           </t>
           <t>
-            Just as in HTTP/1.x, header field names are strings of ASCII characters that are
-            compared in a case-insensitive fashion. However, header field names MUST be converted
+            Just as in HTTP/1.x, field names are strings of ASCII characters that are
+            compared in a case-insensitive fashion. Field names MUST be converted
             to lowercase prior to their encoding in HTTP/2. A request or response containing
             uppercase header field names MUST be treated as <xref target="malformed">malformed</xref>.
           </t>
@@ -2810,7 +2811,8 @@
               character (ASCII 0x3a) for this purpose.
             </t>
             <t>
-              Pseudo-header fields are not HTTP header fields.  Endpoints MUST NOT generate
+              Pseudo-header fields are not HTTP header fields.  Pseudo-header fields contain control
+              data (see <xref target="HTTP" section="6.2"/>).  Endpoints MUST NOT generate
               pseudo-header fields other than those defined in this document.  Note that an
               extension could negotiate the use of additional pseudo-header fields; see
               <xref target="extensibility"/>.
@@ -2819,13 +2821,13 @@
               Pseudo-header fields are only valid in the context in which they are defined.
               Pseudo-header fields defined for requests MUST NOT appear in responses; pseudo-header
               fields defined for responses MUST NOT appear in requests.  Pseudo-header fields MUST
-              NOT appear in trailers.  Endpoints MUST treat a request or response that contains
+              NOT appear in a trailer section.  Endpoints MUST treat a request or response that contains
               undefined or invalid pseudo-header fields as <xref target="malformed">malformed</xref>.
             </t>
             <t>
-              All pseudo-header fields MUST appear in the header block before regular header fields.
-              Any request or response that contains a pseudo-header field that appears in a header
-              block after a regular header field MUST be treated as <xref target="malformed">malformed</xref>.
+              All pseudo-header fields MUST appear in a field block before all regular field lines.
+              Any request or response that contains a pseudo-header field that appears in a field
+              block after a regular field line MUST be treated as <xref target="malformed">malformed</xref>.
             </t>
           </section>
           <section>
@@ -2843,7 +2845,7 @@
             </t>
             <t>
               An intermediary transforming a HTTP/1.x message to HTTP/2 MUST remove connection-specific
-              header fields as discussed in <xref target="HTTP" section="7.6.1"></xref>,
+              header fields as discussed in <xref target="HTTP" section="7.6.1"/>,
               or their messages will be treated by other HTTP/2 endpoints as <xref target="malformed">malformed</xref>.
             </t>
             <aside>
@@ -2919,8 +2921,9 @@
               pseudo-header fields is <xref target="malformed">malformed</xref>.
             </t>
             <t>
-              HTTP/2 does not define a way to carry the version identifier that is included in the
-              HTTP/1.1 request line.
+              Individual HTTP/2 requests do not carry an explicit indicator of protocol version.
+              All HTTP/2 messages implicitly have a protocol version of "2.0" (see
+              <xref target="HTTP" section="6.2"/>).
             </t>
           </section>
           <section anchor="HttpResponse">
@@ -2929,11 +2932,11 @@
               For HTTP/2 responses, a single <tt>:status</tt> pseudo-header
               field is defined that carries the HTTP status code field (see
               <xref target="HTTP" section="15"/>). This pseudo-header field MUST be included in all
-              responses; otherwise, the response is <xref target="malformed">malformed</xref>.
+              responses, including interim responses; otherwise, the response is
+              <xref target="malformed">malformed</xref>.
             </t>
             <t>
-              HTTP/2 does not define a way to carry the version or reason phrase that is included in
-              an HTTP/1.1 status line.
+              HTTP/2 responses implicitly have a protocol version of "2.0".
             </t>
           </section>
           <section anchor="CompressCookie">
@@ -2971,8 +2974,8 @@
             <t>
               A malformed request or response is one that is an otherwise valid sequence of HTTP/2
               frames but is invalid due to the presence of extraneous frames, prohibited
-              header fields, the absence of mandatory header fields, or the inclusion of uppercase
-              header field names.
+              fields or pseudo-header fields, the absence of mandatory fields or pseudo-header fields,
+              or the inclusion of uppercase field names.
             </t>
             <t>
               A request or response that includes message content can include a <tt>content-length</tt> header field.  A request or response is also
@@ -3003,7 +3006,7 @@
             HTTP/2 requests and responses.
           </t>
           <t>
-            An HTTP GET request includes request header fields and no message content and is therefore
+            An HTTP GET request includes control data and a request header with no message content and is therefore
             transmitted as a single <xref target="HEADERS" format="none">HEADERS</xref> frame, followed by zero or more
             <xref target="CONTINUATION" format="none">CONTINUATION</xref> frames containing the serialized block of request header
             fields.  The <xref target="HEADERS" format="none">HEADERS</xref> frame in the following has both the END_HEADERS and
@@ -3020,7 +3023,7 @@
                                        accept = image/jpeg
 ]]></artwork>
           <t>
-            Similarly, a response that includes only response header fields is transmitted as a
+            Similarly, a response that includes only control data and a response header is transmitted as a
             <xref target="HEADERS" format="none">HEADERS</xref> frame (again, followed by zero or more
             <xref target="CONTINUATION" format="none">CONTINUATION</xref> frames) containing the serialized block of response header
             fields.
@@ -3034,9 +3037,9 @@
                                        expires = Thu, 23 Jan ...
 ]]></artwork>
           <t>
-            An HTTP POST request that includes request header fields and message content is transmitted
+            An HTTP POST request that includes control data and a request header and message content is transmitted
             as one <xref target="HEADERS" format="none">HEADERS</xref> frame, followed by zero or more
-            <xref target="CONTINUATION" format="none">CONTINUATION</xref> frames containing the request header fields, followed by one
+            <xref target="CONTINUATION" format="none">CONTINUATION</xref> frames containing the request header, followed by one
             or more <xref target="DATA" format="none">DATA</xref> frames, with the last <xref target="CONTINUATION" format="none">CONTINUATION</xref> (or
             <xref target="HEADERS" format="none">HEADERS</xref>) frame having the END_HEADERS flag set and the final
             <xref target="DATA" format="none">DATA</xref> frame having the END_STREAM flag set:
@@ -3060,12 +3063,12 @@
                                    {binary data}
 ]]></artwork>
           <t keepWithPrevious="true">
-              Note that data contributing to any given header field could be spread between header
-              block fragments.  The allocation of header fields to frames in this example is
+              Note that data contributing to any given field line could be spread between field
+              block fragments.  The allocation of field lines to frames in this example is
               illustrative only.
           </t>
           <t>
-            A response that includes header fields and message content is transmitted as a
+            A response that includes control data and a response header and message content is transmitted as a
             <xref target="HEADERS" format="none">HEADERS</xref> frame, followed by zero or more <xref target="CONTINUATION" format="none">CONTINUATION</xref>
             frames, followed by one or more <xref target="DATA" format="none">DATA</xref> frames, with the last
             <xref target="DATA" format="none">DATA</xref> frame in the sequence having the END_STREAM flag set:
@@ -3088,15 +3091,15 @@
             frames.
           </t>
           <t>
-            Trailing header fields are sent as a header block after both the request or response
-            header block and all the <xref target="DATA" format="none">DATA</xref> frames have been sent.  The
-            <xref target="HEADERS" format="none">HEADERS</xref> frame starting the trailers header block has the END_STREAM flag
-            set.
+            A trailer section is sent as a field block after both the request or response
+            field block and all the <xref target="DATA" format="none">DATA</xref> frames have been sent.  The
+            <xref target="HEADERS" format="none">HEADERS</xref> frame starting the field block that comprises
+            the trailer section has the END_STREAM flag set.
           </t>
           <t keepWithNext="true">
               The following example includes both a 100 (Continue) status code, which is sent in
               response to a request containing a "100-continue" token in the Expect header field,
-              and trailing header fields:
+              and a trailer section:
           </t>
           <artwork type="inline"><![CDATA[
   HTTP/1.1 100 Continue            HEADERS
@@ -3126,7 +3129,7 @@
         <section anchor="Reliability">
           <name>Request Reliability Mechanisms in HTTP/2</name>
           <t>
-            In HTTP/1.1, an HTTP client is unable to retry a non-idempotent request when an error
+            In general, an HTTP client is unable to retry a non-idempotent request when an error
             occurs because there is no means to determine the nature of the error.  It is possible
             that some server processing occurred prior to the error, which could result in
             undesirable effects if the request were reattempted.
@@ -3184,7 +3187,7 @@
         </t>
         <t>
           Promised requests MUST be safe (see <xref target="HTTP" section="9.2.1"/>) and cacheable
-          (see <xref target="HTTP" section="9.2.3"/>), and MUST NOT include any content. Clients
+          (see <xref target="HTTP" section="9.2.3"/>).  Promised requests cannot include any content or a trailer section. Clients
           that receive a promised request that is not cacheable, that is not known to be safe, or
           that indicates the presence of request content MUST reset the promised stream with a <xref
           target="StreamErrorHandler">stream error</xref> of type <xref target="PROTOCOL_ERROR"
@@ -3228,7 +3231,8 @@
             frame.
           </t>
           <t>
-            The <xref target="PUSH_PROMISE" format="none">PUSH_PROMISE</xref> frame includes a header block that contains a complete
+            The <xref target="PUSH_PROMISE" format="none">PUSH_PROMISE</xref> frame includes a
+            field block that contains control data and a complete
             set of request header fields that the server attributes to the request. It is not
             possible to push a response to a request that includes message content.
           </t>
@@ -3257,7 +3261,7 @@
             to multiple image files and the server chooses to push those additional images to the
             client, sending <xref target="PUSH_PROMISE" format="none">PUSH_PROMISE</xref> frames before the <xref target="DATA" format="none">DATA</xref> frames that contain the
             image links ensures that the client is able to see that a resource will be pushed
-            before discovering embedded links. Similarly, if the server pushes responses referenced by the header block
+            before discovering embedded links. Similarly, if the server pushes responses referenced by the field block
             (for instance, in Link header fields), sending a <xref target="PUSH_PROMISE" format="none">PUSH_PROMISE</xref> before sending the
             header block ensures that clients do not request those resources.
           </t>
@@ -3268,7 +3272,7 @@
             (remote)" state with respect to the server.  <xref target="PUSH_PROMISE" format="none">PUSH_PROMISE</xref> frames are
             interspersed with the frames that comprise a response, though they cannot be
             interspersed with <xref target="HEADERS" format="none">HEADERS</xref> and <xref target="CONTINUATION" format="none">CONTINUATION</xref> frames that
-            comprise a single header block.
+            comprise a single field block.
           </t>
           <t>
             Sending a <xref target="PUSH_PROMISE" format="none">PUSH_PROMISE</xref> frame creates a new stream and puts the stream
@@ -3309,7 +3313,7 @@
             Clients receiving a pushed response MUST validate that either the server is
             authoritative (see <xref target="authority"/>) or the proxy that provided the pushed
             response is configured for the corresponding request. For example, a server that offers
-            a certificate for only the <tt>example.com</tt> DNS-ID or Common Name
+            a certificate for only the <tt>example.com</tt> DNS-ID
             is not permitted to push a response for <tt>https://www.example.org/doc</tt>.
           </t>
           <t>
@@ -3335,7 +3339,7 @@
         </t>
         <t>
           In HTTP/2, the CONNECT method is used to establish a tunnel over a single HTTP/2 stream to
-          a remote host for similar purposes. The HTTP header field mapping works as defined in
+          a remote host for similar purposes. A CONNECT header section is constructed as defined in
           <xref target="HttpRequest"/> ("<xref target="HttpRequest" format="title"/>"), with a few
           differences. Specifically:
         </t>
@@ -3358,7 +3362,7 @@
         </t>
         <t>
           A proxy that supports CONNECT establishes a <xref target="TCP">TCP connection</xref> to
-          the server identified in the <tt>:authority</tt> pseudo-header field. Once
+          the host and port identified in the <tt>:authority</tt> pseudo-header field. Once
           this connection is successfully established, the proxy sends a <xref target="HEADERS" format="none">HEADERS</xref>
           frame containing a 2xx series status code to the client, as defined in <xref target="HTTP" section="9.3.6"/>.
         </t>
@@ -3444,19 +3448,16 @@
             For <tt>https</tt> resources, connection reuse additionally depends
             on having a certificate that is valid for the host in the URI.  The certificate
             presented by the server MUST satisfy any checks that the client would perform when
-            forming a new TLS connection for the host in the URI.
-          </t>
-          <t>
-            An origin server might offer a certificate with multiple <tt>subjectAltName</tt> attributes or names with wildcards, one of which is
-            valid for the authority in the URI.  For example, a certificate with a <tt>subjectAltName</tt> of <tt>*.example.com</tt> might
-            permit the use of the same connection for requests to URIs starting with <tt>https://a.example.com/</tt> and <tt>https://b.example.com/</tt>.
+            forming a new TLS connection for the host in the URI.  A single certificate can be
+            used to establish authority for multiple origins.  <xref target="HTTP" section="4.3"/>
+            describes how a client determines whether a server is authoritative for a URI.
           </t>
           <t>
             In some deployments, reusing a connection for multiple origins can result in requests
             being directed to the wrong origin server.  For example, TLS termination might be
             performed by a middlebox that uses the TLS <xref target="TLS-EXT">Server Name Indication
             (SNI)</xref> extension to select an origin server.  This means that it is possible
-            for clients to send confidential information to servers that might not be the intended
+            for clients to send requests to servers that might not be the intended
             target for the request, even though the server is otherwise authoritative.
           </t>
           <t>
@@ -3607,8 +3608,8 @@
       <section anchor="authority">
         <name>Server Authority</name>
         <t>
-          HTTP/2 relies on the HTTP/1.1 definition of authority for determining whether a server is
-          authoritative in providing a given response (see <xref target="HTTP" section="17.1"/>).
+          HTTP/2 relies on the HTTP definition of authority for determining whether a server is
+          authoritative in providing a given response (see <xref target="HTTP" section="4.3"/>).
           This relies on local name resolution for the "http" URI scheme and the authenticated server
           identity for the "https" scheme.
         </t>
@@ -3644,18 +3645,18 @@
       <section>
         <name>Intermediary Encapsulation Attacks</name>
         <t>
-          The HTTP/2 header field encoding allows the expression of names that are not valid field
-          names in the Internet Message Syntax used by HTTP/1.1.  Requests or responses containing
-          invalid header field names MUST be treated as <xref target="malformed">malformed</xref>.
+          The HTTP/2 field block encoding allows the expression of names that are not valid field
+          names in HTTP.  Requests or responses containing
+          invalid field names MUST be treated as <xref target="malformed">malformed</xref>.
           An intermediary therefore cannot translate an HTTP/2 request or response containing an
           invalid field name into an HTTP/1.1 message.
         </t>
         <t>
-          Similarly, HTTP/2 allows header field values that are not valid.  While most of the values
+          Similarly, HTTP/2 allows field values that are not valid.  While most of the values
           that can be encoded will not alter header field parsing, carriage return (CR, ASCII 0xd),
           line feed (LF, ASCII 0xa), and the zero character (NUL, ASCII 0x0) might be exploited by
           an attacker if they are translated verbatim.  Any request or response that contains a
-          character not permitted in a header field value MUST be treated as <xref target="malformed">malformed</xref>.  Valid characters are defined by the <tt>field-content</tt> ABNF rule in <xref target="HTTP" section="5.5"/>.
+          character not permitted in a field value MUST be treated as <xref target="malformed">malformed</xref>.  Valid characters are defined by the <tt>field-content</tt> ABNF rule in <xref target="HTTP" section="5.5"/>.
         </t>
       </section>
       <section>
@@ -3735,29 +3736,29 @@
           <xref target="ENHANCE_YOUR_CALM" format="none">ENHANCE_YOUR_CALM</xref>.
         </t>
         <section anchor="MaxHeaderBlock">
-          <name>Limits on Header Block Size</name>
+          <name>Limits on Field Block Size</name>
           <t>
-            A large <xref target="HeaderBlock">header block</xref> can cause an implementation to
-            commit a large amount of state.  Header fields that are critical for routing can appear
-            toward the end of a header block, which prevents streaming of header fields to their
+            A large <xref target="HeaderBlock">field block</xref> can cause an implementation to
+            commit a large amount of state.  Field lines that are critical for routing can appear
+            toward the end of a field block, which prevents streaming of fields to their
             ultimate destination.  This ordering and other reasons, such as ensuring cache
-            correctness, mean that an endpoint might need to buffer the entire header block.  Since
-            there is no hard limit to the size of a header block, some endpoints could be forced to
-            commit a large amount of available memory for header fields.
+            correctness, mean that an endpoint might need to buffer the entire field block.  Since
+            there is no hard limit to the size of a field block, some endpoints could be forced to
+            commit a large amount of available memory for field blocks.
           </t>
           <t>
             An endpoint can use the <xref target="SETTINGS_MAX_HEADER_LIST_SIZE" format="none">SETTINGS_MAX_HEADER_LIST_SIZE</xref> to advise peers of
-            limits that might apply on the size of header blocks.  This setting is only advisory, so
-            endpoints MAY choose to send header blocks that exceed this limit and risk having the
+            limits that might apply on the size of field blocks.  This setting is only advisory, so
+            endpoints MAY choose to send field blocks that exceed this limit and risk having the
             request or response being treated as malformed.  This setting is specific to a
             connection, so any request or response could encounter a hop with a lower, unknown
             limit.  An intermediary can attempt to avoid this problem by passing on values presented
-            by different peers, but they are not obligated to do so.
+            by different peers, but they are not obliged to do so.
           </t>
           <t>
-            A server that receives a larger header block than it is willing to handle can send an
+            A server that receives a larger field block than it is willing to handle can send an
             HTTP 431 (Request Header Fields Too Large) status code <xref target="RFC6585"/>.  A
-            client can discard responses that it cannot process.  The header block MUST be processed
+            client can discard responses that it cannot process.  The field block MUST be processed
             to ensure a consistent connection state, unless the connection is closed.
           </t>
         </section>
@@ -3778,7 +3779,7 @@
         <name>Use of Compression</name>
         <t>
           Compression can allow an attacker to recover secret data when it is compressed in the same
-          context as data under attacker control.  HTTP/2 enables compression of header fields
+          context as data under attacker control.  HTTP/2 enables compression of field lines
           (<xref target="HeaderBlock"/>); the following concerns also apply to the use of HTTP
           compressed content-codings (<xref target="HTTP" section="8.4.1"/>).
         </t>
@@ -3803,7 +3804,7 @@
         <name>Use of Padding</name>
         <t>
           Padding within HTTP/2 is not intended as a replacement for general purpose padding, such
-          as might be provided by <xref target="TLS13">TLS</xref>.  Redundant padding could even be
+          as that provided by <xref target="TLS13">TLS</xref>.  Redundant padding could even be
           counterproductive.  Correct application can depend on having specific knowledge of the
           data that is being padded.
         </t>

--- a/draft-ietf-httpbis-http2bis.xml
+++ b/draft-ietf-httpbis-http2bis.xml
@@ -2713,7 +2713,7 @@
     <section anchor="HTTPLayer">
       <name>HTTP Message Exchanges</name>
       <t>
-        HTTP/2 defines a framing of the abstract HTTP message abstraction
+        HTTP/2 defines a framing of the HTTP message abstraction
         (<xref target="HTTP" section="6"/>).
       </t>
       <section anchor="HttpSequence">

--- a/draft-ietf-httpbis-http2bis.xml
+++ b/draft-ietf-httpbis-http2bis.xml
@@ -71,7 +71,7 @@
       <name>Introduction</name>
       <t>
         The Hypertext Transfer Protocol (HTTP) is a wildly successful protocol. However, the way
-        HTTP/1.1 uses the underlying transport (<xref target="RFC7230" section="6"/>) has several
+        HTTP/1.1 uses the underlying transport (<xref target="HTTP11"/>) has several
         characteristics that have a negative overall effect on application performance today.
       </t>
       <t>
@@ -240,11 +240,12 @@
         </dl>
         <t>
           Finally, the terms "gateway", "intermediary", "proxy", and "tunnel" are defined in
-          <xref target="RFC7230" section="2.3"/>.  Intermediaries act as both client
+          <xref target="HTTP" section="3.7"/>.  Intermediaries act as both client
           and server at different times.
         </t>
         <t>
-          The term "content" as it applies to message bodies is defined in <xref target="draft-ietf-httpbis-semantics-14" section="6.4"/>.
+          The term "content" as it applies to message bodies is defined in <xref target="HTTP"
+          section="6.4"/>.
         </t>
       </section>
     </section>
@@ -303,7 +304,7 @@
         <name>Starting HTTP/2 for "http" URIs</name>
         <t>
           A client that makes a request for an "http" URI without prior knowledge about support for
-          HTTP/2 on the next hop uses the HTTP Upgrade mechanism (<xref target="RFC7230" section="6.7"/>). The client does so by making an HTTP/1.1 request that
+          HTTP/2 on the next hop uses the HTTP Upgrade mechanism (<xref target="HTTP" section="7.8"/>). The client does so by making an HTTP/1.1 request that
           includes an Upgrade header field with the "h2c" token. Such an HTTP/1.1 request MUST
           include exactly one <xref target="Http2SettingsHeader">HTTP2-Settings</xref> header field.
         </t>
@@ -391,12 +392,12 @@
             base64url string (that is, the URL- and filename-safe Base64 encoding described in
             <xref target="RFC4648" section="5"/>, with any trailing '=' characters omitted).  The
             <xref target="RFC5234">ABNF</xref> production for <tt>token68</tt> is
-            defined in <xref target="RFC7235" section="2.1"/>.
+            defined in <xref target="HTTP" section="11.2"/>.
           </t>
           <t>
             Since the upgrade is only intended to apply to the immediate connection, a client
             sending the <tt>HTTP2-Settings</tt> header field MUST also send <tt>HTTP2-Settings</tt> as a connection option in the <tt>Connection</tt> header field to prevent it from being forwarded
-            (see <xref target="RFC7230" section="6.1"/>).
+            (see <xref target="HTTP" section="7.6.1"/>).
           </t>
           <t>
             A server decodes and interprets these values as it would any other
@@ -1430,8 +1431,7 @@
           </t>
           <t>
             It is possible that the <xref target="GOAWAY" format="none">GOAWAY</xref> will not be reliably received by the
-            receiving endpoint (<xref target="RFC7230" section="6.6"/> describes how an immediate connection close
-            can result in data loss).  In the event of a connection error,
+            receiving endpoint.  In the event of a connection error,
             <xref target="GOAWAY" format="none">GOAWAY</xref> only provides a best-effort attempt to communicate with the peer
             about why the connection is being terminated.
           </t>
@@ -2688,19 +2688,11 @@
     <section anchor="HTTPLayer">
       <name>HTTP Message Exchanges</name>
       <t>
-        HTTP/2 is intended to be as compatible as possible with current uses of HTTP. This means
-        that, from the application perspective, the features of the protocol are largely
-        unchanged. To achieve this, all request and response semantics are preserved, although the
-        syntax of conveying those semantics has changed.
-      </t>
-      <t>
-        Thus, the specification and requirements of HTTP/1.1 Semantics and Content <xref target="RFC7231"/>, Conditional Requests <xref target="RFC7232"/>, Range Requests <xref target="RFC7233"/>, Caching <xref target="RFC7234"/>, and Authentication <xref target="RFC7235"/> are applicable to HTTP/2. Selected portions of HTTP/1.1 Message Syntax
-        and Routing <xref target="RFC7230"/>, such as the HTTP and HTTPS URI schemes, are also
-        applicable in HTTP/2, but the expression of those semantics for this protocol are defined
-        in the sections below.
+        HTTP/2 defines a framing of the abstract HTTP message abstraction
+        (<xref target="HTTP" section="6"/>).
       </t>
       <section anchor="HttpSequence">
-        <name>HTTP Request/Response Exchange</name>
+        <name>HTTP Message Framing</name>
         <t>
           A client sends an HTTP request on a new stream, using a previously unused <xref target="StreamIdentifiers">stream identifier</xref>.  A server sends an HTTP response on
           the same stream as the request.
@@ -2710,21 +2702,25 @@
         </t>
         <ol spacing="normal" type="1">
           <li>
-              for a response only, zero or more <xref target="HEADERS" format="none">HEADERS</xref> frames (each followed by zero
-              or more <xref target="CONTINUATION" format="none">CONTINUATION</xref> frames) containing the message headers of
-              informational (1xx) HTTP responses (see <xref target="RFC7230" section="3.2"/> and
-              <xref target="RFC7231" section="6.2"/>),
+              for a response only, zero or more <xref target="HEADERS" format="none">HEADERS</xref>
+              frames (each followed by zero or more <xref target="CONTINUATION"
+              format="none">CONTINUATION</xref> frames) containing the control data and header
+              section of interim (1xx) HTTP responses (see <xref target="HTTP" section="15"/>),
             </li>
           <li>
-              one <xref target="HEADERS" format="none">HEADERS</xref> frame (followed by zero or more <xref target="CONTINUATION" format="none">CONTINUATION</xref>
-              frames) containing the message headers (see <xref target="RFC7230" section="3.2"/>),
+              one <xref target="HEADERS" format="none">HEADERS</xref> frame (followed by zero or
+              more <xref target="CONTINUATION" format="none">CONTINUATION</xref> frames) containing
+              the header section (see <xref target="HTTP" section="5"/>),
             </li>
           <li>
-              zero or more <xref target="DATA" format="none">DATA</xref> frames containing the message content (see <xref target="draft-ietf-httpbis-semantics-14" section="6.4"/>), and
+              zero or more <xref target="DATA" format="none">DATA</xref> frames containing the
+              message content (see <xref target="HTTP" section="6.4"/>), and
             </li>
           <li>
-              optionally, one <xref target="HEADERS" format="none">HEADERS</xref> frame, followed by zero or more
-              <xref target="CONTINUATION" format="none">CONTINUATION</xref> frames containing the trailer-part, if present (see <xref target="RFC7230" section="4.1.2"/>).
+              optionally, one <xref target="HEADERS" format="none">HEADERS</xref> frame, followed by
+              zero or more <xref target="CONTINUATION" format="none">CONTINUATION</xref> frames
+              containing the trailer-part, if present (see <xref target="HTTP"
+              section="6.5"/>).
             </li>
         </ol>
         <t>
@@ -2737,7 +2733,8 @@
           and any <xref target="CONTINUATION" format="none">CONTINUATION</xref> frames that might follow.
         </t>
         <t>
-          HTTP/2 uses DATA frames to carry message content.  The <tt>chunked</tt> transfer encoding defined in <xref target="RFC7230" section="4.1"/> MUST NOT be used in HTTP/2.
+          HTTP/2 uses DATA frames to carry message content.  The <tt>chunked</tt> transfer encoding
+          defined in <xref target="HTTP11" section="7.1"/> cannot be used in HTTP/2.
         </t>
         <t>
           Trailer fields are carried in a header block that also terminates the stream.  That is,
@@ -2780,7 +2777,7 @@
           <name>Upgrading from HTTP/2</name>
           <t>
             HTTP/2 removes support for the 101 (Switching Protocols) informational status code
-            (<xref target="RFC7231" section="6.2.2"/>).
+            (<xref target="HTTP" section="15.2.2"/>).
           </t>
           <t>
             The semantics of 101 (Switching Protocols) aren't applicable to a multiplexed protocol.
@@ -2803,10 +2800,9 @@
           <section anchor="PseudoHeaderFields">
             <name>Pseudo-Header Fields</name>
             <t>
-              While HTTP/1.x used the message start-line (see <xref target="RFC7230" section="3.1"/>)
-              to convey the target URI, the method of the request, and the
-              status code for the response, HTTP/2 uses special pseudo-header fields beginning with
-              ':' character (ASCII 0x3a) for this purpose.
+              While HTTP/1.x used the message start-line (see <xref target="HTTP11" section="2.1"/>)
+              to convey control data, HTTP/2 uses special pseudo-header fields beginning with ':'
+              character (ASCII 0x3a) for this purpose.
             </t>
             <t>
               Pseudo-header fields are not HTTP header fields.  Endpoints MUST NOT generate
@@ -2842,7 +2838,7 @@
             </t>
             <t>
               An intermediary transforming a HTTP/1.x message to HTTP/2 MUST remove connection-specific
-              header fields as discussed in <xref target="draft-ietf-httpbis-semantics-14" section="7.6.1"></xref>,
+              header fields as discussed in <xref target="HTTP" section="7.6.1"></xref>,
               or their messages will be treated by other HTTP/2 endpoints as <xref target="malformed">malformed</xref>.
             </t>
             <aside>
@@ -2862,7 +2858,7 @@
               <li>
                 <t>
                     The <tt>:method</tt> pseudo-header field includes the HTTP
-                    method (<xref target="RFC7231" section="4"/>).
+                    method (<xref target="HTTP" section="9"/>).
                 </t>
               </li>
               <li>
@@ -2883,10 +2879,10 @@
                     <tt>http</tt> or <tt>https</tt> schemed URIs.
                 </t>
                 <t>
-                    To ensure that the HTTP/1.1 request line can be reproduced accurately, this
+                    To ensure that HTTP/1.1 control data can be reproduced accurately, this
                     pseudo-header field MUST be omitted when translating from an HTTP/1.1 request
                     that has a request target in origin or asterisk form (see
-                    <xref target="RFC7230" section="5.3"/>). Clients that generate HTTP/2 requests
+                    <xref target="HTTP11" section="3.2"/>). Clients that generate HTTP/2 requests
                     directly SHOULD use the <tt>:authority</tt> pseudo-header
                     field instead of the <tt>Host</tt> header field. An
                     intermediary that converts an HTTP/2 request to HTTP/1.1 MUST create a <tt>Host</tt> header field if one is not present in a request by
@@ -2904,12 +2900,12 @@
                     <tt>:path</tt> pseudo-header field.
                 </t>
                 <t>
-                    This pseudo-header field MUST NOT be empty for <tt>http</tt>
-                    or <tt>https</tt> URIs; <tt>http</tt> or
-                    <tt>https</tt> URIs that do not contain a path component
+                    This pseudo-header field MUST NOT be empty for <tt>http</tt> or <tt>https</tt>
+                    URIs; <tt>http</tt> or <tt>https</tt> URIs that do not contain a path component
                     MUST include a value of '/'. The exception to this rule is an OPTIONS request
-                    for an <tt>http</tt> or <tt>https</tt>
-                    URI that does not include a path component; these MUST include a <tt>:path</tt> pseudo-header field with a value of '*' (see <xref target="RFC7230" section="5.3.4"/>).
+                    for an <tt>http</tt> or <tt>https</tt> URI that does not include a path
+                    component; these MUST include a <tt>:path</tt> pseudo-header field with a value
+                    of '*' (see <xref target="HTTP" section="7.1"/>).
                 </t>
               </li>
             </ul>
@@ -2927,7 +2923,7 @@
             <t>
               For HTTP/2 responses, a single <tt>:status</tt> pseudo-header
               field is defined that carries the HTTP status code field (see
-              <xref target="RFC7231" section="6"/>). This pseudo-header field MUST be included in all
+              <xref target="HTTP" section="15"/>). This pseudo-header field MUST be included in all
               responses; otherwise, the response is <xref target="malformed">malformed</xref>.
             </t>
             <t>
@@ -2938,11 +2934,12 @@
           <section anchor="CompressCookie">
             <name>Compressing the Cookie Header Field</name>
             <t>
-              The <xref target="COOKIE">Cookie header field</xref> uses a semi-colon (";") to delimit cookie-pairs (or "crumbs").
-              This header field doesn't follow the list construction rules in HTTP (see
-              <xref target="RFC7230" section="3.2.2"/>), which prevents cookie-pairs from
-              being separated into different name-value pairs.  This can significantly reduce
-              compression efficiency as individual cookie-pairs are updated.
+              The <xref target="COOKIE">Cookie header field</xref> uses a semi-colon (";") to
+              delimit cookie-pairs (or "crumbs").  This header field contains multiple values, but
+              does not use a COMMA (",") as a separator, which prevents cookie-pairs from being sent
+              on multiple field lines (see <xref target="HTTP" section="5.2"/>).  This can
+              significantly reduce compression efficiency as updates to individual cookie-pairs
+              would invalidate any field lines that are stored in the HPACK table.
             </t>
             <t>
               To allow for better compression efficiency, the Cookie header field MAY be split into
@@ -2976,7 +2973,7 @@
               A request or response that includes message content can include a <tt>content-length</tt> header field.  A request or response is also
               malformed if the value of a <tt>content-length</tt> header field
               does not equal the sum of the <xref target="DATA" format="none">DATA</xref> frame payload lengths that form the
-              content.  A response that is defined to have no content, as described in <xref target="RFC7230"/>, can have a non-zero
+              content.  A response that is defined to have no content, as described in <xref target="HTTP"/>, can have a non-zero
               <tt>content-length</tt> header field, even though no content is
               included in <xref target="DATA" format="none">DATA</xref> frames.
             </t>
@@ -3181,17 +3178,18 @@
           that server push is disabled.
         </t>
         <t>
-          Promised requests MUST be cacheable (see <xref target="RFC7231" section="4.2.3"/>), MUST be safe
-          (see <xref target="RFC7231" section="4.2.1"/>), and MUST NOT include any content. Clients that receive a
-          promised request that is not cacheable, that is not known to be safe, or that indicates the
-          presence of request content MUST reset the promised stream with a <xref target="StreamErrorHandler">stream error</xref> of type <xref target="PROTOCOL_ERROR" format="none">PROTOCOL_ERROR</xref>.
-          Note this could result in the promised stream being reset if the client does not recognize
-          a newly defined method as being safe.
+          Promised requests MUST be safe (see <xref target="HTTP" section="9.2.1"/>) and cacheable
+          (see <xref target="HTTP" section="9.2.3"/>), and MUST NOT include any content. Clients
+          that receive a promised request that is not cacheable, that is not known to be safe, or
+          that indicates the presence of request content MUST reset the promised stream with a <xref
+          target="StreamErrorHandler">stream error</xref> of type <xref target="PROTOCOL_ERROR"
+          format="none">PROTOCOL_ERROR</xref>.  Note this could result in the promised stream being
+          reset if the client does not recognize a newly defined method as being safe.
         </t>
         <t>
-          Pushed responses that are cacheable (see <xref target="RFC7234" section="3"/>) can be stored by the client, if it implements an HTTP
+          Pushed responses that are cacheable (see <xref target="CACHE" section="3"/>) can be stored by the client, if it implements an HTTP
           cache.  Pushed responses are considered successfully validated on the origin server (e.g.,
-          if the "no-cache" cache response directive is present; see <xref target="RFC7234" section="5.2.2"/>) while the stream identified by the
+          if the "no-cache" cache response directive is present; see <xref target="CACHE" section="5.2.2.4"/>) while the stream identified by the
           promised stream ID is still open.
         </t>
         <t>
@@ -3325,7 +3323,7 @@
       <section anchor="CONNECT">
         <name>The CONNECT Method</name>
         <t>
-          In HTTP/1.x, the pseudo-method CONNECT (<xref target="RFC7231" section="4.3.6"/>) is
+          In HTTP/1.x, the pseudo-method CONNECT (<xref target="HTTP" section="9.3.6"/>) is
           used to convert an HTTP connection into a tunnel to a remote host.
           CONNECT is primarily used with HTTP proxies to establish a TLS session with an origin
           server for the purposes of interacting with <tt>https</tt> resources.
@@ -3347,7 +3345,7 @@
           <li>
               The <tt>:authority</tt> pseudo-header field contains the host and port to
               connect to (equivalent to the authority-form of the request-target of CONNECT
-              requests (see <xref target="RFC7230" section="5.3"/>)).
+              requests; see <xref target="HTTP11" section="3.2.3"/>).
             </li>
         </ul>
         <t>
@@ -3357,7 +3355,7 @@
           A proxy that supports CONNECT establishes a <xref target="TCP">TCP connection</xref> to
           the server identified in the <tt>:authority</tt> pseudo-header field. Once
           this connection is successfully established, the proxy sends a <xref target="HEADERS" format="none">HEADERS</xref>
-          frame containing a 2xx series status code to the client, as defined in <xref target="RFC7231" section="4.3.6"/>.
+          frame containing a 2xx series status code to the client, as defined in <xref target="HTTP" section="9.3.6"/>.
         </t>
         <t>
           After the initial <xref target="HEADERS" format="none">HEADERS</xref> frame sent by each peer, all subsequent
@@ -3459,7 +3457,7 @@
           <t>
             A server that does not wish clients to reuse connections can indicate that it is not
             authoritative for a request by sending a 421 (Misdirected Request) status code in response
-            to the request (see <xref target="draft-ietf-httpbis-semantics-14" section="15.5.20"/>).
+            to the request (see <xref target="HTTP" section="15.5.20"/>).
           </t>
           <t>
             A client that is configured to use a proxy over HTTP/2 directs requests to that proxy
@@ -3605,9 +3603,9 @@
         <name>Server Authority</name>
         <t>
           HTTP/2 relies on the HTTP/1.1 definition of authority for determining whether a server is
-          authoritative in providing a given response (see <xref target="RFC7230" section="9.1"/>).
+          authoritative in providing a given response (see <xref target="HTTP" section="17.1"/>).
           This relies on local name resolution for the "http" URI scheme and the authenticated server
-          identity for the "https" scheme (see <xref target="RFC2818" section="3"/>).
+          identity for the "https" scheme.
         </t>
       </section>
       <section>
@@ -3652,7 +3650,7 @@
           that can be encoded will not alter header field parsing, carriage return (CR, ASCII 0xd),
           line feed (LF, ASCII 0xa), and the zero character (NUL, ASCII 0x0) might be exploited by
           an attacker if they are translated verbatim.  Any request or response that contains a
-          character not permitted in a header field value MUST be treated as <xref target="malformed">malformed</xref>.  Valid characters are defined by the <tt>field-content</tt> ABNF rule in <xref target="RFC7230" section="3.2"/>.
+          character not permitted in a header field value MUST be treated as <xref target="malformed">malformed</xref>.  Valid characters are defined by the <tt>field-content</tt> ABNF rule in <xref target="HTTP" section="5.5"/>.
         </t>
       </section>
       <section>
@@ -3777,7 +3775,7 @@
           Compression can allow an attacker to recover secret data when it is compressed in the same
           context as data under attacker control.  HTTP/2 enables compression of header fields
           (<xref target="HeaderBlock"/>); the following concerns also apply to the use of HTTP
-          compressed content-codings (<xref target="RFC7231" section="3.1.2.1"/>).
+          compressed content-codings (<xref target="HTTP" section="8.4.1"/>).
         </t>
         <t>
           There are demonstrable attacks on compression that exploit the characteristics of the web
@@ -4306,7 +4304,7 @@
         <name>PRI Method Registration</name>
         <t>
           This section registers the <tt>PRI</tt> method in the "HTTP Method
-          Registry" (<xref target="RFC7231" section="8.1"/>).
+          Registry" (<xref target="HTTP" section="18.2"/>).
         </t>
         <dl newline="false" spacing="normal">
           <dt>Method Name:</dt>
@@ -4336,7 +4334,7 @@
         <name>The h2c Upgrade Token</name>
         <t>
          This document registers the "h2c" upgrade token in the "HTTP
-         Upgrade Tokens" registry (<xref target="RFC7230" section="8.6"/>).
+         Upgrade Tokens" registry (<xref target="HTTP" section="18.10"/>).
         </t>
         <dl newline="false" spacing="normal">
           <dt>Value:</dt>
@@ -4400,16 +4398,6 @@
               </address>
             </author>
             <date month="March" year="1997"/>
-          </front>
-        </reference>
-        <reference anchor="RFC2818">
-          <front>
-            <title>
-            HTTP Over TLS
-            </title>
-            <seriesInfo name="RFC" value="2818"/>
-            <author initials="E." surname="Rescorla" fullname="Eric Rescorla"/>
-            <date month="May" year="2000"/>
           </front>
         </reference>
         <reference anchor="RFC3986">
@@ -4523,134 +4511,6 @@
               <organization>NIST</organization>
             </author>
             <date year="2013" month="July"/>
-          </front>
-        </reference>
-        <reference anchor="RFC7230">
-          <front>
-            <title>
-          Hypertext Transfer Protocol (HTTP/1.1): Message Syntax and Routing</title>
-            <seriesInfo name="RFC" value="7230"/>
-            <author fullname="Roy T. Fielding" initials="R." role="editor" surname="Fielding">
-              <organization abbrev="Adobe">Adobe Systems Incorporated</organization>
-              <address>
-                <email>fielding@gbiv.com</email>
-              </address>
-            </author>
-            <author fullname="Julian F. Reschke" initials="J. F." role="editor" surname="Reschke">
-              <organization abbrev="greenbytes">greenbytes GmbH</organization>
-              <address>
-                <email>julian.reschke@greenbytes.de</email>
-              </address>
-            </author>
-            <date month="June" year="2014"/>
-          </front>
-        </reference>
-        <reference anchor="RFC7231">
-          <front>
-            <title>
-          Hypertext Transfer Protocol (HTTP/1.1): Semantics and Content</title>
-            <seriesInfo name="RFC" value="7231"/>
-            <author fullname="Roy T. Fielding" initials="R." role="editor" surname="Fielding">
-              <organization abbrev="Adobe">Adobe Systems Incorporated</organization>
-              <address>
-                <email>fielding@gbiv.com</email>
-              </address>
-            </author>
-            <author fullname="Julian F. Reschke" initials="J. F." role="editor" surname="Reschke">
-              <organization abbrev="greenbytes">greenbytes GmbH</organization>
-              <address>
-                <email>julian.reschke@greenbytes.de</email>
-              </address>
-            </author>
-            <date month="June" year="2014"/>
-          </front>
-        </reference>
-        <reference anchor="RFC7232">
-          <front>
-            <title>Hypertext Transfer Protocol (HTTP/1.1): Conditional Requests</title>
-            <seriesInfo name="RFC" value="7232"/>
-            <author fullname="Roy T. Fielding" initials="R." role="editor" surname="Fielding">
-              <organization abbrev="Adobe">Adobe Systems Incorporated</organization>
-              <address>
-                <email>fielding@gbiv.com</email>
-              </address>
-            </author>
-            <author fullname="Julian F. Reschke" initials="J. F." role="editor" surname="Reschke">
-              <organization abbrev="greenbytes">greenbytes GmbH</organization>
-              <address>
-                <email>julian.reschke@greenbytes.de</email>
-              </address>
-            </author>
-            <date month="June" year="2014"/>
-          </front>
-        </reference>
-        <reference anchor="RFC7233">
-          <front>
-            <title>Hypertext Transfer Protocol (HTTP/1.1): Range Requests</title>
-            <seriesInfo name="RFC" value="7233"/>
-            <author initials="R." surname="Fielding" fullname="Roy T. Fielding" role="editor">
-              <organization abbrev="Adobe">Adobe Systems Incorporated</organization>
-              <address>
-                <email>fielding@gbiv.com</email>
-              </address>
-            </author>
-            <author initials="Y." surname="Lafon" fullname="Yves Lafon" role="editor">
-              <organization abbrev="W3C">World Wide Web Consortium</organization>
-              <address>
-                <email>ylafon@w3.org</email>
-              </address>
-            </author>
-            <author initials="J. F." surname="Reschke" fullname="Julian F. Reschke" role="editor">
-              <organization abbrev="greenbytes">greenbytes GmbH</organization>
-              <address>
-                <email>julian.reschke@greenbytes.de</email>
-              </address>
-            </author>
-            <date month="June" year="2014"/>
-          </front>
-        </reference>
-        <reference anchor="RFC7234">
-          <front>
-            <title>Hypertext Transfer Protocol (HTTP/1.1): Caching</title>
-            <seriesInfo name="RFC" value="7234"/>
-            <author initials="R." surname="Fielding" fullname="Roy T. Fielding" role="editor">
-              <organization abbrev="Adobe">Adobe Systems Incorporated</organization>
-              <address>
-                <email>fielding@gbiv.com</email>
-              </address>
-            </author>
-            <author fullname="Mark Nottingham" initials="M." role="editor" surname="Nottingham">
-              <organization>Akamai</organization>
-              <address>
-                <email>mnot@mnot.net</email>
-              </address>
-            </author>
-            <author initials="J. F." surname="Reschke" fullname="Julian F. Reschke" role="editor">
-              <organization abbrev="greenbytes">greenbytes GmbH</organization>
-              <address>
-                <email>julian.reschke@greenbytes.de</email>
-              </address>
-            </author>
-            <date month="June" year="2014"/>
-          </front>
-        </reference>
-        <reference anchor="RFC7235">
-          <front>
-            <title>Hypertext Transfer Protocol (HTTP/1.1): Authentication</title>
-            <seriesInfo name="RFC" value="7235"/>
-            <author initials="R." surname="Fielding" fullname="Roy T. Fielding" role="editor">
-              <organization abbrev="Adobe">Adobe Systems Incorporated</organization>
-              <address>
-                <email>fielding@gbiv.com</email>
-              </address>
-            </author>
-            <author initials="J. F." surname="Reschke" fullname="Julian F. Reschke" role="editor">
-              <organization abbrev="greenbytes">greenbytes GmbH</organization>
-              <address>
-                <email>julian.reschke@greenbytes.de</email>
-              </address>
-            </author>
-            <date month="June" year="2014"/>
           </front>
         </reference>
         <reference anchor="COOKIE">
@@ -4813,30 +4673,62 @@
             <date year="2019" month="January" />
           </front>
         </reference>
-        <reference anchor="draft-ietf-httpbis-semantics-14">
+        <reference anchor="HTTP">
           <front>
             <title>HTTP Semantics</title>
+            <seriesInfo name="Internet-Draft" value="draft-ietf-httpbis-semantics-14"/>
             <author fullname="Roy T. Fielding"
                     initials="R."
                     surname="Fielding"
-                    role="editor">
-              <organization>Adobe</organization>
-            </author>
+                    role="editor"/>
             <author fullname="Mark Nottingham"
                     initials="M."
                     surname="Nottingham"
-                    role="editor">
-              <organization>Fastly</organization>
-            </author>
+                    role="editor"/>
             <author fullname="Julian Reschke"
                     initials="J."
                     surname="Reschke"
-                    role="editor">
-              <organization abbrev="greenbytes">greenbytes GmbH</organization>
-            </author>
+                    role="editor"/>
             <date year="2021" month="January" day="13"/>
           </front>
-          <seriesInfo name="Internet-Draft" value="draft-ietf-httpbis-semantics-14"/>
+        </reference>
+        <reference anchor="HTTP11">
+          <front>
+            <title>HTTP/1.1</title>
+            <seriesInfo name="Internet-Draft" value="draft-ietf-httpbis-messaging-14"/>
+            <author fullname="Roy T. Fielding"
+                    initials="R."
+                    surname="Fielding"
+                    role="editor"/>
+            <author fullname="Mark Nottingham"
+                    initials="M."
+                    surname="Nottingham"
+                    role="editor"/>
+            <author fullname="Julian Reschke"
+                    initials="J."
+                    surname="Reschke"
+                    role="editor"/>
+            <date year="2021" month="January" day="13"/>
+          </front>
+        </reference>
+        <reference anchor="CACHE">
+          <front>
+            <title>HTTP Caching</title>
+            <seriesInfo name="Internet-Draft" value="draft-ietf-httpbis-cache-14"/>
+            <author fullname="Roy T. Fielding"
+                    initials="R."
+                    surname="Fielding"
+                    role="editor"/>
+            <author fullname="Mark Nottingham"
+                    initials="M."
+                    surname="Nottingham"
+                    role="editor"/>
+            <author fullname="Julian Reschke"
+                    initials="J."
+                    surname="Reschke"
+                    role="editor"/>
+            <date year="2021" month="January" day="13"/>
+          </front>
         </reference>
       </references>
     </references>


### PR DESCRIPTION
This is fairly cursory at this stage.  The goal is to get the document
functional first.  Next step is a full read-through for terminology.