### PR TITLE
Correct WG name

### DIFF
--- a/draft-ietf-httpbis-http2bis.xml
+++ b/draft-ietf-httpbis-http2bis.xml
@@ -36,7 +36,7 @@
       </address>
     </author>
     <area>Applications and Real-Time</area>
-    <workgroup>HTTPbis</workgroup>
+    <workgroup>HTTP</workgroup>
     <keyword>HTTP</keyword>
     <keyword>SPDY</keyword>
     <keyword>Web</keyword>


### PR DESCRIPTION
The name of the wg is "HTTP Working Group" or just "HTTP". The data tracker abbreviation is httpbis.