### PR TITLE
Don't justify lowercase requirement

### DIFF
--- a/draft-ietf-httpbis-http2bis.xml
+++ b/draft-ietf-httpbis-http2bis.xml
@@ -2733,8 +2733,7 @@ CONTINUATION Frame {
           CONTINUATION, and PUSH_PROMISE frames, compressed with <xref target="COMPRESSION">HPACK</xref>.
         </t>
         <t>
-          To improve efficiency and interoperability, field names MUST be converted to lowercase
-          when constructing an HTTP/2 message.
+          Field names MUST be converted to lowercase when constructing an HTTP/2 message.
         </t>
         <section>
           <name>Field Validity</name>


### PR DESCRIPTION
Just state it. No need to justify it so (especially as this invites
questions about the claimed benefits).

This is less than Julian wanted from #963, but I think that it is
important to include a requirement like this very clearly and it isn't
really said anywhere else.  At least not directly.

Closes #963.