### PR TITLE
Improve list construction

### DIFF
--- a/draft-ietf-httpbis-http2bis.xml
+++ b/draft-ietf-httpbis-http2bis.xml
@@ -2581,9 +2581,9 @@ CONTINUATION Frame {
             message content (see <xref target="HTTP" section="6.4"/>), and
           </li>
           <li>
-            optionally, one <xref target="HEADERS" format="none">HEADERS</xref> frame, followed by
-            zero or more <xref target="CONTINUATION" format="none">CONTINUATION</xref> frames
-            containing the trailer-part, if present (see <xref target="HTTP" section="6.5"/>).
+            optionally, one <xref target="HEADERS" format="none">HEADERS</xref> frame (followed by
+            zero or more <xref target="CONTINUATION" format="none">CONTINUATION</xref> frames)
+            containing the trailer section, if present (see <xref target="HTTP" section="6.5"/>).
           </li>
         </ol>
         <t>


### PR DESCRIPTION
And correctly refer to the trailer section.

Closes #900.