### PR TITLE
Clarify that PRIORITY does not close streams.

### DIFF
--- a/draft-ietf-httpbis-http2bis.xml
+++ b/draft-ietf-httpbis-http2bis.xml
@@ -1032,11 +1032,12 @@
             type <xref target="PROTOCOL_ERROR" format="none">PROTOCOL_ERROR</xref>.
           </t>
           <t>
-            The first use of a new stream identifier implicitly closes all streams in the "idle"
-            state that might have been initiated by that peer with a lower-valued stream identifier.
-            For example, if a client sends a <xref target="HEADERS" format="none">HEADERS</xref> frame on stream 7 without ever
-            sending a frame on stream 5, then stream 5 transitions to the "closed" state when the
-            first frame for stream 7 is sent or received.
+            A <xref target="HEADERS" format="none">HEADERS</xref> frame will transition the client-initiated stream identified
+            by the stream identifier in frame header from "idle" to "open". A <xref target="PUSH_PROMISE" format="none">PUSH_PROMISE</xref>
+            frame will transition the server-initiated stream identified by the "Promised Stream ID" field in the frame payload. When
+            a stream transitions out of the "idle" state, all streams that might have been initiated by that peer with a lower-valued
+            stream identifier are implicitly transitioned to "closed". That is, an endpoint may skip a stream identifier, with the
+            effect being that the skipped stream is immediately closed.
           </t>
           <t>
             Stream identifiers cannot be reused.  Long-lived connections can result in an endpoint

--- a/draft-ietf-httpbis-http2bis.xml
+++ b/draft-ietf-httpbis-http2bis.xml
@@ -1033,8 +1033,8 @@
           </t>
           <t>
             A <xref target="HEADERS" format="none">HEADERS</xref> frame will transition the client-initiated stream identified
-            by the stream identifier in frame header from "idle" to "open". A <xref target="PUSH_PROMISE" format="none">PUSH_PROMISE</xref>
-            frame will transition the server-initiated stream identified by the "Promised Stream ID" field in the frame payload. When
+            by the stream identifier in the frame header from "idle" to "open". A <xref target="PUSH_PROMISE" format="none">PUSH_PROMISE</xref>
+            frame will transition the server-initiated stream identified by the "Promised Stream ID" field in the frame payload from "idle" to "reserved". When
             a stream transitions out of the "idle" state, all streams that might have been initiated by that peer with a lower-valued
             stream identifier are implicitly transitioned to "closed". That is, an endpoint may skip a stream identifier, with the
             effect being that the skipped stream is immediately closed.


### PR DESCRIPTION
This is a first stab at #759. I've gone for a minimal change here, simply clarifying that only HEADERS and PUSH_PROMISE frames have the effect of implicitly closing streams.

While I was writing this I did have a question that may need to be raised on-list: do HEADERS and PUSH_PROMISE only implicitly close streams if they are _accepted_? That is, if a client sends a HEADERS frame that triggers a stream error, does that HEADERS frame still implicitly close all streams with a lower stream ID that are in the "idle" state? This may also be worth clarifying.