### PR TITLE
"idle"->"closed" transition

### DIFF
--- a/draft-ietf-httpbis-http2bis.xml
+++ b/draft-ietf-httpbis-http2bis.xml
@@ -841,7 +841,12 @@ HTTP Frame {
                     Note that the <xref target="PUSH_PROMISE" format="none">PUSH_PROMISE</xref> frame is not sent on the idle
                     stream but references the newly reserved stream in the Promised Stream ID
                     field.
-                  </li>
+              </li>
+              <li>
+                Opening a stream with a higher-valued stream identifier causes the stream to
+                transition immediately to a "closed" state; note that this transition is not shown
+                in the diagram.
+              </li>
             </ul>
             <t>
                 Receiving any frame other than <xref target="HEADERS" format="none">HEADERS</xref> or <xref target="PRIORITY" format="none">PRIORITY</xref> on
@@ -1065,8 +1070,8 @@ HTTP Frame {
             A <xref target="HEADERS" format="none">HEADERS</xref> frame will transition the client-initiated stream identified
             by the stream identifier in the frame header from "idle" to "open". A <xref target="PUSH_PROMISE" format="none">PUSH_PROMISE</xref>
             frame will transition the server-initiated stream identified by the "Promised Stream ID" field in the frame payload from "idle" to "reserved". When
-            a stream transitions out of the "idle" state, all streams that might have been initiated by that peer with a lower-valued
-            stream identifier are implicitly transitioned to "closed". That is, an endpoint may skip a stream identifier, with the
+            a stream transitions out of the "idle" state, all "idle" streams that might have been opened by the peer with a lower-valued
+            stream identifier immediately transition to "closed". That is, an endpoint may skip a stream identifier, with the
             effect being that the skipped stream is immediately closed.
           </t>
           <t>


### PR DESCRIPTION
I improved the text along the lines Jörg suggested.  However, I realized
that the transition should really be in the diagram.  That's basically
impossible given the nature of the diagram, but it's worth including in
the description at least.

For #990.