### PR TITLE
More regarding erratum 6309

### DIFF
--- a/draft-ietf-httpbis-http2bis.xml
+++ b/draft-ietf-httpbis-http2bis.xml
@@ -908,11 +908,18 @@ HTTP Frame {
           </dd>
         </dl>
         <t>
-          In the absence of more specific guidance elsewhere in this document, implementations
-          SHOULD treat the receipt of a frame that is not expressly permitted in the description of
-          a state as a <xref target="ConnectionErrorHandler">connection error</xref> of type
-          <xref target="PROTOCOL_ERROR" format="none">PROTOCOL_ERROR</xref>.  Note that <xref target="PRIORITY" format="none">PRIORITY</xref> can be sent and received
-          in any stream state.  Frames of unknown types are ignored.
+          In the absence of more specific rules, implementations SHOULD treat the receipt of a frame
+          that is not expressly permitted in the description of a state as a <xref
+          target="ConnectionErrorHandler">connection error</xref> of type <xref
+          target="PROTOCOL_ERROR" format="none">PROTOCOL_ERROR</xref>.  Note that <xref
+          target="PRIORITY" format="none">PRIORITY</xref> can be sent and received in any stream
+          state.
+        </t>
+        <t>
+          The rules in this section only apply to frames defined in this document.  Receipt of
+          frames for which the semantics are unknown cannot be treated as an error as the conditions
+          for sending and receiving those frames are also unknown; see <xref
+          target="extensibility"/>.
         </t>
         <t>
           An example of the state transitions for an HTTP request/response exchange can be found in


### PR DESCRIPTION
We could try to make every statement precise.  We could add "of the
frames defined in this document" to a bunch of places.  Or we could make
a (better) blanket statement.  That is what this does.

Closes #915.