### PR TITLE
Connections, not implemenations

### DIFF
--- a/draft-ietf-httpbis-http2bis.xml
+++ b/draft-ietf-httpbis-http2bis.xml
@@ -341,8 +341,8 @@
           A client that knows that a server supports HTTP/2 can establish a TCP connection and send
           the <xref target="ConnectionHeader">connection preface</xref> followed by HTTP/2 frames.
           Servers can identify these connections by the presence of the connection preface. This
-          only affects the establishment of HTTP/2 connections over cleartext TCP; implementations
-          that support HTTP/2 over TLS MUST use <xref target="TLS-ALPN">protocol negotiation in
+          only affects the establishment of HTTP/2 connections over cleartext TCP; HTTP/2 connections
+          over TLS MUST use <xref target="TLS-ALPN">protocol negotiation in
           TLS</xref>.
         </t>
         <t>


### PR DESCRIPTION
This text wasn't actually changed in #933, but I noticed it while reviewing.  This says that implementations which support TLS MUST use ALPN, but that's not really tied to what the implementation supports -- it's tied to what the current connection is doing.  If you support TLS but are using cleartext TCP for the current connection (regardless of why), you're not required to use ALPN.