### PR TITLE
Update of "Prohibited TLS 1.2 Cipher Suites"

### DIFF
--- a/draft-ietf-httpbis-http2bis.xml
+++ b/draft-ietf-httpbis-http2bis.xml
@@ -4835,7 +4835,7 @@
       </references>
     </references>
     <section anchor="BadCipherSuites">
-      <name>Prohibited TLS 1.2 Cipher Suites</name>
+      <name>Prohibited TLS 1.2 Cipher Suites and PskKeyExchangeModes</name>
       <t>
         An HTTP/2 implementation MAY treat the negotiation of any of the following cipher suites
         with TLS 1.2 as a <xref target="ConnectionErrorHandler">connection error</xref> of type
@@ -5118,13 +5118,32 @@
         <li>TLS_PSK_WITH_AES_256_CCM</li>
         <li>TLS_PSK_WITH_AES_128_CCM_8</li>
         <li>TLS_PSK_WITH_AES_256_CCM_8</li>
+        <li>TLS_PSK_WITH_CHACHA20_POLY1305_SHA256</li>
+        <li>TLS_RSA_PSK_WITH_CHACHA20_POLY1305_SHA256</li>         
+      </ul>
+      <t>
+        An HTTP/2 implementation MAY treat the negotiation of any of the following cipher suites
+        with TLS 1.3 as a <xref target="ConnectionErrorHandler">connection error</xref> of type
+        <xref target="INADEQUATE_SECURITY" format="none">INADEQUATE_SECURITY</xref>:
+      </t>
+      <ul spacing="compact">
+        <li>TLS_SHA256_SHA256</li>
+        <li>TLS_SHA384_SHA384</li>
+      </ul>
+      <t>
+        An HTTP/2 implementation MAY treat the negotiation of any of the following PskKeyExchangeModes
+        with TLS 1.3 as a <xref target="ConnectionErrorHandler">connection error</xref> of type
+        <xref target="INADEQUATE_SECURITY" format="none">INADEQUATE_SECURITY</xref>:
+      </t>
+      <ul spacing="compact">
+        <li>psk_ke</li>
       </ul>
       <aside>
         <t>Note:
-          This list was assembled from the set of registered TLS cipher suites at the time of
-          writing.  This list includes those cipher suites that do not offer an ephemeral key
+          This list was assembled from the set of registered TLS cipher suites and PskKeyExchangeModes at the time of
+          writing.  This list includes those cipher suites and PskKeyExchangeMode that do not offer an ephemeral key
           exchange and those that are based on the TLS null, stream, or block cipher type (as
-          defined in <xref target="TLS12" section="6.2.3"/>).  Additional cipher suites with
+          defined in <xref target="TLS12" section="6.2.3"/>).  Additional cipher suites or PskKeyExchangeMode with
           these properties could be defined; these would not be explicitly prohibited.
         </t>
       </aside>


### PR DESCRIPTION
RFC 7540 is an awesome TLS 1.2 profile, a often recomment it for that purpose. 

As far as I know, there has been 4 new ciphersuites (2 for TLS 1.2 and 2 for TLS 1.3) and 1 PskKeyExchangeMode violating the null and ephemeral key exchange requirements mandated by RFC 7540.