### PR TITLE
More on connection-specific headers

### DIFF
--- a/draft-ietf-httpbis-http2bis.xml
+++ b/draft-ietf-httpbis-http2bis.xml
@@ -2790,11 +2790,12 @@ CONTINUATION Frame {
             HTTP/2 does not use the <tt>Connection</tt> header field (<xref target="HTTP"
             section="7.6.1"/>) to indicate connection-specific header fields; in this protocol,
             connection-specific metadata is conveyed by other means.  An endpoint MUST NOT generate
-            an HTTP/2 message containing connection-specific header fields, including those listed
-            as having connection-specific semantics in <xref target="HTTP" section="7.6.1"/> (that
-            is, <tt>Proxy-Connection</tt>, <tt>Keep-Alive</tt>, <tt>Transfer-Encoding</tt>, and
-            <tt>Upgrade</tt>).  Any message containing connection-specific header fields MUST be
-            treated as <xref target="malformed">malformed</xref>.
+            an HTTP/2 message containing connection-specific header fields.  This includes the
+            <tt>Connection</tt> header field and those listed as having connection-specific
+            semantics in <xref target="HTTP" section="7.6.1"/> (that is, <tt>Proxy-Connection</tt>,
+            <tt>Keep-Alive</tt>, <tt>Transfer-Encoding</tt>, and <tt>Upgrade</tt>).  Any message
+            containing connection-specific header fields MUST be treated as <xref
+            target="malformed">malformed</xref>.
           </t>
           <t>
             The only exception to this is the TE header field, which MAY be present in an HTTP/2

--- a/draft-ietf-httpbis-http2bis.xml
+++ b/draft-ietf-httpbis-http2bis.xml
@@ -2792,10 +2792,9 @@ CONTINUATION Frame {
             connection-specific metadata is conveyed by other means.  An endpoint MUST NOT generate
             an HTTP/2 message containing connection-specific header fields, including those listed
             as having connection-specific semantics in <xref target="HTTP" section="7.6.1"/> (that
-            is, <tt>Proxy-Connection</tt>, <tt>Keep-Alive</tt>, <tt>TE</tt>,
-            <tt>Transfer-Encoding</tt>, and <tt>Upgrade</tt>).  Any message containing
-            connection-specific header fields MUST be treated as <xref
-            target="malformed">malformed</xref>.
+            is, <tt>Proxy-Connection</tt>, <tt>Keep-Alive</tt>, <tt>Transfer-Encoding</tt>, and
+            <tt>Upgrade</tt>).  Any message containing connection-specific header fields MUST be
+            treated as <xref target="malformed">malformed</xref>.
           </t>
           <t>
             The only exception to this is the TE header field, which MAY be present in an HTTP/2

--- a/draft-ietf-httpbis-http2bis.xml
+++ b/draft-ietf-httpbis-http2bis.xml
@@ -5113,6 +5113,10 @@ cookie: e=f
           The ranges of codepoints for settings and frame types that were reserved for "Experimental
           Use" are now available for general use.
         </li>
+        <li>
+          Connection-specific header fields - which are prohibited - are more precisely and
+          comprehensively identified.
+        </li>
       </ul>
     </section>
     <section numbered="false">

--- a/draft-ietf-httpbis-http2bis.xml
+++ b/draft-ietf-httpbis-http2bis.xml
@@ -2633,7 +2633,8 @@ CONTINUATION Frame {
         </t>
         <t>
           HTTP/2 uses DATA frames to carry message content.  The <tt>chunked</tt> transfer encoding
-          defined in <xref target="HTTP11" section="7.1"/> cannot be used in HTTP/2.
+          defined in <xref target="HTTP11" section="7.1"/> cannot be used in HTTP/2; see <xref
+          target="ConnectionSpecific"/>.
         </t>
         <t>
           Trailer fields are carried in a field block that also terminates the stream. That is,
@@ -2783,14 +2784,18 @@ CONTINUATION Frame {
             for field values as defined in <xref target="HTTP" section="5.5"/>.
           </t>
         </section>
-        <section>
+        <section anchor="ConnectionSpecific">
           <name>Connection-Specific Header Fields</name>
           <t>
-            HTTP/2 does not use the <tt>Connection</tt> header field (<xref target="HTTP" section="7.6.1"/>) to
-            indicate connection-specific header fields; in this protocol, connection-specific
-            metadata is conveyed by other means.  An endpoint MUST NOT generate an HTTP/2 message
-            containing connection-specific header fields; any message containing
-            connection-specific header fields MUST be treated as <xref target="malformed">malformed</xref>.
+            HTTP/2 does not use the <tt>Connection</tt> header field (<xref target="HTTP"
+            section="7.6.1"/>) to indicate connection-specific header fields; in this protocol,
+            connection-specific metadata is conveyed by other means.  An endpoint MUST NOT generate
+            an HTTP/2 message containing connection-specific header fields, including those listed
+            as having connection-specific semantics in <xref target="HTTP" section="7.6.1"/> (that
+            is, <tt>Proxy-Connection</tt>, <tt>Keep-Alive</tt>, <tt>TE</tt>,
+            <tt>Transfer-Encoding</tt>, and <tt>Upgrade</tt>).  Any message containing
+            connection-specific header fields MUST be treated as <xref
+            target="malformed">malformed</xref>.
           </t>
           <t>
             The only exception to this is the TE header field, which MAY be present in an HTTP/2


### PR DESCRIPTION
The original issue here was concerned with Transfer-Encoding, but this
was not a normative statement, it was a note.  With a forward reference,
this is better.

The section on connection-specific headers probably could have been more
specific.  Now that the -semantics draft has a specific list of things
(plus whatever `Connection` lists), we can lean on that more directly.

Closes #938.