### PR TITLE
Update ECC reference

### DIFF
--- a/draft-ietf-httpbis-http2bis.xml
+++ b/draft-ietf-httpbis-http2bis.xml
@@ -3491,7 +3491,7 @@ cookie: e=f
             Implementations MUST support ephemeral key exchange sizes of at least 2048 bits for
             cipher suites that use ephemeral finite field Diffie-Hellman (DHE) <xref
             target="TLS13"/> and 224 bits for cipher suites that use ephemeral elliptic curve
-            Diffie-Hellman (ECDHE) <xref target="RFC4492"/>. Clients MUST accept DHE sizes of up to
+            Diffie-Hellman (ECDHE) <xref target="RFC8422"/>. Clients MUST accept DHE sizes of up to
             4096 bits. Endpoints MAY treat negotiation of key sizes smaller than the lower limits
             as a <xref target="ConnectionErrorHandler">connection error</xref> of type <xref
             target="INADEQUATE_SECURITY" format="none">INADEQUATE_SECURITY</xref>.
@@ -4592,18 +4592,17 @@ cookie: e=f
             <date year="2012" month="April"/>
           </front>
         </reference>
-        <reference anchor="RFC4492">
+        <reference anchor="RFC8422">
           <front>
             <title>
-            Elliptic Curve Cryptography (ECC) Cipher Suites for Transport Layer Security (TLS)
+              Elliptic Curve Cryptography (ECC) Cipher Suites
+              for Transport Layer Security (TLS) Versions 1.2 and Earlier
             </title>
-            <seriesInfo name="RFC" value="4492"/>
-            <author initials="S." surname="Blake-Wilson" fullname="S. Blake-Wilson"/>
-            <author initials="N." surname="Bolyard" fullname="N. Bolyard"/>
-            <author initials="V." surname="Gupta" fullname="V. Gupta"/>
-            <author initials="C." surname="Hawk" fullname="C. Hawk"/>
-            <author initials="B." surname="Moeller" fullname="B. Moeller"/>
-            <date year="2006" month="May"/>
+            <seriesInfo name="RFC" value="8422"/>
+            <author initials="Y." surname="Nir" fullname="Yoav Nir"/>
+            <author initials="S." surname="Josefsson" fullname="Simon Josefsson"/>
+            <author initials="M." surname="Pegourie-Gonnard" fullname="Manuel Pegourie-Gonnard"/>
+            <date year="2018" month="August"/>
           </front>
         </reference>
         <reference anchor="PRIVACY">


### PR DESCRIPTION
RFC 4492 is obsolete.

This is a TLS 1.2 section, so it is OK to refer to the TLS 1.2 document here.