### PR TITLE
Avoid mention of Alt-Svc for h2c

### DIFF
--- a/draft-ietf-httpbis-http2bis.xml
+++ b/draft-ietf-httpbis-http2bis.xml
@@ -332,14 +332,15 @@
         <name>Starting HTTP/2 with Prior Knowledge</name>
         <t>
           A client can learn that a particular server supports HTTP/2 by other means.  For example,
-          <xref target="ALT-SVC"/> describes a mechanism for advertising this capability.
+          a client could be configured with knowledge that a server supports HTTP/2.
         </t>
         <t>
-          A client MUST send the <xref target="ConnectionHeader">connection preface</xref> and
-          then MAY immediately send HTTP/2 frames to such a server; servers can identify these
-          connections by the presence of the connection preface. This only affects the
-          establishment of HTTP/2 connections over cleartext TCP; implementations that support
-          HTTP/2 over TLS MUST use <xref target="TLS-ALPN">protocol negotiation in TLS</xref>.
+          A client that knows that a server supports HTTP/2 can establish a TCP connection and send
+          the <xref target="ConnectionHeader">connection preface</xref> followed by HTTP/2 frames.
+          Servers can identify these connections by the presence of the connection preface. This
+          only affects the establishment of HTTP/2 connections over cleartext TCP; implementations
+          that support HTTP/2 over TLS MUST use <xref target="TLS-ALPN">protocol negotiation in
+          TLS</xref>.
         </t>
         <t>
           Likewise, the server MUST send a <xref target="ConnectionHeader">connection preface</xref>.


### PR DESCRIPTION
As stated in #903, it's misleading and contradictory.  Better to
concentrate on configuration for this, as that is the common usage.

Closes #903.