### PR TITLE
Add 0x to Frame layout diagrams for consistency

### DIFF
--- a/draft-ietf-httpbis-http2bis.xml
+++ b/draft-ietf-httpbis-http2bis.xml
@@ -1470,7 +1470,7 @@ HTTP Frame {
           <artwork type="inline"><![CDATA[
 DATA Frame {
   Length (24),
-  Type (8) = 0,
+  Type (8) = 0x0,
 
   Unused Flags (4),
   PADDED Flag (1),
@@ -1564,7 +1564,7 @@ DATA Frame {
           <artwork type="inline"><![CDATA[
 HEADERS Frame {
   Length (24),
-  Type (8) = 1,
+  Type (8) = 0x1,
 
   Unused Flags (2),
   PRIORITY Flag (1),
@@ -1703,7 +1703,7 @@ HEADERS Frame {
           <artwork type="inline"><![CDATA[
 PRIORITY Frame {
   Length (24),
-  Type (8) = 2,
+  Type (8) = 0x2,
 
   Unused Flags (8),
 
@@ -1762,7 +1762,7 @@ PRIORITY Frame {
           <artwork type="inline"><![CDATA[
 RST_STREAM Frame {
   Length (24),
-  Type (8) = 3,
+  Type (8) = 0x3,
 
   Unused Flags (8),
 
@@ -1871,7 +1871,7 @@ RST_STREAM Frame {
             <artwork type="inline"><![CDATA[
 SETTINGS Frame {
   Length (24),
-  Type (8) = 4,
+  Type (8) = 0x4,
 
   Unused Flags (7),
   ACK Flag (1),
@@ -2035,7 +2035,7 @@ Setting {
           <artwork type="inline"><![CDATA[
 PUSH_PROMISE Frame {
   Length (24),
-  Type (8) = 5,
+  Type (8) = 0x5,
 
   Unused Flags (4),
   PADDED Flag (1),
@@ -2179,7 +2179,7 @@ PUSH_PROMISE Frame {
           <artwork type="inline"><![CDATA[
 PING Frame {
   Length (24),
-  Type (8) = 6,
+  Type (8) = 0x6,
 
   Unused Flags (7),
   ACK Flag (1),
@@ -2274,7 +2274,7 @@ PING Frame {
           <artwork type="inline"><![CDATA[
 GOAWAY Frame {
   Length (24),
-  Type (8) = 7,
+  Type (8) = 0x7,
 
   Unused Flags (8),
 
@@ -2399,7 +2399,7 @@ GOAWAY Frame {
           <artwork type="inline"><![CDATA[
 WINDOW_UPDATE Frame {
   Length (24),
-  Type (8) = 8,
+  Type (8) = 0x8,
 
   Unused Flags (8),
 
@@ -2575,7 +2575,7 @@ WINDOW_UPDATE Frame {
           <artwork type="inline"><![CDATA[
 CONTINUATION Frame {
   Length (24),
-  Type (8) = 9,
+  Type (8) = 0x9,
 
   Unused Flags (5),
   END_HEADERS Flag (1),


### PR DESCRIPTION
This stems from the IESG review of the priorities draft, where Éric Vyncke noted the inconsistenc between prose and diagram. This change to use 0x throughout makes it consistent with HTTP/3, which helps documents that need to define frames for both versions.