### PR TITLE
Add details regarding removal of connection-specific fields.

### DIFF
--- a/draft-ietf-httpbis-http2bis.xml
+++ b/draft-ietf-httpbis-http2bis.xml
@@ -3474,6 +3474,13 @@
           an attacker if they are translated verbatim.  Any request or response that contains a
           character not permitted in a field value MUST be treated as <xref target="malformed">malformed</xref>.  Valid characters are defined by the <tt>field-content</tt> ABNF rule in <xref target="HTTP" section="5.5"/>.
         </t>
+        <t>
+          An intermediary that receives any field that requires removal before forwarding
+          (see <xref target="HTTP" section="7.6.1" />) MUST remove or replace those header fields when
+          forwarding messages. Additionally, intermediaries should take care when forwarding messages
+          containing Content-Length fields to ensure that the message is <xref target="malformed">well-formed</xref>.
+          This ensures that if the message is translated into HTTP/1.1 at any point the framing will be correct.
+        </t>
       </section>
       <section>
         <name>Cacheability of Pushed Responses</name>


### PR DESCRIPTION
Here is some draft text. In principle we don't need any of this at all: as this text shows, all of the relevant guidance is already present in both semantics and H2. I've elected to throw up some possible text, but if we wanted to say that some or all of it is entirely redundant with existing specifications then I'm happy to do so.

Fixes #789.
Fixes #851.