### PR TITLE
Alternate for #866 Invalid field handling

### DIFF
--- a/draft-ietf-httpbis-http2bis.xml
+++ b/draft-ietf-httpbis-http2bis.xml
@@ -2618,12 +2618,20 @@
               A field value MUST NOT start or end with an ASCII whitespace character (ASCII SP or
               HTAB, 0x20 or 0x9).
             </li>
+            <li>
+              Optionally, a field name or field value MAY NOT contain characters disallowed
+              by <xref target="HTTP" section="5.1"/> and <xref target="HTTP" section="5.5"/>,
+              respectively.
+            </li>
           </ul>
           <t>
             A request or response that contains a field that violates any of these conditions MUST
-            be treated as <xref target="malformed">malformed</xref>.  In particular, an intermediary
-            that does not process fields when forwarding messages MUST NOT forward fields that
-            contain any of the values that are listed as prohibited above.
+            be treated as <xref target="malformed">malformed</xref>. If the message is a request,
+            then the recipient SHOULD send a response using the 400 (Bad Request) status code
+            <xref target="HTTP" section="15.5.1"/> if possible, prior to closing or resetting the
+            stream. In particular, an intermediary that does not process fields when forwarding
+            messages MUST NOT forward fields that contain any of the values that are listed as
+            prohibited above.
           </t>
           <t>
             Field values that are not valid according to the definition of the corresponding field
@@ -2824,9 +2832,10 @@
             <name>Malformed Requests and Responses</name>
             <t>
               A malformed request or response is one that is an otherwise valid sequence of HTTP/2
-              frames but is invalid due to the presence of extraneous frames, prohibited
-              fields or pseudo-header fields, the absence of mandatory fields or pseudo-header fields,
-              or the inclusion of uppercase field names.
+              frames but is invalid due to the presence of extraneous frames, prohibited fields or
+              pseudo-header fields, the absence of mandatory fields or pseudo-header fields, the
+              inclusion of uppercase field names, or invalid field names and/or values (in certain
+              circumstances; see <xref target="HttpHeaders"/>).
             </t>
             <t>
               A request or response that includes message content can include a <tt>content-length</tt> header field.  A request or response is also


### PR DESCRIPTION
Removed distinction between treating as malformed and sending a 400, since treating as malformed already
allows a 400 to be sent.

This uses some text from #866 and replaces that PR.