### PR TITLE
A leaner acknowledgments section

### DIFF
--- a/draft-ietf-httpbis-http2bis.xml
+++ b/draft-ietf-httpbis-http2bis.xml
@@ -4965,51 +4965,11 @@
       </t>
     </section>
     <section numbered="false">
-      <name>Acknowledgements</name>
+      <name>Acknowledgments</name>
       <t>
-        This document includes substantial input from the following individuals:
-      </t>
-      <ul spacing="normal">
-        <li>
-            Adam Langley, Wan-Teh Chang, Jim Morrison, Mark Nottingham, Alyssa Wilk, Costin
-            Manolache, William Chan, Vitaliy Lvin, Joe Chan, Adam Barth, Ryan Hamilton, Gavin
-            Peters, Kent Alstad, Kevin Lindsay, Paul Amer, Fan Yang, and Jonathan Leighton (SPDY
-            contributors).
-          </li>
-        <li>
-            Gabriel Montenegro and Willy Tarreau (Upgrade mechanism).
-          </li>
-        <li>
-            William Chan, Salvatore Loreto, Osama Mazahir, Gabriel Montenegro, Jitu Padhye, Roberto
-            Peon, and Rob Trace (Flow control).
-          </li>
-        <li>
-            Mike Bishop (Extensibility).
-          </li>
-        <li><t>
-          Mark Nottingham, Julian Reschke, James Snell, Jeff Pinner, Mike Bishop,
-          and <contact fullname="Hervé Ruellan"/> (Substantial editorial contributions).
-        </t></li>
-        <li>
-            Kari Hurtta, Tatsuhiro Tsujikawa, Greg Wilkins, Poul-Henning Kamp,
-            and Jonathan Thackray.
-          </li>
-        <li>
-            Alexey Melnikov, who was an editor of this document in 2013.
-        </li>
-        <li>
-          David Benjamin, who was author of RFC 8740, the contents of which are integrated here.
-        </li>
-      </ul>
-      <t>
-        A substantial proportion of Martin's contribution was supported by Microsoft during his
-        employment there.
-      </t>
-      <t>
-        The Japanese HTTP/2 community provided invaluable contributions,
-        including a number of implementations as well as numerous technical and
-        editorial contributions.
-      </t>
+        Credit for non-trivial input to this document is owed to a large number of people who have
+        contributed to the HTTP working group over the years.  <xref target="RFC7540"/> contains a
+        more extensive list of people that deserve acknowledgment for their contributions.</t>
     </section>
   </back>
 </rfc>


### PR DESCRIPTION
Now without the "e" too.

For this revision I would consider Mark Nottingham, Willy Tarreau, and
Greg Wilkins for direct acknowledgment, but as they are all listed in
RFC 7540 it seems safer to avoid specific mentions here.

Closes #862.