### PR TITLE
Experimental begone

### DIFF
--- a/draft-ietf-httpbis-http2bis.xml
+++ b/draft-ietf-httpbis-http2bis.xml
@@ -3757,11 +3757,10 @@
       <section anchor="iana-frames">
         <name>Frame Type Registry</name>
         <t>
-          This document establishes a registry for HTTP/2 frame type codes.  The "HTTP/2 Frame
-          Type" registry manages an 8-bit space.  The "HTTP/2 Frame Type" registry operates under
-          either of the <xref target="RFC5226">"IETF Review" or "IESG Approval" policies</xref> for
-          values between 0x00 and 0xef, with values between 0xf0 and 0xff being reserved for
-          Experimental Use.
+          This document establishes a registry for HTTP/2 frame type codes.  The "HTTP/2 Frame Type"
+          registry manages an 8-bit space.  The "HTTP/2 Frame Type" registry operates under either
+          of the <xref target="RFC8126" section="4.8">"IETF Review"</xref> or <xref target="RFC8126"
+          section="4.10">"IESG Approval"</xref> policies.
         </t>
         <t>
           New entries in this registry require the following information:
@@ -3871,8 +3870,8 @@
         <name>Settings Registry</name>
         <t>
           This document establishes a registry for HTTP/2 settings.  The "HTTP/2 Settings" registry
-          manages a 16-bit space.  The "HTTP/2 Settings" registry operates under the <xref target="RFC5226">"Expert Review" policy</xref> for values in the range from 0x0000 to
-          0xefff, with values between and 0xf000 and 0xffff being reserved for Experimental Use.
+          manages a 16-bit space.  The "HTTP/2 Settings" registry operates under the <xref
+          target="RFC8126" section="4.5">"Expert Review" policy</xref>.
         </t>
         <t>
           New registrations are advised to provide the following information:
@@ -3964,7 +3963,7 @@
         <t>
           This document establishes a registry for HTTP/2 error codes.  The "HTTP/2 Error Code"
           registry manages a 32-bit space.  The "HTTP/2 Error Code" registry operates under the
-          <xref target="RFC5226">"Expert Review" policy</xref>.
+          <xref target="RFC8126" section="4.5">"Expert Review" policy</xref>.
         </t>
         <t>
           Registrations for error codes are required to include a description of the error code.  An
@@ -4232,14 +4231,16 @@
             <date year="2006" month="October"/>
           </front>
         </reference>
-        <reference anchor="RFC5226">
+        <reference anchor="RFC8126">
           <front>
             <title>Guidelines for Writing an IANA Considerations Section in RFCs</title>
             <seriesInfo name="BCP" value="26"/>
-            <seriesInfo name="RFC" value="5226"/>
-            <author initials="T." surname="Narten" fullname="T. Narten"/>
-            <author initials="H." surname="Alvestrand" fullname="H. Alvestrand"/>
-            <date year="2008" month="May"/>
+            <seriesInfo name="RFC" value="8126"/>
+            <seriesInfo name="DOI" value="10.17487/RFC8126"/>
+            <author initials="M." surname="Cotton" fullname="Michelle Cotton"/>
+            <author initials="B." surname="Leiba" fullname="Barry Leiba"/>
+            <author initials="R." surname="Narten" fullname="Thomas Narten"/>
+            <date year="2017" month="June"/>
           </front>
         </reference>
         <reference anchor="RFC5234">

--- a/draft-ietf-httpbis-http2bis.xml
+++ b/draft-ietf-httpbis-http2bis.xml
@@ -4902,6 +4902,10 @@
           The HTTP/1.1 Upgrade mechanism is no longer specified in this document. It was never widely deployed,
           with plaintext HTTP/2 users choosing to use the prior-knowledge implementation instead.
         </li>
+        <li>
+          The ranges of codepoints for settings and frame types that were reserved for "Experimental
+          Use" are now available for general use.
+        </li>
       </ul>
     </section>
     <section numbered="false">


### PR DESCRIPTION
This is part of the fix for #826.  This part removes the experimental range for frame types and settings.

Also updates to use section references to RFC 8126, which replaces RFC 5226.