### PR TITLE
Only update registries that refer to RFC 7540

### DIFF
--- a/draft-ietf-httpbis-http2bis.xml
+++ b/draft-ietf-httpbis-http2bis.xml
@@ -2954,7 +2954,7 @@ cookie: e=f
               </t>
               <t>
                 An intermediary that needs to generate a <tt>Host</tt> header field (which might be
-                necessary to construct an HTTP/1.1 request) MUST use the value from the <tt>:authority</tt> 
+                necessary to construct an HTTP/1.1 request) MUST use the value from the <tt>:authority</tt>
                 pseudo-header field as the value of the <tt>Host</tt> field,
                 unless the intermediary also changes the request target. This replaces any existing
                 <tt>Host</tt> field to avoid potential vulnerabilities in HTTP routing.
@@ -4023,9 +4023,10 @@ cookie: e=f
         HTTP/2, but are not redefined in this document.
       </t>
       <t>
-        [RFC Editor: please remove this paragraph.]  IANA is requested to update references in these
-        registries to refer to this document.  The registration of the <tt>PRI</tt> method needs to
-        be updated to refer to <xref target="preface"/>; all other section numbers have not changed.
+        [RFC Editor: please remove this paragraph.]  IANA is requested to update references to RFC
+        7540 in these registries to refer to this document.  The registration of the <tt>PRI</tt>
+        method needs to be updated to refer to <xref target="preface"/>; all other section numbers
+        have not changed.
       </t>
       <section anchor="HTTP2-Settings">
         <name>HTTP2-Settings Header Field Registration</name>


### PR DESCRIPTION
Not all of the references.  That would be bad.