### PR TITLE
:scheme is just the scheme

### DIFF
--- a/draft-ietf-httpbis-http2bis.xml
+++ b/draft-ietf-httpbis-http2bis.xml
@@ -2911,7 +2911,7 @@
               <li>
                 <t>
                   The <tt>:scheme</tt> pseudo-header field includes the scheme portion of the
-                  request.  The scheme is taken from the target URI (<xref target="RFC3986"
+                  request target.  The scheme is taken from the target URI (<xref target="RFC3986"
                   section="3.1"/>) when generating a request directly, or from the scheme of a
                   translated request (for example. see <xref target="HTTP11" section="3.3"/>).
                   Scheme is omitted for <xref target="CONNECT">CONNECT requests</xref>.

--- a/draft-ietf-httpbis-http2bis.xml
+++ b/draft-ietf-httpbis-http2bis.xml
@@ -2910,12 +2910,16 @@
               </li>
               <li>
                 <t>
-                    The <tt>:scheme</tt> pseudo-header field includes the scheme
-                    portion of the target URI (<xref target="RFC3986" section="3.1"/>).
+                  The <tt>:scheme</tt> pseudo-header field includes the scheme portion of the
+                  request.  The scheme is taken from the target URI (<xref target="RFC3986"
+                  section="3.1"/>) when generating a request directly, or from the scheme of a
+                  translated request (for example. see <xref target="HTTP11" section="3.3"/>).
+                  Scheme is omitted for <xref target="CONNECT">CONNECT requests</xref>.
                 </t>
-                <t><tt>:scheme</tt> is not restricted to <tt>http</tt> and <tt>https</tt> schemed URIs.  A
-                    proxy or gateway can translate requests for non-HTTP schemes, enabling the use
-                    of HTTP to interact with non-HTTP services.
+                <t>
+                  <tt>:scheme</tt> is not restricted to <tt>http</tt> and <tt>https</tt> schemed
+                  URIs.  A proxy or gateway can translate requests for non-HTTP schemes, enabling
+                  the use of HTTP to interact with non-HTTP services.
                 </t>
               </li>
               <li>


### PR DESCRIPTION
This is either taken from the target URI, or translated in (S3.3 of
-messaging).  Unless it is CONNECT where is is absent.

Closes #831.