### PR TITLE
No fields are mandatory

### DIFF
--- a/draft-ietf-httpbis-http2bis.xml
+++ b/draft-ietf-httpbis-http2bis.xml
@@ -2683,9 +2683,9 @@ CONTINUATION Frame {
           <t>
             A malformed request or response is one that is an otherwise valid sequence of HTTP/2
             frames but is invalid due to the presence of extraneous frames, prohibited fields or
-            pseudo-header fields, the absence of mandatory fields or pseudo-header fields, the
-            inclusion of uppercase field names, or invalid field names and/or values (in certain
-            circumstances; see <xref target="HttpHeaders"/>).
+            pseudo-header fields, the absence of mandatory pseudo-header fields, the inclusion of
+            uppercase field names, or invalid field names and/or values (in certain circumstances;
+            see <xref target="HttpHeaders"/>).
           </t>
           <t>
             A request or response that includes message content can include a


### PR DESCRIPTION
Only pseudo-header fields can be mandatory, so no point saying anything
about fields more generally here.

Closes #962.