### PR TITLE
Rewrite :authority description

### DIFF
--- a/draft-ietf-httpbis-http2bis.xml
+++ b/draft-ietf-httpbis-http2bis.xml
@@ -2926,15 +2926,28 @@
                     <tt>http</tt> or <tt>https</tt> schemed URIs.
                 </t>
                 <t>
-                    To ensure that HTTP/1.1 control data can be reproduced accurately, this
-                    pseudo-header field MUST be omitted when translating from an HTTP/1.1 request
-                    that has a request target in origin or asterisk form (see
-                    <xref target="HTTP11" section="3.2"/>). Clients that generate HTTP/2 requests
-                    directly SHOULD use the <tt>:authority</tt> pseudo-header
-                    field instead of the <tt>Host</tt> header field. An
-                    intermediary that converts an HTTP/2 request to HTTP/1.1 MUST create a <tt>Host</tt> header field if one is not present in a request by
-                    copying the value of the <tt>:authority</tt> pseudo-header
-                    field.
+                  Clients that generate HTTP/2 requests directly SHOULD use the <tt>:authority</tt>
+                  pseudo-header field instead of the <tt>Host</tt> header field.
+                </t>
+                <t>
+                  An intermediary that translates a request to HTTP/2 from HTTP/1.1, with an
+                  origin-, asterisk-, or authority-form request target (see <xref target="HTTP11"
+                  section="3.2"/>) MUST retain the <tt>Host</tt> header field and not add an
+                  <tt>:authority</tt> pseudo-header field.  For an absolute-form request target, the
+                  intermediary MUST obtain a value for the <tt>:authority</tt> pseudo-header field
+                  from the request URI and retain the value of the <tt>Host</tt> header field.
+
+                  <!-- The intermediary reject the request if they differ, but is this worth saying? -->
+                </t>
+                <t>
+                  An intermediary that translates a request to HTTP/1.1 from HTTP/2 MUST create a
+                  <tt>Host</tt> header field if one is not present in a request by copying the value
+                  of the <tt>:authority</tt> pseudo-header field.
+                </t>
+                <t>
+                  A request that was translated from absolute form could include both
+                  <tt>:authority</tt> and <tt>Host</tt>.  The value of the <tt>Host</tt> header
+                  field is ignored, as defined in <xref target="HTTP11" section="3.2.2"/>.
                 </t>
               </li>
               <li>


### PR DESCRIPTION
I think that this is better, but I'd like input on that.

I've tried to simplify this into 3 chunks:

* requests generated natively in HTTP/2
* translating HTTP/1.1 -> HTTP/2
* translating HTTP/2 -> HTTP/1.1

I realized that absolute-form was underserved here.  I could have
excluded it on the basis that it is special, but the rules seemed fairly
clear - at least regarding :authority, so that went in too.

The text now deals more fully with absolute form.  The previous text
really only hinted at the possibility that there might be two values.
This points to -messaging for what to do about those two values (hint:
:authority wins).

Closes #828.