### PR TITLE
SETTINGS_ENABLE_PUSH from the server

### DIFF
--- a/draft-ietf-httpbis-http2bis.xml
+++ b/draft-ietf-httpbis-http2bis.xml
@@ -2014,12 +2014,11 @@
                 target="PROTOCOL_ERROR" format="none">PROTOCOL_ERROR</xref>.
               </t>
               <t>
-                A server MUST NOT explicitly set this value to 1.  A server MAY choose to always
-                omit this setting when it sends a SETTINGS frame, but if a server does include a
-                value it MUST be 0.  A client MUST treat receipt of a SETTINGS frame with
-                SETTINGS_ENABLE_PUSH set to 1 as a <xref target="ConnectionErrorHandler">connection
-                error</xref> of type <xref target="PROTOCOL_ERROR"
-                format="none">PROTOCOL_ERROR</xref>.
+                A server MUST NOT explicitly set this value to 1.  A server MAY choose to omit this
+                setting when it sends a SETTINGS frame, but if a server does include a value it MUST
+                be 0.  A client MUST treat receipt of a SETTINGS frame with SETTINGS_ENABLE_PUSH set
+                to 1 as a <xref target="ConnectionErrorHandler">connection error</xref> of type
+                <xref target="PROTOCOL_ERROR" format="none">PROTOCOL_ERROR</xref>.
               </t>
             </dd>
             <dt anchor="SETTINGS_MAX_CONCURRENT_STREAMS">SETTINGS_MAX_CONCURRENT_STREAMS (0x3):</dt>

--- a/draft-ietf-httpbis-http2bis.xml
+++ b/draft-ietf-httpbis-http2bis.xml
@@ -1999,17 +1999,27 @@
             <dt anchor="SETTINGS_ENABLE_PUSH">SETTINGS_ENABLE_PUSH (0x2):</dt>
             <dd>
               <t>
-                  This setting can be used to disable <xref target="PushResources">server
-                  push</xref>. An endpoint MUST NOT send a <xref target="PUSH_PROMISE" format="none">PUSH_PROMISE</xref> frame if it
-                  receives this parameter set to a value of 0. An endpoint that has both set this
-                  parameter to 0 and had it acknowledged MUST treat the receipt of a
-                  <xref target="PUSH_PROMISE" format="none">PUSH_PROMISE</xref> frame as a <xref target="ConnectionErrorHandler">connection error</xref> of type
-                  <xref target="PROTOCOL_ERROR" format="none">PROTOCOL_ERROR</xref>.
+                This setting can be used to disable <xref target="PushResources">server
+                push</xref>. A server MUST NOT send a <xref target="PUSH_PROMISE"
+                format="none">PUSH_PROMISE</xref> frame if it receives this parameter set to a value
+                of 0. A client that has both set this parameter to 0 and had it acknowledged MUST
+                treat the receipt of a <xref target="PUSH_PROMISE" format="none">PUSH_PROMISE</xref>
+                frame as a <xref target="ConnectionErrorHandler">connection error</xref> of type
+                <xref target="PROTOCOL_ERROR" format="none">PROTOCOL_ERROR</xref>.
               </t>
               <t>
-                  The initial value is 1, which indicates that server push is permitted.  Any value
-                  other than 0 or 1 MUST be treated as a <xref target="ConnectionErrorHandler">connection error</xref> of type
-                  <xref target="PROTOCOL_ERROR" format="none">PROTOCOL_ERROR</xref>.
+                The initial value of SETTINGS_ENABLE_PUSH is 1, which indicates that server push is
+                permitted.  Any value other than 0 or 1 MUST be treated as a <xref
+                target="ConnectionErrorHandler">connection error</xref> of type <xref
+                target="PROTOCOL_ERROR" format="none">PROTOCOL_ERROR</xref>.
+              </t>
+              <t>
+                A server MUST NOT explicitly set this value to 1.  A server MAY choose to always
+                omit this setting when it sends a SETTINGS frame, but if a server does include a
+                value it MUST be 0.  A client MUST treat receipt of a SETTINGS frame with
+                SETTINGS_ENABLE_PUSH set to 1 as a <xref target="ConnectionErrorHandler">connection
+                error</xref> of type <xref target="PROTOCOL_ERROR"
+                format="none">PROTOCOL_ERROR</xref>.
               </t>
             </dd>
             <dt anchor="SETTINGS_MAX_CONCURRENT_STREAMS">SETTINGS_MAX_CONCURRENT_STREAMS (0x3):</dt>
@@ -3256,12 +3266,12 @@
           client, without any action taken by the server.
         </t>
         <t>
-          A client cannot push. Thus, servers MUST treat the receipt of a
-          <xref target="PUSH_PROMISE" format="none">PUSH_PROMISE</xref> frame as a <xref target="ConnectionErrorHandler">connection
-          error</xref> of type <xref target="PROTOCOL_ERROR" format="none">PROTOCOL_ERROR</xref>. Clients MUST reject any attempt to
-          change the <xref target="SETTINGS_ENABLE_PUSH" format="none">SETTINGS_ENABLE_PUSH</xref> setting to a value other than 0 by treating
-          the message as a <xref target="ConnectionErrorHandler">connection error</xref> of type
-          <xref target="PROTOCOL_ERROR" format="none">PROTOCOL_ERROR</xref>.
+          A client cannot push. Thus, servers MUST treat the receipt of a <xref
+          target="PUSH_PROMISE" format="none">PUSH_PROMISE</xref> frame as a <xref
+          target="ConnectionErrorHandler">connection error</xref> of type <xref
+          target="PROTOCOL_ERROR" format="none">PROTOCOL_ERROR</xref>. A server cannot set the <xref
+          target="SETTINGS_ENABLE_PUSH" format="none">SETTINGS_ENABLE_PUSH</xref> setting to a value
+          other than 0 (see <xref target="SettingValues"/>).
         </t>
         <section anchor="PushRequests">
           <name>Push Requests</name>


### PR DESCRIPTION
The previous text implied that a value of 1 was a problem,
which was somewhat in tension with the default being 1 and servers
mostly not sending the setting.  So clearly what was being checked by
client was the frame, not the value.  This changes to checking the
setting as it arrives, changes where that text lives.

Also, this changes from "endpoint" to "client" or "server" as
appropriate to match actual practice.

Closes #793.