### PR TITLE
Explicitly state HEADERS and PUSH_PROMISE padding reqs

### DIFF
--- a/draft-ietf-httpbis-http2bis.xml
+++ b/draft-ietf-httpbis-http2bis.xml
@@ -1479,7 +1479,10 @@ HEADERS Frame {
             </dd>
           <dt>Padding:</dt>
           <dd>
-              Padding octets.
+              Padding octets that contain no application semantic value.  Padding octets MUST be set
+              to zero when sending.  A receiver is not obligated to verify padding but MAY treat
+              non-zero padding as a <xref target="ConnectionErrorHandler">connection error</xref> of
+              type <xref target="PROTOCOL_ERROR" format="none">PROTOCOL_ERROR</xref>.
             </dd>
         </dl>
         <t>
@@ -1541,8 +1544,7 @@ HEADERS Frame {
           The HEADERS frame changes the connection state as described in <xref target="FieldBlock"/>.
         </t>
         <t>
-          The HEADERS frame can include padding.  Padding fields and flags are identical to those
-          defined for <xref target="DATA">DATA frames</xref>.  Padding that exceeds the size
+          The total number of padding octets is determined by the value of the Pad Length field.  Padding that exceeds the size
           remaining for the field block fragment MUST be treated as a
           <xref target="PROTOCOL_ERROR" format="none">PROTOCOL_ERROR</xref>.
         </t>
@@ -1927,7 +1929,10 @@ PUSH_PROMISE Frame {
             </dd>
           <dt>Padding:</dt>
           <dd>
-              Padding octets.
+              Padding octets that contain no application semantic value.  Padding octets MUST be set
+              to zero when sending.  A receiver is not obligated to verify padding but MAY treat
+              non-zero padding as a <xref target="ConnectionErrorHandler">connection error</xref> of
+              type <xref target="PROTOCOL_ERROR" format="none">PROTOCOL_ERROR</xref>.
             </dd>
         </dl>
         <t>
@@ -2000,8 +2005,9 @@ PUSH_PROMISE Frame {
           is an identifier for a stream that is not currently in the "idle" state.
         </t>
         <t>
-          The PUSH_PROMISE frame can include padding.  Padding fields and flags are identical to
-          those defined for <xref target="DATA">DATA frames</xref>.
+          The total number of padding octets is determined by the value of the Pad Length field.  Padding that exceeds the size
+          remaining for the field block fragment MUST be treated as a
+          <xref target="PROTOCOL_ERROR" format="none">PROTOCOL_ERROR</xref>.
         </t>
       </section>
       <section anchor="PING">


### PR DESCRIPTION
fixes #896

The old text stated padding things were identical to DATA frames. That might not be
entirely true. ﻿So just spell out the requirements expicitly.
