### PR TITLE
A simple, but manual, s/bit \d/the XXX Flag/

### DIFF
--- a/draft-ietf-httpbis-http2bis.xml
+++ b/draft-ietf-httpbis-http2bis.xml
@@ -1408,12 +1408,12 @@ DATA Frame {
         <dl newline="false" spacing="normal">
           <dt>PADDED (0x8):</dt>
           <dd>
-              When set, bit 3 indicates that the Pad Length field and any padding that it describes
+              When set, the PADDED Flag indicates that the Pad Length field and any padding that it describes
               are present.
             </dd>
           <dt>END_STREAM (0x1):</dt>
           <dd>
-              When set, bit 0 indicates that this frame is the last that the endpoint will send for
+              When set, the END_STREAM Flag indicates that this frame is the last that the endpoint will send for
               the identified stream.  Setting this flag causes the stream to enter one of <xref target="StreamStates">the "half-closed" states or the "closed" state</xref>.
             </dd>
         </dl>
@@ -1513,21 +1513,21 @@ HEADERS Frame {
           <dt>PRIORITY (0x20):</dt>
           <dd>
             <t>
-              When set, bit 5 indicates that the Exclusive, Stream Dependency, and Weight
+              When set, the PRIORITY Flag indicates that the Exclusive, Stream Dependency, and Weight
               fields are present.
             </t>
           </dd>
           <dt>PADDED (0x8):</dt>
           <dd>
             <t>
-                When set, bit 3 indicates that the Pad Length field and any padding that it
+                When set, the PADDED Flag indicates that the Pad Length field and any padding that it
                 describes are present.
             </t>
           </dd>
           <dt>END_HEADERS (0x4):</dt>
           <dd>
             <t>
-                When set, bit 2 indicates that this frame contains an entire <xref target="FieldBlock">field block</xref> and is not followed by any
+                When set, the END_HEADERS Flag indicates that this frame contains an entire <xref target="FieldBlock">field block</xref> and is not followed by any
                 <xref target="CONTINUATION" format="none">CONTINUATION</xref> frames.
             </t>
             <t>
@@ -1540,7 +1540,7 @@ HEADERS Frame {
           <dt>END_STREAM (0x1):</dt>
           <dd>
             <t>
-                When set, bit 0 indicates that the <xref target="FieldBlock">field block</xref> is
+                When set, the END_STREAM Flag indicates that the <xref target="FieldBlock">field block</xref> is
                 the last that the endpoint will send for the identified stream.
             </t>
             <t>
@@ -1715,7 +1715,7 @@ RST_STREAM Frame {
         <dl newline="false" spacing="normal">
           <dt>ACK (0x1):</dt>
           <dd>
-              When set, bit 0 indicates that this frame acknowledges receipt and application of the
+              When set, the ACK Flag indicates that this frame acknowledges receipt and application of the
               peer's SETTINGS frame.  When this bit is set, the frame payload of the SETTINGS frame MUST
               be empty.  Receipt of a SETTINGS frame with the ACK flag set and a length field value
               other than 0 MUST be treated as a <xref target="ConnectionErrorHandler">connection
@@ -1957,14 +1957,14 @@ PUSH_PROMISE Frame {
           <dt>PADDED (0x8):</dt>
           <dd>
             <t>
-                When set, bit 3 indicates that the Pad Length field and any padding that it
+                When set, the PADDED Flag indicates that the Pad Length field and any padding that it
                 describes are present.
             </t>
           </dd>
           <dt>END_HEADERS (0x4):</dt>
           <dd>
             <t>
-                When set, bit 2 indicates that this frame contains an entire <xref target="FieldBlock">field block</xref> and is not followed by any
+                When set, the END_HEADERS Flag indicates that this frame contains an entire <xref target="FieldBlock">field block</xref> and is not followed by any
                 <xref target="CONTINUATION" format="none">CONTINUATION</xref> frames.
             </t>
             <t>
@@ -2063,7 +2063,7 @@ PING Frame {
         <dl newline="false" spacing="normal">
           <dt>ACK (0x1):</dt>
           <dd>
-              When set, bit 0 indicates that this PING frame is a PING response.  An endpoint MUST
+              When set, the ACK Flag indicates that this PING frame is a PING response.  An endpoint MUST
               set this flag in PING responses.  An endpoint MUST NOT respond to PING frames
               containing this flag.
             </dd>
@@ -2443,11 +2443,11 @@ CONTINUATION Frame {
           <dt>END_HEADERS (0x4):</dt>
           <dd>
             <t>
-                When set, bit 2 indicates that this frame ends a <xref target="FieldBlock">field
+                When set, the END_HEADERS Flag indicates that this frame ends a <xref target="FieldBlock">field
                 block</xref>.
             </t>
             <t>
-                If the END_HEADERS bit is not set, this frame MUST be followed by another
+                If the END_HEADERS Flag is not set, this frame MUST be followed by another
                 CONTINUATION frame.  A receiver MUST treat the receipt of any other type of frame or
                 a frame on a different stream as a <xref target="ConnectionErrorHandler">connection
                 error</xref> of type <xref target="PROTOCOL_ERROR" format="none">PROTOCOL_ERROR</xref>.


### PR DESCRIPTION
Though I had to be careful with text on TCP, which has FIN and RST bits
we don't want to touch.