### PR TITLE
First pass cleaning up some of the typos from AD review

### DIFF
--- a/draft-ietf-httpbis-http2bis.xml
+++ b/draft-ietf-httpbis-http2bis.xml
@@ -1867,7 +1867,7 @@ SETTINGS Frame {
   ACK Flag (1),
 
   Reserved (1),
-  Stream Identifier (31),
+  Stream Identifier (31) = 0,
 
   Setting (48) ...,
 }
@@ -1994,7 +1994,8 @@ Setting {
             other frame processing between values.  Unsupported settings MUST be ignored.  Once
             all values have been processed, the recipient MUST immediately emit a SETTINGS frame
             with the ACK flag set. Upon receiving a SETTINGS frame with the ACK flag set, the sender
-            of the altered settings can rely on the value having been applied.
+            of the altered settings can rely on the values from the oldest un-ACKed SETTINGS frame
+            having been applied.
           </t>
           <t>
             If the sender of a SETTINGS frame does not receive an acknowledgement within a
@@ -2167,7 +2168,7 @@ PING Frame {
   ACK Flag (1),
 
   Reserved (1),
-  Stream Identifier (31),
+  Stream Identifier (31) = 0,
 
   Opaque Data (64),
 }
@@ -2261,7 +2262,7 @@ GOAWAY Frame {
   Unused Flags (8),
 
   Reserved (1),
-  Stream Identifier (31),
+  Stream Identifier (31) = 0,
 
   Reserved (1),
   Last-Stream-ID (31),
@@ -2409,7 +2410,7 @@ WINDOW_UPDATE Frame {
           the value "0" indicates that the entire connection is the subject of the frame.
         </t>
         <t>
-          A receiver MUST treat the receipt of a WINDOW_UPDATE frame with an flow-control window
+          A receiver MUST treat the receipt of a WINDOW_UPDATE frame with a flow-control window
           increment of 0 as a <xref target="StreamErrorHandler">stream error</xref> of type
           <xref target="PROTOCOL_ERROR" format="none">PROTOCOL_ERROR</xref>; errors on the connection flow-control window MUST be
           treated as a <xref target="ConnectionErrorHandler">connection error</xref>.
@@ -3052,7 +3053,7 @@ cookie: e=f
               <t>
                 An intermediary that forwards a request over HTTP/2 MUST construct an
                 <tt>:authority</tt> pseudo-header field using the authority information from the
-                control data of the original request, unless the the original request's target URI
+                control data of the original request, unless the original request's target URI
                 does not contain authority information (in which case it MUST NOT generate
                 <tt>:authority</tt>). Note that the <tt>Host</tt> header field is not the sole
                 source of this information; see <xref target="HTTP" section="7.2"/>.
@@ -3847,7 +3848,7 @@ cookie: e=f
         <t>
           HPACK permits encoding of field names and values that might be treated as delimiters in
           other HTTP versions.  An intermediary that translates an HTTP/2 request or response MUST
-          validate fields according to the rules in <xref target="HttpHeaders"/> roles before
+          validate fields according to the rules in <xref target="HttpHeaders"/> before
           translating a message to another HTTP version.  Translating a field that includes invalid
           delimiters could be used to cause recipients to incorrectly interpret a message, which
           could be exploited by an attacker.
@@ -4006,7 +4007,7 @@ cookie: e=f
         <section anchor="connectDos">
           <name>CONNECT Issues</name>
           <t>
-            The CONNECT method can be used to create disproportionate load on an proxy, since stream
+            The CONNECT method can be used to create disproportionate load on a proxy, since stream
             creation is relatively inexpensive when compared to the creation and maintenance of a
             TCP connection.  A proxy might also maintain some resources for a TCP connection beyond
             the closing of the stream that carries the CONNECT request, since the outgoing TCP

--- a/draft-ietf-httpbis-http2bis.xml
+++ b/draft-ietf-httpbis-http2bis.xml
@@ -1994,7 +1994,7 @@ Setting {
             other frame processing between values.  Unsupported settings MUST be ignored.  Once
             all values have been processed, the recipient MUST immediately emit a SETTINGS frame
             with the ACK flag set. Upon receiving a SETTINGS frame with the ACK flag set, the sender
-            of the altered settings can rely on the values from the oldest un-ACKed SETTINGS frame
+            of the altered settings can rely on the values from the oldest unacknowledged SETTINGS frame
             having been applied.
           </t>
           <t>


### PR DESCRIPTION
Partially addresses some of #974. This is the low hanging fruit.