### PR TITLE
Lower-case hex

### DIFF
--- a/draft-ietf-httpbis-http2bis.xml
+++ b/draft-ietf-httpbis-http2bis.xml
@@ -2743,7 +2743,7 @@ CONTINUATION Frame {
           </t>
           <ul>
             <li>
-              A field name MUST NOT contain characters in the ranges 0x00-0x20, 0x41-0x5A, or 0x7F-0xFF
+              A field name MUST NOT contain characters in the ranges 0x00-0x20, 0x41-0x5a, or 0x7f-0xff
               (all ranges inclusive).  This limits field names to visible ASCII characters, other than
               ASCII SP (0x20) and uppercase characters ('A' to 'Z', ASCII 0x41 to 0x5a).
             </li>
@@ -2825,7 +2825,7 @@ CONTINUATION Frame {
             To allow for better compression efficiency, the Cookie header field MAY be split into
             separate header fields, each with one or more cookie-pairs.  If there are multiple
             Cookie header fields after decompression, these MUST be concatenated into a single
-            octet string using the two-octet delimiter of 0x3B, 0x20 (the ASCII string "; ")
+            octet string using the two-octet delimiter of 0x3b, 0x20 (the ASCII string "; ")
             before being passed into a non-HTTP/2 context, such as an HTTP/1.1 connection, or a
             generic HTTP server application.
           </t>


### PR DESCRIPTION
More instances of using a-f than using A-F, so I normalized the outliers to lower-case.