### PR TITLE
The core drafts are normative references

### DIFF
--- a/draft-ietf-httpbis-http2bis.xml
+++ b/draft-ietf-httpbis-http2bis.xml
@@ -4552,6 +4552,63 @@
             <date year="2011" month="April"/>
           </front>
         </reference>
+        <reference anchor="HTTP">
+          <front>
+            <title>HTTP Semantics</title>
+            <seriesInfo name="Internet-Draft" value="draft-ietf-httpbis-semantics-14"/>
+            <author fullname="Roy T. Fielding"
+                    initials="R."
+                    surname="Fielding"
+                    role="editor"/>
+            <author fullname="Mark Nottingham"
+                    initials="M."
+                    surname="Nottingham"
+                    role="editor"/>
+            <author fullname="Julian Reschke"
+                    initials="J."
+                    surname="Reschke"
+                    role="editor"/>
+            <date year="2021" month="January" day="13"/>
+          </front>
+        </reference>
+        <reference anchor="HTTP11">
+          <front>
+            <title>HTTP/1.1</title>
+            <seriesInfo name="Internet-Draft" value="draft-ietf-httpbis-messaging-14"/>
+            <author fullname="Roy T. Fielding"
+                    initials="R."
+                    surname="Fielding"
+                    role="editor"/>
+            <author fullname="Mark Nottingham"
+                    initials="M."
+                    surname="Nottingham"
+                    role="editor"/>
+            <author fullname="Julian Reschke"
+                    initials="J."
+                    surname="Reschke"
+                    role="editor"/>
+            <date year="2021" month="January" day="13"/>
+          </front>
+        </reference>
+        <reference anchor="CACHE">
+          <front>
+            <title>HTTP Caching</title>
+            <seriesInfo name="Internet-Draft" value="draft-ietf-httpbis-cache-14"/>
+            <author fullname="Roy T. Fielding"
+                    initials="R."
+                    surname="Fielding"
+                    role="editor"/>
+            <author fullname="Mark Nottingham"
+                    initials="M."
+                    surname="Nottingham"
+                    role="editor"/>
+            <author fullname="Julian Reschke"
+                    initials="J."
+                    surname="Reschke"
+                    role="editor"/>
+            <date year="2021" month="January" day="13"/>
+          </front>
+        </reference>
       </references>
       <references>
         <name>Informative References</name>
@@ -4702,63 +4759,6 @@
             <author initials="A." surname="Sullivan" fullname="A. Sullivan"/>
             <author initials="K." surname="Fujiwara" fullname="K. Fujiwara"/>
             <date year="2019" month="January" />
-          </front>
-        </reference>
-        <reference anchor="HTTP">
-          <front>
-            <title>HTTP Semantics</title>
-            <seriesInfo name="Internet-Draft" value="draft-ietf-httpbis-semantics-14"/>
-            <author fullname="Roy T. Fielding"
-                    initials="R."
-                    surname="Fielding"
-                    role="editor"/>
-            <author fullname="Mark Nottingham"
-                    initials="M."
-                    surname="Nottingham"
-                    role="editor"/>
-            <author fullname="Julian Reschke"
-                    initials="J."
-                    surname="Reschke"
-                    role="editor"/>
-            <date year="2021" month="January" day="13"/>
-          </front>
-        </reference>
-        <reference anchor="HTTP11">
-          <front>
-            <title>HTTP/1.1</title>
-            <seriesInfo name="Internet-Draft" value="draft-ietf-httpbis-messaging-14"/>
-            <author fullname="Roy T. Fielding"
-                    initials="R."
-                    surname="Fielding"
-                    role="editor"/>
-            <author fullname="Mark Nottingham"
-                    initials="M."
-                    surname="Nottingham"
-                    role="editor"/>
-            <author fullname="Julian Reschke"
-                    initials="J."
-                    surname="Reschke"
-                    role="editor"/>
-            <date year="2021" month="January" day="13"/>
-          </front>
-        </reference>
-        <reference anchor="CACHE">
-          <front>
-            <title>HTTP Caching</title>
-            <seriesInfo name="Internet-Draft" value="draft-ietf-httpbis-cache-14"/>
-            <author fullname="Roy T. Fielding"
-                    initials="R."
-                    surname="Fielding"
-                    role="editor"/>
-            <author fullname="Mark Nottingham"
-                    initials="M."
-                    surname="Nottingham"
-                    role="editor"/>
-            <author fullname="Julian Reschke"
-                    initials="J."
-                    surname="Reschke"
-                    role="editor"/>
-            <date year="2021" month="January" day="13"/>
           </front>
         </reference>
       </references>


### PR DESCRIPTION
Why these were not already is a mystery not worth investigating.  Fix it
instead.

Closes #777 while we're at it.