### PR TITLE
Hervé was the only one

### DIFF
--- a/draft-ietf-httpbis-http2bis.xml
+++ b/draft-ietf-httpbis-http2bis.xml
@@ -5099,7 +5099,7 @@
           </li>
         <li>
             Mark Nottingham, Julian Reschke, James Snell, Jeff Pinner, Mike Bishop,
-            and Herve Ruellan (Substantial editorial contributions).
+            and Hervé Ruellan (Substantial editorial contributions).
           </li>
         <li>
             Kari Hurtta, Tatsuhiro Tsujikawa, Greg Wilkins, Poul-Henning Kamp,


### PR DESCRIPTION
That is, in text we added.

I have an open question to rfc-interest@ regarding correcting the spelling of author names in references.  It's pretty clear [what Bodo thinks](https://www.bmoeller.de/) about the mangling we have done to his name in pursuit of ASCII and I'd like to correct that.  I didn't see any others that would appear in the final document (Hervé is there too, but only first initials survive).

Closes #791.