### PR TITLE
h2c really isn't covered by security promises

### DIFF
--- a/draft-ietf-httpbis-http2bis.xml
+++ b/draft-ietf-httpbis-http2bis.xml
@@ -277,14 +277,16 @@
       <section anchor="versioning">
         <name>HTTP/2 Version Identification</name>
         <t>
-          The protocol defined in this document has two identifiers. Creating a
-          connection based on either implies the use of the transport, security,
-          framing, and message semantics described in this document.
+          The protocol defined in this document has two identifiers. Creating a connection based on
+          either implies the use of the transport, framing, and message semantics described in this
+          document.
         </t>
         <ul spacing="normal">
           <li>
             <t>
-                The string "h2" identifies the protocol where HTTP/2 uses <xref target="TLS13">Transport Layer Security (TLS)</xref>.  This identifier is used in the <xref target="TLS-ALPN">TLS application-layer protocol negotiation (ALPN) extension</xref>
+                The string "h2" identifies the protocol where HTTP/2 uses Transport Layer Security
+                (TLS); see <xref target="TLSUsage"/>.  This identifier is used in the <xref
+                target="TLS-ALPN">TLS application-layer protocol negotiation (ALPN) extension</xref>
                 field and in any place where HTTP/2 over TLS is identified.
             </t>
             <t>
@@ -298,8 +300,9 @@
                 This identifier is used in any place where HTTP/2 over TCP is identified.
             </t>
             <t>
-                The "h2c" string is reserved from the ALPN identifier space but describes a
-                protocol that does not use TLS.
+                The "h2c" string is reserved from the ALPN identifier space but describes a protocol
+                that does not use TLS.  The security properties of this protocol do not hold unless
+                TLS is used; see <xref target="security"/>.
             </t>
             <t>
                 The "h2c" string was previously used as a token for use in the HTTP Upgrade mechanism's
@@ -3602,6 +3605,11 @@ cookie: e=f
     </section>
     <section anchor="security">
       <name>Security Considerations</name>
+      <t>
+        The use of TLS is necessary to provide many of the security properties of this protocol.
+        Many of the claims in this section do not hold unless TLS is used as described in <xref
+        target="TLSUsage"/>.
+      </t>
       <section anchor="authority">
         <name>Server Authority</name>
         <t>

--- a/draft-ietf-httpbis-http2bis.xml
+++ b/draft-ietf-httpbis-http2bis.xml
@@ -277,7 +277,9 @@
       <section anchor="versioning">
         <name>HTTP/2 Version Identification</name>
         <t>
-          The protocol defined in this document has two identifiers.
+          The protocol defined in this document has two identifiers. Creating a
+          connection based on either implies the use of the transport, security,
+          framing, and message semantics described in this document.
         </t>
         <ul spacing="normal">
           <li>
@@ -306,10 +308,6 @@
             </t>
           </li>
         </ul>
-        <t>
-          Negotiating "h2" or "h2c" implies the use of the transport, security, framing, and message
-          semantics described in this document.
-        </t>
       </section>
       <section anchor="discover-https">
         <name>Starting HTTP/2 for "https" URIs</name>


### PR DESCRIPTION
... or the analysis in the security considerations.

We had to walk a more careful path when RFC 7540 was published, so we were careful to legitimize h2c.  In the years since, things have changed and we can be more direct.  This isn't a "don't use h2c", but more of a disclaimer as far as security goes.