### PR TITLE
Link to frame type definitions.

### DIFF
--- a/draft-ietf-httpbis-http2bis.xml
+++ b/draft-ietf-httpbis-http2bis.xml
@@ -456,7 +456,8 @@ HTTP Frame {
           <dd>
             <t>
                 The 8-bit type of the frame.  The frame type determines the format and semantics of
-                the frame.  Implementations MUST ignore and discard any frame that has a type that
+                the frame.  Frames defined in this documented are listed in <xref target="FrameTypes"/>.
+                Implementations MUST ignore and discard any frame that has a type that
                 is unknown.
             </t>
           </dd>


### PR DESCRIPTION
This links to the section rather than the registry as we no longer list
frame types in the IANA considerations section.

For #974.