### PR TITLE
Remove presupposition

### DIFF
--- a/draft-ietf-httpbis-http2bis.xml
+++ b/draft-ietf-httpbis-http2bis.xml
@@ -2775,7 +2775,7 @@ CONTINUATION Frame {
           <t>
             When a request message violates one of the requirements above, it SHOULD be responded
             to using the 400 (Bad Request) status code (<xref target="HTTP" section="15.5.1"/>)
-            before the stream is reset, unless a more suitable status code is defined, or the
+            unless a more suitable status code is defined or the
             status code cannot be sent (e.g., because the error occurs in a trailer field).
           </t>
           <t>


### PR DESCRIPTION
The existing language presupposes that the server will reset the stream upon detecting a malformed request, when in fact it only MAY do so.  The simplest fix for this text is to remove any reference to resetting the stream and restrict the advice to using an HTTP status code.