### PR TITLE
Manually add quotes to important strings

### DIFF
--- a/draft-ietf-httpbis-http2bis.xml
+++ b/draft-ietf-httpbis-http2bis.xml
@@ -188,7 +188,7 @@
         <t>
           All numeric values are in network byte order.  Values are unsigned unless otherwise
           indicated.  Literal values are provided in decimal or hexadecimal as appropriate.
-          Hexadecimal literals are prefixed with <tt>0x</tt> to distinguish them
+          Hexadecimal literals are prefixed with "<tt>0x</tt>" to distinguish them
           from decimal literals.
         </t>
         <t>
@@ -370,8 +370,8 @@
   0x505249202a20485454502f322e300d0a0d0a534d0d0a0d0a
 ]]></artwork>
         <t>
-          That is, the connection preface starts with the string <tt>PRI *
-          HTTP/2.0\r\n\r\nSM\r\n\r\n</tt>. This sequence
+          That is, the connection preface starts with the string "<tt>PRI *
+          HTTP/2.0\r\n\r\nSM\r\n\r\n</tt>". This sequence
           MUST be followed by a <xref target="SETTINGS" format="none">SETTINGS</xref> frame (<xref target="SETTINGS"/>), which
           MAY be empty. The client sends the client connection preface as the first
           application data octets of a connection.


### PR DESCRIPTION
A recent xml2rfc update changed the way that the `<tt>` element was
rendered in text.  Take advantage of that by adding quotes to strings
that really do benefit from additional quoting, such as the "PRI ..."
preface string.

Most of the changes shown in a recent diff are down to losing quotes
on header field names and other protocol elements.  These do not need
to be quoted for their meaning to be clear and unambiguous.  The use
of `<tt>` for these items improves the HTML rendering, but the loss of
line noise in text renderings is a net win (at least in my opinion).