### PR TITLE
Remove "parameters" from the IANA registry name

### DIFF
--- a/draft-ietf-httpbis-http2bis.xml
+++ b/draft-ietf-httpbis-http2bis.xml
@@ -3953,7 +3953,7 @@
       </t>
       <t>
         This document establishes a registry for frame types, settings, and error codes.  These new
-        registries appear in the new "Hypertext Transfer Protocol version 2 (HTTP/2) Parameters" section.
+        registries appear in the new "Hypertext Transfer Protocol version 2 (HTTP/2)" section.
       </t>
       <t>
         This document registers the <tt>HTTP2-Settings</tt> header field for


### PR DESCRIPTION
Closes #829.