### PR TITLE
Fix the flow control text

### DIFF
--- a/draft-ietf-httpbis-http2bis.xml
+++ b/draft-ietf-httpbis-http2bis.xml
@@ -1197,9 +1197,12 @@ HTTP Frame {
           </t>
           <t>
             Even with full awareness of the current bandwidth-delay product, implementation of flow
-            control can be difficult.  When using flow control, the receiver MUST read from the TCP
-            receive buffer in a timely fashion.  Failure to do so could lead to a deadlock when
-            critical frames, such as <xref target="WINDOW_UPDATE" format="none">WINDOW_UPDATE</xref>, are not read and acted upon.
+            control can be difficult.  Endpoints MUST read and process HTTP/2 frames from the TCP
+            receive buffer as soon as data is available.  Failure to read promptly could lead to a
+            deadlock when critical frames, such as <xref target="WINDOW_UPDATE"
+            format="none">WINDOW_UPDATE</xref>, are not read and acted upon. Reading frames promptly
+            does not expose endpoints to resource exhaustion attacks as HTTP/2 flow control limits
+            resource commitments.
           </t>
         </section>
         <section anchor="FlowControlPerformance">


### PR DESCRIPTION
Editorial change only.  The idea is to read as soon as data arrives in
the TCP buffer.

In practice, this is not necessary, but leaving things in the TCP buffer
indefinitely can deadlock.  (Some implementations of over TCP-based
protocols do this and in this case it is BAD.)

For #974.