### PR TITLE
Lowercase "flag" when not in frame artwork

### DIFF
--- a/draft-ietf-httpbis-http2bis.xml
+++ b/draft-ietf-httpbis-http2bis.xml
@@ -568,7 +568,7 @@ HTTP Frame {
         <ul spacing="normal">
           <li>
               a single <xref target="HEADERS" format="none">HEADERS</xref> or <xref target="PUSH_PROMISE" format="none">PUSH_PROMISE</xref> frame,
-              with the END_HEADERS Flag set, or
+              with the END_HEADERS flag set, or
             </li>
           <li>
               a <xref target="HEADERS" format="none">HEADERS</xref> or <xref target="PUSH_PROMISE" format="none">PUSH_PROMISE</xref> frame with the END_HEADERS
@@ -1696,7 +1696,7 @@ RST_STREAM Frame {
         <dl newline="false" spacing="normal">
           <dt>ACK (0x1):</dt>
           <dd>
-              When set, the ACK Flag indicates that this frame acknowledges receipt and application of the
+              When set, the ACK flag indicates that this frame acknowledges receipt and application of the
               peer's SETTINGS frame.  When this bit is set, the frame payload of the SETTINGS frame MUST
               be empty.  Receipt of a SETTINGS frame with the ACK flag set and a length field value
               other than 0 MUST be treated as a <xref target="ConnectionErrorHandler">connection
@@ -2054,7 +2054,7 @@ PING Frame {
         <dl newline="false" spacing="normal">
           <dt>ACK (0x1):</dt>
           <dd>
-              When set, the ACK Flag indicates that this PING frame is a PING response.  An endpoint MUST
+              When set, the ACK flag indicates that this PING frame is a PING response.  An endpoint MUST
               set this flag in PING responses.  An endpoint MUST NOT respond to PING frames
               containing this flag.
             </dd>
@@ -2443,11 +2443,11 @@ CONTINUATION Frame {
           <dt>END_HEADERS (0x4):</dt>
           <dd>
             <t>
-                When set, the END_HEADERS Flag indicates that this frame ends a <xref target="FieldBlock">field
+                When set, the END_HEADERS flag indicates that this frame ends a <xref target="FieldBlock">field
                 block</xref>.
             </t>
             <t>
-                If the END_HEADERS Flag is not set, this frame MUST be followed by another
+                If the END_HEADERS flag is not set, this frame MUST be followed by another
                 CONTINUATION frame.  A receiver MUST treat the receipt of any other type of frame or
                 a frame on a different stream as a <xref target="ConnectionErrorHandler">connection
                 error</xref> of type <xref target="PROTOCOL_ERROR" format="none">PROTOCOL_ERROR</xref>.


### PR DESCRIPTION
I believe the rule in #918 is supposed to be that the layout diagrams use "FOO Flag", while the prose uses "the FOO flag."  If so, this lowercases some other instances.