### PR TITLE
Tighten forward language

### DIFF
--- a/draft-ietf-httpbis-http2bis.xml
+++ b/draft-ietf-httpbis-http2bis.xml
@@ -2895,28 +2895,23 @@ cookie: e=f
                 pseudo-header field instead of the <tt>Host</tt> header field.
               </t>
               <t>
-                An intermediary that translates a request to HTTP/2 from another HTTP version MUST
-                translate any authority information from the request into an <tt>:authority</tt>
-                pseudo-header field.  If the control data in the original request contains
-                authority information, an intermediary MUST include a <tt>:authority</tt>
-                pseudo-header field.  If control data does not contain authority, an intermediary
-                MUST NOT add an <tt>:authority</tt> pseudo-header field.  For reference, an
-                HTTP/1.1 request target (<xref target="HTTP11" section="3.2"/>) in
-                authority-form always includes authority, a request target in absolute-form
-                includes authority if the target URI includes authority, and request targets in
-                origin- or asterisk-form do not include authority.
+                An intermediary that forwards a request to HTTP/2 MUST construct an
+                <tt>:authority</tt> pseudo-header field using the authority information from the
+                control data in the original request.  If control data does not contain authority,
+                an intermediary MUST NOT add an <tt>:authority</tt> pseudo-header field.  Note that
+                while the <tt>Host</tt> header field can determine a request target, is not control
+                data for this purpose; see <xref target="HTTP" section="7.2"/>.
               </t>
               <t>
-                An intermediary that translates a request to another HTTP version from HTTP/2 can
-                construct a <tt>Host</tt> header field by copying the value of the
-                <tt>:authority</tt> pseudo-header field if that version requires that
-                <tt>Host</tt> be included in a request, as HTTP/1.1 does for some forms of request
-                target (see <xref target="HTTP11" section="3.2"/>).
+                An intermediary that forwards from HTTP/2 can construct a <tt>Host</tt> header field
+                by copying the value of the <tt>:authority</tt> pseudo-header field. This might be
+                necessary if that version requires that <tt>Host</tt> be included in a request, as
+                HTTP/1.1 does for some forms of request target (see <xref target="HTTP11"
+                section="3.2"/>).
               </t>
               <t>
-                An intermediary that translates a request to HTTP/2 from another HTTP version MUST
-                retain any <tt>Host</tt> header field, even if an authority is part of control
-                data.
+                An intermediary that forwards a request to HTTP/2 MUST retain any <tt>Host</tt>
+                header field, even if an authority is part of control data.
               </t>
               <t>
                 The value of the <tt>Host</tt> header field MUST be ignored if control data


### PR DESCRIPTION
This removes the "from another HTTP version" and just uses "forwards"
with "to" or "from".  Not sure if that helps.

The rest is an attempt to tighten things up.

Closes #913.
Closes #935 (as this supersedes it).
Closes #912.