### PR TITLE
Improve on fix for #815

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ venv/
 archive.json
 report.xml
 /lib
+/.idea/

--- a/draft-ietf-httpbis-http2bis.xml
+++ b/draft-ietf-httpbis-http2bis.xml
@@ -2587,13 +2587,13 @@
           <name>HTTP Fields</name>
           <t>
             HTTP fields carry information as a series of field lines, which are key-value pairs. For a listing of
-            registered HTTP fields, see the "Hypertext Transfer Protocol (HTTP) Field Name Registry" registry maintained at <eref target="https://www.iana.org/assignments/http-fields/"/>.
+            registered HTTP fields, see the "Hypertext Transfer Protocol (HTTP) Field Name Registry"
+            registry maintained at <eref target="https://www.iana.org/assignments/http-fields/"/>.
           </t>
           <t>
             Field names are strings of ASCII characters that are compared in a case-insensitive
             fashion. Field names MUST be converted to lowercase when constructing a HTTP/2
-            message. A request or response containing an uppercase character ('A' to 'Z', ASCII 0x41
-            to 0x5a) in a field name MUST be treated as <xref target="malformed">malformed</xref>.
+            message.
           </t>
           <t>
             HPACK is capable of carrying field names or values that are not valid in HTTP.  Though
@@ -2601,9 +2601,9 @@
           </t>
           <ul>
             <li>
-              A field name MUST NOT contain characters in the range 0x00-0x20 or 0x7F-0xFF (both
-              ranges inclusive).  This limits field names to visible ASCII characters, other than
-              ASCII SP (0x20).
+              A field name MUST NOT contain characters in the range 0x00-0x20, 0x41-0x5A or 0x7F-0xFF
+              (all ranges inclusive).  This limits field names to visible ASCII characters, other than
+              ASCII SP (0x20) and uppercase characters ('A' to 'Z', ASCII 0x41 to 0x5a).
             </li>
             <li>
               With the exception of <xref target="PseudoHeaderFields">pseudo-header fields</xref>,
@@ -2624,6 +2624,11 @@
             be treated as <xref target="malformed">malformed</xref>.  In particular, an intermediary
             that does not process fields when forwarding messages MUST NOT forward fields that
             contain any of the values that are listed as prohibited above.
+          </t>
+          <t>
+            In addition to the minimum validation defined above, non pseudo-header fields
+            that violate the HTTP ABNF grammar from <xref target="HTTP" section="5"/> MAY also be
+            treated as <xref target="malformed">malformed</xref>.
           </t>
           <t>
             Field values that are not valid according to the definition of the corresponding field

--- a/draft-ietf-httpbis-http2bis.xml
+++ b/draft-ietf-httpbis-http2bis.xml
@@ -2587,13 +2587,13 @@
           <name>HTTP Fields</name>
           <t>
             HTTP fields carry information as a series of field lines, which are key-value pairs. For a listing of
-            registered HTTP fields, see the "Hypertext Transfer Protocol (HTTP) Field Name Registry"
-            registry maintained at <eref target="https://www.iana.org/assignments/http-fields/"/>.
+            registered HTTP fields, see the "Hypertext Transfer Protocol (HTTP) Field Name Registry" registry maintained at <eref target="https://www.iana.org/assignments/http-fields/"/>.
           </t>
           <t>
             Field names are strings of ASCII characters that are compared in a case-insensitive
             fashion. Field names MUST be converted to lowercase when constructing a HTTP/2
-            message.
+            message. A request or response containing an uppercase character ('A' to 'Z', ASCII 0x41
+            to 0x5a) in a field name MUST be treated as <xref target="malformed">malformed</xref>.
           </t>
           <t>
             HPACK is capable of carrying field names or values that are not valid in HTTP.  Though
@@ -2601,9 +2601,9 @@
           </t>
           <ul>
             <li>
-              A field name MUST NOT contain characters in the range 0x00-0x20, 0x41-0x5A or 0x7F-0xFF
-              (all ranges inclusive).  This limits field names to visible ASCII characters, other than
-              ASCII SP (0x20) and uppercase characters ('A' to 'Z', ASCII 0x41 to 0x5a).
+              A field name MUST NOT contain characters in the range 0x00-0x20 or 0x7F-0xFF (both
+              ranges inclusive).  This limits field names to visible ASCII characters, other than
+              ASCII SP (0x20).
             </li>
             <li>
               With the exception of <xref target="PseudoHeaderFields">pseudo-header fields</xref>,


### PR DESCRIPTION
Improve on #846 that fixes for #815 by adding extra clarity:
 + The validation for uppercase characters is no longer listed separately
 + It is clearly stated that violations of the full HTTP ABNF field definition MAY be treated as *Malformed*