### PR TITLE
Do the obsoletes thing properly

### DIFF
--- a/draft-ietf-httpbis-http2bis.xml
+++ b/draft-ietf-httpbis-http2bis.xml
@@ -51,14 +51,14 @@
       </t>
       <t>
         This specification is an alternative to, but does not obsolete, the HTTP/1.1 message syntax.
-        HTTP's existing semantics remain unchanged.
+        HTTP's existing semantics remain unchanged.  This document obsoletes RFC 7540 and RFC 8740.
       </t>
     </abstract>
     <note title="Discussion Venues" removeInRFC="true">
       <t>
-        Discussion of this document takes place on the
-        HTTPBIS Working Group mailing list (ietf-http-wg@w3.org),
-        which is archived at <eref target="https://lists.w3.org/Archives/Public/ietf-http-wg/"/>.
+        Discussion of this document takes place on the HTTPBIS Working Group mailing list
+        (ietf-http-wg@w3.org), which is archived at <eref
+        target="https://lists.w3.org/Archives/Public/ietf-http-wg/"/>.
       </t>
       <t>
         Source for this draft and an issue tracker can be found at
@@ -66,6 +66,7 @@
       </t>
     </note>
   </front>
+
   <middle>
     <section anchor="intro">
       <name>Introduction</name>
@@ -103,6 +104,10 @@
       <t>
         Finally, HTTP/2 also enables more efficient processing of messages through use of binary
         message framing.
+      </t>
+      <t>
+        This document obsoletes <xref target="RFC7540">RFC 7540</xref> and <xref
+        target="RFC8740">RFC 8740</xref>.
       </t>
     </section>
     <section anchor="Overview">
@@ -4693,8 +4698,32 @@
           </front>
         </reference>
       </references>
+
       <references>
         <name>Informative References</name>
+
+        <reference  anchor="RFC7540">
+          <front>
+            <title>Hypertext Transfer Protocol Version 2 (HTTP/2)</title>
+            <seriesInfo name="RFC" value="7540"/>
+            <seriesInfo name="DOI" value="10.17487/RFC7540"/>
+            <author initials="M." surname="Belshe" fullname="M. Belshe"/>
+            <author initials="R." surname="Peon" fullname="R. Peon"/>
+            <author initials="M." surname="Thomson" fullname="M. Thomson" role="editor"/>
+            <date year="2015" month="May" />
+          </front>
+        </reference>
+        <reference anchor="RFC8740">
+          <front>
+            <title>Using TLS 1.3 with HTTP/2</title>
+            <seriesInfo name="RFC" value="8740"/>
+            <seriesInfo name="DOI" value="10.17487/RFC8740"/>
+            <author initials="D." surname="Benjamin" fullname="D. Benjamin"/>
+            <date year="2020" month="February" />
+          </front>
+        </reference>
+
+
         <reference anchor="RFC7323">
           <front>
             <title>


### PR DESCRIPTION
The current rules state that you need to include text in abstract and
introduction.

This will result in redundant entries for the specs with other changes that add 7540 references, but we can sort that out later. 

Closes #842.