### PR TITLE
extending H2: make ref to settings more generic

### DIFF
--- a/draft-ietf-httpbis-http2bis.xml
+++ b/draft-ietf-httpbis-http2bis.xml
@@ -1271,7 +1271,7 @@ HTTP Frame {
         </t>
         <t>
           Extensions are permitted to use new <xref target="FrameHeader">frame types</xref>, new
-          <xref target="SettingValues">settings</xref>, or new <xref target="ErrorCodes">error
+          <xref target="SETTINGS">settings</xref>, or new <xref target="ErrorCodes">error
           codes</xref>.  Registries are established for managing these extension points: <xref target="iana-frames">frame types</xref>, <xref target="iana-settings">settings</xref>, and
           <xref target="iana-errors">error codes</xref>.
         </t>


### PR DESCRIPTION
Which changes

> Extensions are permitted to use new frame types (Section 4.1), new settings (Section 6.5.2), or new error codes (Section 7).

to

> Extensions are permitted to use new frame types (Section 4.1), new settings (Section 6.5), or new error codes (Section 7).