### PR TITLE
Host and :authority must agree

### DIFF
--- a/draft-ietf-httpbis-http2bis.xml
+++ b/draft-ietf-httpbis-http2bis.xml
@@ -2951,9 +2951,9 @@ cookie: e=f
               <t>
                 An intermediary that forwards a request received in HTTP/2 via HTTP/1.1 MUST set the
                 <tt>Host</tt> field in the forwarded request to the value from the
-                <tt>:authority</tt> pseudo-header field, unless it changes the request target. This
-                replaces any existing <tt>Host</tt> field to avoid potential vulnerabilities in HTTP
-                routing.
+                <tt>:authority</tt> pseudo-header field, unless the intermediary also changes the
+                request target. This replaces any existing <tt>Host</tt> field to avoid potential
+                vulnerabilities in HTTP routing.
               </t>
               <t>
                 An intermediary that forwards a request over HTTP/2 MAY retain any <tt>Host</tt>
@@ -5184,6 +5184,9 @@ cookie: e=f
         <li>
           Connection-specific header fields - which are prohibited - are more precisely and
           comprehensively identified.
+        </li>
+        <li>
+          <tt>Host</tt> and <tt>:authority</tt> are no longer permitted to disagree.
         </li>
       </ul>
     </section>

--- a/draft-ietf-httpbis-http2bis.xml
+++ b/draft-ietf-httpbis-http2bis.xml
@@ -2953,7 +2953,7 @@ cookie: e=f
                 source of this information; see <xref target="HTTP" section="7.2"/>.
               </t>
               <t>
-                An intermediary that needs to produce a <tt>Host</tt> header field (which might be
+                An intermediary that needs to generate a <tt>Host</tt> header field (which might be
                 necessary to construct an HTTP/1.1 request) MUST use the value from the <tt>:authority</tt> 
                 pseudo-header field as the value of the <tt>Host</tt> field,
                 unless the intermediary also changes the request target. This replaces any existing

--- a/draft-ietf-httpbis-http2bis.xml
+++ b/draft-ietf-httpbis-http2bis.xml
@@ -2936,7 +2936,7 @@ cookie: e=f
               </t>
               <t>
                 Clients MUST NOT generate a request with a <tt>Host</tt> header field that differs
-                from the <tt>:authority</tt> pseudo-header field, when compared byte-for-byte.  A
+                from the <tt>:authority</tt> pseudo-header field.  A
                 server SHOULD treat a request as malformed if it contains a <tt>Host</tt> header
                 field that identifies a different entity to the <tt>:authority</tt> pseudo-header
                 field.  The values of fields need to be normalized to compare them (see <xref

--- a/draft-ietf-httpbis-http2bis.xml
+++ b/draft-ietf-httpbis-http2bis.xml
@@ -2935,15 +2935,28 @@ cookie: e=f
                 information to convey (in which case it MUST NOT generate :authority).
               </t>
               <t>
+                Clients MUST NOT generate a request with a <tt>Host</tt> header field that differs
+                from the <tt>:authority</tt> pseudo-header field.  A server MAY treat a request as
+                malformed if it contains a <tt>Host</tt> header field that is different from the
+                value of the <tt>:authority</tt> pseudo-header field.
+              </t>
+              <t>
                 An intermediary that forwards a request over HTTP/2 MUST construct an
                 <tt>:authority</tt> pseudo-header field using the authority information from the
                 control data of the original request, unless the the original request's target URI
                 does not contain authority information (in which case it MUST NOT generate
-                <tt>:authority</tt>). Note that the Host header field is not the sole source of this
-                information; see <xref target="HTTP" section="7.2"/>.
+                <tt>:authority</tt>). Note that the <tt>Host</tt> header field is not the sole
+                source of this information; see <xref target="HTTP" section="7.2"/>.
               </t>
               <t>
-                An intermediary that forwards a request over HTTP/2 MUST retain any <tt>Host</tt>
+                An intermediary that forwards a request received in HTTP/2 via HTTP/1.1 MUST set the
+                <tt>Host</tt> field in the forwarded request to the value from the
+                <tt>:authority</tt> pseudo-header field, unless it changes the request target. This
+                replaces any existing <tt>Host</tt> field to avoid potential vulnerabilities in HTTP
+                routing.
+              </t>
+              <t>
+                An intermediary that forwards a request over HTTP/2 MAY retain any <tt>Host</tt>
                 header field.
               </t>
               <t>

--- a/draft-ietf-httpbis-http2bis.xml
+++ b/draft-ietf-httpbis-http2bis.xml
@@ -2953,11 +2953,11 @@ cookie: e=f
                 source of this information; see <xref target="HTTP" section="7.2"/>.
               </t>
               <t>
-                An intermediary that forwards a request received in HTTP/2 via HTTP/1.1 MUST set the
-                <tt>Host</tt> field in the forwarded request to the value from the
-                <tt>:authority</tt> pseudo-header field, unless the intermediary also changes the
-                request target. This replaces any existing <tt>Host</tt> field to avoid potential
-                vulnerabilities in HTTP routing.
+                An intermediary that needs to produce a <tt>Host</tt> header field (which might be
+                necessary to construct an HTTP/1.1 request) MUST set the <tt>Host</tt> field in the
+                forwarded request to the value from the <tt>:authority</tt> pseudo-header field,
+                unless the intermediary also changes the request target. This replaces any existing
+                <tt>Host</tt> field to avoid potential vulnerabilities in HTTP routing.
               </t>
               <t>
                 An intermediary that forwards a request over HTTP/2 MAY retain any <tt>Host</tt>

--- a/draft-ietf-httpbis-http2bis.xml
+++ b/draft-ietf-httpbis-http2bis.xml
@@ -2936,9 +2936,13 @@ cookie: e=f
               </t>
               <t>
                 Clients MUST NOT generate a request with a <tt>Host</tt> header field that differs
-                from the <tt>:authority</tt> pseudo-header field.  A server MAY treat a request as
-                malformed if it contains a <tt>Host</tt> header field that is different from the
-                value of the <tt>:authority</tt> pseudo-header field.
+                from the <tt>:authority</tt> pseudo-header field, when compared byte-for-byte.  A
+                server SHOULD treat a request as malformed if it contains a <tt>Host</tt> header
+                field that identifies a different entity to the <tt>:authority</tt> pseudo-header
+                field.  The values of fields need to be normalized to compare them (see <xref
+                target="RFC3986" section="6.2"/>).  An origin server can apply any normalization
+                method, whereas other servers MUST perform scheme-based normalization (see <xref
+                target="RFC3986" section="6.2.3"/>) of the two fields.
               </t>
               <t>
                 An intermediary that forwards a request over HTTP/2 MUST construct an

--- a/draft-ietf-httpbis-http2bis.xml
+++ b/draft-ietf-httpbis-http2bis.xml
@@ -2954,8 +2954,8 @@ cookie: e=f
               </t>
               <t>
                 An intermediary that needs to produce a <tt>Host</tt> header field (which might be
-                necessary to construct an HTTP/1.1 request) MUST set the <tt>Host</tt> field in the
-                forwarded request to the value from the <tt>:authority</tt> pseudo-header field,
+                necessary to construct an HTTP/1.1 request) MUST use the value from the <tt>:authority</tt> 
+                pseudo-header field as the value of the <tt>Host</tt> field,
                 unless the intermediary also changes the request target. This replaces any existing
                 <tt>Host</tt> field to avoid potential vulnerabilities in HTTP routing.
               </t>


### PR DESCRIPTION
This makes a few changes, restricting things further than before.  For
the most part, this removes an allowance in the original specification
that had Host and :authority potentially differing.  The goal of that
was - from memory - to preserve some of the inherent quirks in HTTP/1.1.
That turns out to be more of a liability than an asset and far less
important now that we have a more formal understanding of the structure
of requests.

Closes #905.