### PR TITLE
Move field validation text around

### DIFF
--- a/draft-ietf-httpbis-http2bis.xml
+++ b/draft-ietf-httpbis-http2bis.xml
@@ -2750,9 +2750,10 @@ CONTINUATION Frame {
           </t>
           <ul>
             <li>
-              A field name MUST NOT contain characters in the ranges 0x00-0x20, 0x41-0x5A, or 0x7F-0xFF
-              (all ranges inclusive).  This limits field names to visible ASCII characters, other than
-              ASCII SP (0x20) and uppercase characters ('A' to 'Z', ASCII 0x41 to 0x5a).
+              A field name MUST NOT contain characters in the ranges 0x00-0x20, 0x41-0x5A, or
+              0x7F-0xFF (all ranges inclusive).  This specifically excludes all non-visible ASCII
+              characters, ASCII SP (0x20), and uppercase characters ('A' to 'Z', ASCII 0x41 to
+              0x5a).
             </li>
             <li>
               With the exception of <xref target="PseudoHeaderFields">pseudo-header fields</xref>,

--- a/draft-ietf-httpbis-http2bis.xml
+++ b/draft-ietf-httpbis-http2bis.xml
@@ -2742,16 +2742,16 @@ CONTINUATION Frame {
             The definitions of field names and values in HTTP prohibits some characters that HPACK
             might be able to convey.  HTTP/2 implementations SHOULD validate field names and values
             according to their definitions in Sections <xref target="HTTP" section="5.1"
-            format="counter"/> and <xref target="HTTP" section="5.5"/> respectively and treat
-            messages that contain prohibited characters as <xref
-            target="malformed">malformed</xref>.
+            format="counter"/> and <xref target="HTTP" section="5.5" format="counter"/> of <xref
+            target="HTTP"/> respectively and treat messages that contain prohibited characters as
+            <xref target="malformed">malformed</xref>.
           </t>
           <t>
             Failure to validate fields can be exploited for request smuggling attacks.  In
             particular, unvalidated fields might enable attacks when messages are forwarded using
             <xref target="HTTP11">HTTP 1.1</xref>, where characters such as CR, LF, and COLON are
-            used as delimiters.  Implementations that do not fully validate field names and values
-            MUST perform the following minimal validation:
+            used as delimiters.  Implementations MUST perform the following minimal validation of
+            field names and values:
           </t>
           <ul>
             <li>
@@ -2774,6 +2774,14 @@ CONTINUATION Frame {
               HTAB, 0x20 or 0x9).
             </li>
           </ul>
+          <aside>
+          <t>
+            Note: An implementation that validates fields according the definitions in Sections
+            <xref target="HTTP" section="5.1" format="counter"/> and <xref target="HTTP"
+            section="5.5" format="counter"/> of <xref target="HTTP"/> only needs an additional check
+            that field names do not include uppercase characters.
+          </t>
+        </aside>
           <t>
             A request or response that contains a field that violates any of these conditions MUST
             be treated as <xref target="malformed">malformed</xref>.  In particular, an intermediary

--- a/draft-ietf-httpbis-http2bis.xml
+++ b/draft-ietf-httpbis-http2bis.xml
@@ -2778,9 +2778,10 @@ CONTINUATION Frame {
           <t>
             These checks are the minimum necessary to avoid accepting messages that might avoid
             security checks.  <xref target="HTTP" section="5.1"/> and <xref target="HTTP"
-            section="5.5"/> define field names and values and what characters are valid.  A
-            recipient can treat a message that contains a field name or value that contains
-            characters that are not permitted by HTTP as <xref target="malformed">malformed</xref>.
+            section="5.5"/> define field names and values and what characters are valid, prohibiting
+            more characters than those listed here.  A recipient can treat a message that contains a
+            field name or value that contains characters that are not permitted by HTTP as <xref
+            target="malformed">malformed</xref>.
           </t>
           <t>
             Note that field values that are not valid according to the definition of the

--- a/draft-ietf-httpbis-http2bis.xml
+++ b/draft-ietf-httpbis-http2bis.xml
@@ -2749,9 +2749,9 @@ CONTINUATION Frame {
           <t>
             Failure to validate fields can be exploited for request smuggling attacks.  In
             particular, unvalidated fields might enable attacks when messages are forwarded using
-            <xref target="HTTP11">HTTP 1.1</xref>, where characters such as CR and COLON are used as
-            delimiters.  Implementations that do not fully validate field names and values MUST
-            perform the following minimal validation:
+            <xref target="HTTP11">HTTP 1.1</xref>, where characters such as CR, LF, and COLON are
+            used as delimiters.  Implementations that do not fully validate field names and values
+            MUST perform the following minimal validation:
           </t>
           <ul>
             <li>

--- a/draft-ietf-httpbis-http2bis.xml
+++ b/draft-ietf-httpbis-http2bis.xml
@@ -2743,10 +2743,10 @@ CONTINUATION Frame {
             names and values and what characters are valid.  A recipient MAY treat a message that
             contains a field name or value that contains characters that are not permitted by HTTP
             as <xref target="malformed">malformed</xref>.  This section defines additional
-            validation for HTTP/2 endpoints.
+            validation for HTTP/2 implementations.
           </t>
           <t>
-            All HTTP/2 endpoints MUST validate fields in messages they receive as follows:
+            All HTTP/2 implementations MUST validate fields in messages they receive as follows:
           </t>
           <ul>
             <li>

--- a/draft-ietf-httpbis-http2bis.xml
+++ b/draft-ietf-httpbis-http2bis.xml
@@ -2739,10 +2739,10 @@ CONTINUATION Frame {
             HPACK is capable of carrying field names or values that are not valid in HTTP.
           </t>
           <t>
-            <xref target="HTTP" section="5.1"/> and <xref target="HTTP" section="5.5"/> as <xref
-            target="malformed">malformed</xref> define field names and values and what characters
-            are valid.  A recipient MAY treat a message that contains a field name or value that
-            includes characters that are not permitted by HTTP.  This section defines additional
+            <xref target="HTTP" section="5.1"/> and <xref target="HTTP" section="5.5"/> define field
+            names and values and what characters are valid.  A recipient MAY treat a message that
+            contains a field name or value that contains characters that are not permitted by HTTP
+            as <xref target="malformed">malformed</xref>.  This section defines additional
             validation for HTTP/2 endpoints.
           </t>
           <t>

--- a/draft-ietf-httpbis-http2bis.xml
+++ b/draft-ietf-httpbis-http2bis.xml
@@ -2736,8 +2736,15 @@ CONTINUATION Frame {
         <section>
           <name>Field Validity</name>
           <t>
-            HPACK is capable of carrying field names or values that are not valid in HTTP.  Though
-            HPACK can carry any octet, fields are not valid in the following cases:
+            HPACK is capable of carrying field names or values that are not valid in HTTP.
+          </t>
+          <t>
+            A recipient MAY treat a message that contains a field name or value that includes other
+            characters disallowed by <xref target="HTTP" section="5.1"/> and <xref target="HTTP"
+            section="5.5"/> as <xref target="malformed">malformed</xref>.
+          </t>
+          <t>
+            All HTTP/2 endpoints MUST validate fields in messages they receive as follows:
           </t>
           <ul>
             <li>
@@ -2764,11 +2771,6 @@ CONTINUATION Frame {
             be treated as <xref target="malformed">malformed</xref>.  In particular, an intermediary
             that does not process fields when forwarding messages MUST NOT forward fields that
             contain any of the values that are listed as prohibited above.
-          </t>
-          <t>
-            A recipient MAY treat a message that contains a field name or value that includes other
-            characters disallowed by <xref target="HTTP" section="5.1"/> and <xref target="HTTP"
-            section="5.5"/> as <xref target="malformed">malformed</xref>.
           </t>
           <t>
             When a request message violates one of the requirements above, it SHOULD be responded

--- a/draft-ietf-httpbis-http2bis.xml
+++ b/draft-ietf-httpbis-http2bis.xml
@@ -2739,9 +2739,11 @@ CONTINUATION Frame {
             HPACK is capable of carrying field names or values that are not valid in HTTP.
           </t>
           <t>
-            A recipient MAY treat a message that contains a field name or value that includes other
-            characters disallowed by <xref target="HTTP" section="5.1"/> and <xref target="HTTP"
-            section="5.5"/> as <xref target="malformed">malformed</xref>.
+            <xref target="HTTP" section="5.1"/> and <xref target="HTTP" section="5.5"/> as <xref
+            target="malformed">malformed</xref> define field names and values and what characters
+            are valid.  A recipient MAY treat a message that contains a field name or value that
+            includes characters that are not permitted by HTTP.  This section defines additional
+            validation for HTTP/2 endpoints.
           </t>
           <t>
             All HTTP/2 endpoints MUST validate fields in messages they receive as follows:
@@ -2773,10 +2775,10 @@ CONTINUATION Frame {
             contain any of the values that are listed as prohibited above.
           </t>
           <t>
-            When a request message violates one of the requirements above, it SHOULD be responded
-            to using the 400 (Bad Request) status code (<xref target="HTTP" section="15.5.1"/>)
-            before the stream is reset, unless a more suitable status code is defined, or the
-            status code cannot be sent (e.g., because the error occurs in a trailer field).
+            When a request message violates one of these requirements, an implementation SHOULD
+            generate a 400 (Bad Request) status code (<xref target="HTTP" section="15.5.1"/>) before
+            the stream is reset, unless a more suitable status code is defined, or the status code
+            cannot be sent (e.g., because the error occurs in a trailer field).
           </t>
           <t>
             Note that field values that are not valid according to the definition of the

--- a/draft-ietf-httpbis-http2bis.xml
+++ b/draft-ietf-httpbis-http2bis.xml
@@ -2771,17 +2771,16 @@ CONTINUATION Frame {
           </t>
           <t>
             When a request message violates one of these requirements, an implementation SHOULD
-            generate a 400 (Bad Request) status code (<xref target="HTTP" section="15.5.1"/>) before
-            the stream is reset, unless a more suitable status code is defined, or the status code
-            cannot be sent (e.g., because the error occurs in a trailer field).
+            generate a 400 (Bad Request) status code (<xref target="HTTP" section="15.5.1"/>),
+            unless a more suitable status code is defined or the status code cannot be sent (e.g.,
+            because the error occurs in a trailer field).
           </t>
           <t>
-            These checks are the minimum necessary to avoid accepting messages that might avoid
-            security checks.  <xref target="HTTP" section="5.1"/> and <xref target="HTTP"
-            section="5.5"/> define field names and values and what characters are valid, prohibiting
-            more characters than those listed here.  A recipient can treat a message that contains a
-            field name or value that contains characters that are not permitted by HTTP as <xref
-            target="malformed">malformed</xref>.
+            These checks are the minimum necessary for any form of message handling.  <xref
+            target="HTTP" section="5.1"/> and <xref target="HTTP" section="5.5"/> define field names
+            and values and what characters are valid, prohibiting more characters than those listed
+            here.  A recipient can treat a message that contains a field name or value that contains
+            characters that are not permitted by HTTP as <xref target="malformed">malformed</xref>.
           </t>
           <t>
             Note that field values that are not valid according to the definition of the

--- a/draft-ietf-httpbis-http2bis.xml
+++ b/draft-ietf-httpbis-http2bis.xml
@@ -2736,11 +2736,19 @@ CONTINUATION Frame {
         <section>
           <name>Field Validity</name>
           <t>
-            HPACK is capable of carrying field names or values that are not valid in HTTP.  Attacks
-            on HTTP/2 implementations might exploit this by including delimiters in fields with the
-            intent evading security controls.  This might be used in a request smuggling attack, for
-            example.  To prevent these attacks, HTTP/2 implementations MUST validate fields they
-            receive as follows:
+            The definitions of field names and values in HTTP prohibits some characters that HPACK
+            might be able to convey.  HTTP/2 implementations SHOULD validate field names and values
+            according to their definitions in Sections <xref target="HTTP" section="5.1"
+            format="counter"/> and <xref target="HTTP" section="5.5"/> respectively and treat
+            messages that contain prohibited characters as <xref
+            target="malformed">malformed</xref>.
+          </t>
+          <t>
+            Failure to validate fields can be exploited for request smuggling attacks.  In
+            particular, unvalidated fields might enable attacks when messages are forwarded using
+            <xref target="HTTP11">HTTP 1.1</xref>, where characters such as CR and COLON are used as
+            delimiters.  Implementations that do not fully validate field names and values MUST
+            perform the following minimal validation:
           </t>
           <ul>
             <li>
@@ -2771,24 +2779,18 @@ CONTINUATION Frame {
           </t>
           <t>
             When a request message violates one of these requirements, an implementation SHOULD
-            generate a 400 (Bad Request) status code (<xref target="HTTP" section="15.5.1"/>),
+            generate a <xref target="HTTP" section="15.5.1">400 (Bad Request) status code</xref>,
             unless a more suitable status code is defined or the status code cannot be sent (e.g.,
             because the error occurs in a trailer field).
           </t>
-          <t>
-            These checks are the minimum necessary for any form of message handling; they do not
-            guarantee that fields are valid.  <xref target="HTTP" section="5.1"/> and <xref
-            target="HTTP" section="5.5"/> define field names and values and what characters are
-            valid, prohibiting more characters than those listed here.  A recipient can treat a
-            message that contains an invalid field name or value <xref
-            target="malformed">malformed</xref>.
-          </t>
-          <t>
-            Note that field values that are not valid according to the definition of the
-            corresponding field do not cause a request to be <xref target="malformed"
-            format="none">malformed</xref>; the requirements above only apply to the generic syntax
-            for field values as defined in <xref target="HTTP" section="5.5"/>.
-          </t>
+          <aside>
+            <t>
+              Note: Field values that are not valid according to the definition of the corresponding
+              field do not cause a request to be <xref target="malformed"
+              format="none">malformed</xref>; the requirements above only apply to the generic
+              syntax for fields as defined in <xref target="HTTP" section="5"/>.
+            </t>
+          </aside>
         </section>
         <section>
           <name>Connection-Specific Header Fields</name>

--- a/draft-ietf-httpbis-http2bis.xml
+++ b/draft-ietf-httpbis-http2bis.xml
@@ -2736,17 +2736,11 @@ CONTINUATION Frame {
         <section>
           <name>Field Validity</name>
           <t>
-            HPACK is capable of carrying field names or values that are not valid in HTTP.
-          </t>
-          <t>
-            <xref target="HTTP" section="5.1"/> and <xref target="HTTP" section="5.5"/> define field
-            names and values and what characters are valid.  A recipient MAY treat a message that
-            contains a field name or value that contains characters that are not permitted by HTTP
-            as <xref target="malformed">malformed</xref>.  This section defines additional
-            validation for HTTP/2 implementations.
-          </t>
-          <t>
-            All HTTP/2 implementations MUST validate fields in messages they receive as follows:
+            HPACK is capable of carrying field names or values that are not valid in HTTP.  Attacks
+            on HTTP/2 implementations might exploit this by including delimiters in fields with the
+            intent evading security controls.  This might be used in a request smuggling attack, for
+            example.  To prevent these attacks, HTTP/2 implementations MUST validate fields they
+            receive as follows:
           </t>
           <ul>
             <li>
@@ -2780,6 +2774,13 @@ CONTINUATION Frame {
             generate a 400 (Bad Request) status code (<xref target="HTTP" section="15.5.1"/>) before
             the stream is reset, unless a more suitable status code is defined, or the status code
             cannot be sent (e.g., because the error occurs in a trailer field).
+          </t>
+          <t>
+            These checks are the minimum necessary to avoid accepting messages that might avoid
+            security checks.  <xref target="HTTP" section="5.1"/> and <xref target="HTTP"
+            section="5.5"/> define field names and values and what characters are valid.  A
+            recipient can treat a message that contains a field name or value that contains
+            characters that are not permitted by HTTP as <xref target="malformed">malformed</xref>.
           </t>
           <t>
             Note that field values that are not valid according to the definition of the

--- a/draft-ietf-httpbis-http2bis.xml
+++ b/draft-ietf-httpbis-http2bis.xml
@@ -2776,11 +2776,12 @@ CONTINUATION Frame {
             because the error occurs in a trailer field).
           </t>
           <t>
-            These checks are the minimum necessary for any form of message handling.  <xref
-            target="HTTP" section="5.1"/> and <xref target="HTTP" section="5.5"/> define field names
-            and values and what characters are valid, prohibiting more characters than those listed
-            here.  A recipient can treat a message that contains a field name or value that contains
-            characters that are not permitted by HTTP as <xref target="malformed">malformed</xref>.
+            These checks are the minimum necessary for any form of message handling; they do not
+            guarantee that fields are valid.  <xref target="HTTP" section="5.1"/> and <xref
+            target="HTTP" section="5.5"/> define field names and values and what characters are
+            valid, prohibiting more characters than those listed here.  A recipient can treat a
+            message that contains an invalid field name or value <xref
+            target="malformed">malformed</xref>.
           </t>
           <t>
             Note that field values that are not valid according to the definition of the


### PR DESCRIPTION
This just moves the reference to the canonical definition of what is
valid up to the top of the section.  That's the canonical text.

This emphasizes the point that HTTP/2 is placing *additional*
requirements on endpoints with respect to validation.

This does not really fix #902 in the sense that it leaves validation of
DQUOTE and friends to the core semantics implementations.

Note that any "MAY" requirement for rejecting a messaging can have the
desired effect on those generating those messages: if an endpoint puts
DQUOTE in a field name, that message will have little hope of being
successfully handled.

Closes #902.