### PR TITLE
Fix bad reference to 400 (Bad Request)

### DIFF
--- a/draft-ietf-httpbis-http2bis.xml
+++ b/draft-ietf-httpbis-http2bis.xml
@@ -2905,7 +2905,7 @@ CONTINUATION Frame {
           </t>
           <t>
             When a request message violates one of these requirements, an implementation SHOULD
-            generate a <xref target="HTTP" section="15.5.1">400 (Bad Request) status code</xref>,
+            generate a 400 (Bad Request) status code (see <xref target="HTTP" section="15.5.1"/>),
             unless a more suitable status code is defined or the status code cannot be sent (e.g.,
             because the error occurs in a trailer field).
           </t>


### PR DESCRIPTION
A consequence of bad rendering logic, methinks.

Noted in #990.