### PR TITLE
Remove contradictory text on use of RST_STREAM

### DIFF
--- a/draft-ietf-httpbis-http2bis.xml
+++ b/draft-ietf-httpbis-http2bis.xml
@@ -2824,10 +2824,7 @@ CONTINUATION Frame {
             complete request. Similarly, intermediaries might forward incomplete messages before
             detecting errors. A server MAY generate a final response before receiving an entire
             request when the response does not depend on the remainder of the request being
-            correct. A server or intermediary MAY use <xref target="RST_STREAM"
-            format="none">RST_STREAM</xref> -- with a code other than <xref
-            target="REFUSED_STREAM" format="none">REFUSED_STREAM</xref> -- to abort a stream if a
-            malformed request or response is received.
+            correct.
           </t>
           <t>
             These requirements are intended to protect against several types of common attacks


### PR DESCRIPTION
Two paragraphs up we mandate the use of PROTOCOL_ERROR, so this is not
necessary.

For #974.