### PR TITLE
Add some structure to the undifferentiated mess

### DIFF
--- a/draft-ietf-httpbis-http2bis.xml
+++ b/draft-ietf-httpbis-http2bis.xml
@@ -419,9 +419,12 @@
 HTTP Frame {
   Length (24),
   Type (8),
+
   Flags (8),
+
   Reserved (1),
   Stream Identifier (31),
+
   Frame Payload (..),
 }
 ]]></artwork>
@@ -1331,12 +1334,15 @@ HTTP Frame {
 DATA Frame {
   Length (24),
   Type (8) = 0,
+
   Unused Flags (4),
   PADDED Flag (1),
   Unused Flags (2),
   END_STREAM Flag (1),
+
   Reserved (1),
   Stream Identifier (31),
+
   [Pad Length (8)],
   Data (..),
   Padding (..),
@@ -1422,6 +1428,7 @@ DATA Frame {
 HEADERS Frame {
   Length (24),
   Type (8) = 1,
+
   Unused Flags (2),
   PRIORITY Flag (1),
   Unused Flag (1),
@@ -1429,8 +1436,10 @@ HEADERS Frame {
   END_HEADERS Flag (1),
   Unused Flag (1),
   END_STREAM Flag (1),
+
   Reserved (1),
   Stream Identifier (31),
+
   [Pad Length (8)],
   [Exclusive (1)],
   [Stream Dependency (31)],
@@ -1548,9 +1557,12 @@ HEADERS Frame {
 PRIORITY Frame {
   Length (24),
   Type (8) = 2,
+
   Unused Flags (8),
+
   Reserved (1),
   Stream Identifier (31),
+
   Exclusive (1),
   Stream Dependency (31),
   Weight (8),
@@ -1604,9 +1616,12 @@ PRIORITY Frame {
 RST_STREAM Frame {
   Length (24),
   Type (8) = 3,
+
   Unused Flags (8),
+
   Reserved (1),
   Stream Identifier (31),
+
   Error Code (32),
 }
 ]]></artwork>
@@ -1710,10 +1725,13 @@ RST_STREAM Frame {
 SETTINGS Frame {
   Length (24),
   Type (8) = 4,
+
   Unused Flags (7),
   ACK Flag (1),
+
   Reserved (1),
   Stream Identifier (31),
+
   Setting (..) ...,
 }
 
@@ -1863,12 +1881,15 @@ Setting {
 PUSH_PROMISE Frame {
   Length (24),
   Type (8) = 5,
+
   Unused Flags (4),
   PADDED Flag (1),
   END_HEADERS Flag (1),
   Unused Flags (2),
+
   Reserved (1),
   Stream Identifier (31),
+
   [Pad Length (8)],
   Reserved (1),
   Promised Stream ID (31),
@@ -1994,10 +2015,13 @@ PUSH_PROMISE Frame {
 PING Frame {
   Length (24),
   Type (8) = 6,
+
   Unused Flags (7),
   ACK Flag (1),
+
   Reserved (1),
   Stream Identifier (31),
+
   Opaque Data (64),
 }
 ]]></artwork>
@@ -2086,9 +2110,12 @@ PING Frame {
 GOAWAY Frame {
   Length (24),
   Type (8) = 7,
+
   Unused Flags (8),
+
   Reserved (1),
   Stream Identifier (31),
+
   Reserved (1),
   Last-Stream-ID (31),
   Error Code (32),
@@ -2208,9 +2235,12 @@ GOAWAY Frame {
 WINDOW_UPDATE Frame {
   Length (24),
   Type (8) = 8,
+
   Unused Flags (8),
+
   Reserved (1),
   Stream Identifier (31),
+
   Reserved (1),
   Window Size Increment (31),
 }
@@ -2379,11 +2409,14 @@ WINDOW_UPDATE Frame {
 CONTINUATION Frame {
   Length (24),
   Type (8) = 9,
+
   Unused Flags (5),
   END_HEADERS Flag (1),
   Unused Flags (2),
+
   Reserved (1),
   Stream Identifier (31),
+
   Field Block Fragment (..),
 }
 ]]></artwork>

--- a/draft-ietf-httpbis-http2bis.xml
+++ b/draft-ietf-httpbis-http2bis.xml
@@ -187,8 +187,9 @@
           from decimal literals.
         </t>
         <t>
-          This specification describes binary formats using the convention described in
-          <xref target="QUIC" section="1.3">RFC 9000</xref>.
+          This specification describes binary formats using the convention described in <xref
+          target="QUIC" section="1.3">RFC 9000</xref>.  Note that this format uses network byte
+          order and high-valued bits are listed before low-valued bits.
         </t>
         <t>
           The following terms are used:


### PR DESCRIPTION
...that is frame formats.

I've chosen to put blank lines before and after both frames and the
stream identifier part of the stream header.  That should make this a
lot clearer.

@wtarreau was right that this was a little hard to process without that.
Hopefully this is a tiny bit better.