### PR TITLE
xml2rfc workaround

### DIFF
--- a/draft-ietf-httpbis-http2bis.xml
+++ b/draft-ietf-httpbis-http2bis.xml
@@ -5236,10 +5236,10 @@
         <li>
             Mike Bishop (Extensibility).
           </li>
-        <li>
-            Mark Nottingham, Julian Reschke, James Snell, Jeff Pinner, Mike Bishop,
-            and Hervé Ruellan (Substantial editorial contributions).
-          </li>
+        <li><t>
+          Mark Nottingham, Julian Reschke, James Snell, Jeff Pinner, Mike Bishop,
+          and <contact fullname="Hervé Ruellan"/> (Substantial editorial contributions).
+        </t></li>
         <li>
             Kari Hurtta, Tatsuhiro Tsujikawa, Greg Wilkins, Poul-Henning Kamp,
             and Jonathan Thackray.


### PR DESCRIPTION
xml2rfc is overly pedantic about non-ASCII text.  The result in this
case was that Hervé's name was being mangled to include a literal
`&#233;`, even in a text format (where HTML character references make no
sense).  To avoid that, this is what is necessary.  Of course, this
makes the rendering of the document with the RFC Editor stylesheet look
awful.  I've decided not to concern myself with that part though; the
stylesheet we use is fine.