### PR TITLE
2119 language for second GOAWAY

### DIFF
--- a/draft-ietf-httpbis-http2bis.xml
+++ b/draft-ietf-httpbis-http2bis.xml
@@ -2336,7 +2336,7 @@ GOAWAY Frame {
           connection SHOULD send an initial GOAWAY frame with the last stream identifier set to
           2<sup>31</sup>-1 and a <xref target="NO_ERROR" format="none">NO_ERROR</xref> code.  This signals to the client that
           a shutdown is imminent and that initiating further requests is prohibited.  After allowing
-          time for any in-flight stream creation (at least one round-trip time),  the server can
+          time for any in-flight stream creation (at least one round-trip time),  the server MAY
           send another GOAWAY frame with an updated last stream identifier.  This ensures that a
           connection can be cleanly shut down without losing requests.
         </t>


### PR DESCRIPTION
This is the one case in Jörg's review where I think we need text.  In
the other places, the text is secondary to other normative language and
should not be restated in direct terms (or it would need to be far more
precise than it is).

For #990.