### PR TITLE
Stricter, clearer rules for Dynamic Table Size Update v2

### DIFF
--- a/draft-ietf-httpbis-http2bis.xml
+++ b/draft-ietf-httpbis-http2bis.xml
@@ -575,12 +575,6 @@ HTTP Frame {
             </li>
         </ul>
         <t>
-          Field compression is stateful.  One compression context and one decompression context are
-          used for the entire connection.  A decoding error in a field block MUST be treated as a
-          <xref target="ConnectionErrorHandler">connection error</xref> of type
-          <xref target="COMPRESSION_ERROR" format="none">COMPRESSION_ERROR</xref>.
-        </t>
-        <t>
           Each field block is processed as a discrete unit.
           Field blocks MUST be transmitted as a contiguous sequence of frames, with no interleaved
           frames of any other type or from any other stream.  The last frame in a sequence of
@@ -599,6 +593,42 @@ HTTP Frame {
           connection with a <xref target="ConnectionErrorHandler">connection error</xref> of type
           <xref target="COMPRESSION_ERROR" format="none">COMPRESSION_ERROR</xref> if it does not decompress a field block.
         </t>
+        <t>
+          A decoding error in a field block MUST be treated as a <xref
+          target="ConnectionErrorHandler">connection error</xref> of type <xref
+          target="COMPRESSION_ERROR" format="none">COMPRESSION_ERROR</xref>.
+        </t>
+
+        <section>
+          <name>Compression State</name>
+          <t>
+            Field compression is stateful.  One compression context and one decompression context
+            are used for the entire connection.  <xref target="COMPRESSION" section="4"/> defines
+            the dynamic table, which is the primary state that is used for field compression.
+          </t>
+          <t>
+            The dynamic table has a maximum size that is set by a decoder using the
+            SETTINGS_HEADER_TABLE_SIZE setting; see <xref target="SettingValues"/>.  The encoder can
+            set the dynamic table to any size up to the maximum value set by the decoder.  The
+            encoder declares the size of the dynamic table with a Dynamic Table Size Update
+            instruction (<xref target="COMPRESSION" section="6.3"/>).  The encoder at both client
+            and server is initialized with a dynamic table size of 4,096 bytes, the initial value of
+            the SETTINGS_HEADER_TABLE_SIZE setting.
+          </t>
+          <t>
+            Any change to the maximum value set by the decoder takes effect when the encoder <xref
+            target="SettingsSync">acknowledges settings</xref>.  The first field block sent by an
+            encoder after a change in SETTINGS_HEADER_TABLE_SIZE starts with at least one Dynamic
+            Table Size Update instruction; see <xref target="COMPRESSION" section="4.2"/>.  An
+            encoder sends a Dynamic Table Size Update instruction after acknowledging a change of
+            SETTINGS_HEADER_TABLE_SIZE even if it is not changing the size of the dynamic table or
+            an increase to the maximum size is subsequently reverted before the field block is sent.
+            An encoder MAY treat the absence of Dynamic Table Size Update instructions in a field
+            block following an acknowledgment of a change to SETTINGS_HEADER_TABLE_SIZE as a <xref
+            target="ConnectionErrorHandler">connection error</xref> of type <xref
+            target="COMPRESSION_ERROR" format="none">COMPRESSION_ERROR</xref>.
+          </t>
+        </section>
       </section>
     </section>
     <section anchor="StreamsLayer">

--- a/draft-ietf-httpbis-http2bis.xml
+++ b/draft-ietf-httpbis-http2bis.xml
@@ -626,11 +626,11 @@ HTTP Frame {
             maximum below the current size of the dynamic table, the encoder MUST start the next
             field block with a Dynamic Table Size Update instruction that sets the dynamic table to
             a size that is less than or equal to the reduced maximum; see <xref target="COMPRESSION"
-            section="4.2"/>.  A decoder MUST treat a field block without a sufficiently small
-            Dynamic Table Size Update instruction that follows an acknowledgment of a reduction of
-            SETTINGS_HEADER_TABLE_SIZE as a <xref target="ConnectionErrorHandler">connection
+            section="4.2"/>.  A decoder MUST treat a field block that follows a reduction to the
+            maximum dynamic table size as a <xref target="ConnectionErrorHandler">connection
             error</xref> of type <xref target="COMPRESSION_ERROR"
-            format="none">COMPRESSION_ERROR</xref>.
+            format="none">COMPRESSION_ERROR</xref> if it does not start with an conformant Dynamic
+            Table Size Update instruction.
           </t>
           <aside>
             <t>

--- a/draft-ietf-httpbis-http2bis.xml
+++ b/draft-ietf-httpbis-http2bis.xml
@@ -608,24 +608,28 @@ HTTP Frame {
           </t>
           <t>
             The dynamic table has a maximum size that is set by a decoder using the
-            SETTINGS_HEADER_TABLE_SIZE setting; see <xref target="SettingValues"/>.  Any change to
-            the maximum value set by the decoder takes effect when the encoder <xref
-            target="SettingsSync">acknowledges settings</xref>.  The encoder can set the dynamic
-            table to any size up to the maximum value set by the decoder.  The encoder declares the
-            size of the dynamic table with a Dynamic Table Size Update instruction (<xref
-            target="COMPRESSION" section="6.3"/>).  When a connection is established, the dynamic
-            table size for the decoder and encoder at both endpoints starts at 4,096 bytes, the
-            initial value of the SETTINGS_HEADER_TABLE_SIZE setting.
+            SETTINGS_HEADER_TABLE_SIZE setting; see <xref target="SettingValues"/>.  When a
+            connection is established, the dynamic table size for the decoder and encoder at both
+            endpoints starts at 4,096 bytes, the initial value of the SETTINGS_HEADER_TABLE_SIZE
+            setting.
           </t>
           <t>
-            If a change to SETTINGS_HEADER_TABLE_SIZE reduces the maximum below the current size of
-            the dynamic table, the encoder MUST start the next field block with a Dynamic Table Size
-            Update instruction that sets the dynamic table to a size that is less than or equal to
-            the reduced maximum; see <xref target="COMPRESSION" section="4.2"/>.  A decoder MUST
-            treat a field block without a sufficiently small Dynamic Table Size Update instruction
-            that follows an acknowledgment of a reduction of SETTINGS_HEADER_TABLE_SIZE as a <xref
-            target="ConnectionErrorHandler">connection error</xref> of type <xref
-            target="COMPRESSION_ERROR" format="none">COMPRESSION_ERROR</xref>.
+            Any change to the maximum value set by the decoder using SETTINGS_HEADER_TABLE_SIZE
+            takes effect when the encoder <xref target="SettingsSync">acknowledges settings</xref>.
+            The encoder can set the dynamic table to any size up to the maximum value set by the
+            decoder.  The encoder declares the size of the dynamic table with a Dynamic Table Size
+            Update instruction (<xref target="COMPRESSION" section="6.3"/>).
+          </t>
+          <t>
+            Once an endpoint acknowledges a change to SETTINGS_HEADER_TABLE_SIZE that reduces the
+            maximum below the current size of the dynamic table, the encoder MUST start the next
+            field block with a Dynamic Table Size Update instruction that sets the dynamic table to
+            a size that is less than or equal to the reduced maximum; see <xref target="COMPRESSION"
+            section="4.2"/>.  A decoder MUST treat a field block without a sufficiently small
+            Dynamic Table Size Update instruction that follows an acknowledgment of a reduction of
+            SETTINGS_HEADER_TABLE_SIZE as a <xref target="ConnectionErrorHandler">connection
+            error</xref> of type <xref target="COMPRESSION_ERROR"
+            format="none">COMPRESSION_ERROR</xref>.
           </t>
           <aside>
             <t>

--- a/draft-ietf-httpbis-http2bis.xml
+++ b/draft-ietf-httpbis-http2bis.xml
@@ -613,9 +613,9 @@ HTTP Frame {
             target="SettingsSync">acknowledges settings</xref>.  The encoder can set the dynamic
             table to any size up to the maximum value set by the decoder.  The encoder declares the
             size of the dynamic table with a Dynamic Table Size Update instruction (<xref
-            target="COMPRESSION" section="6.3"/>).  The encoder at both client and server is
-            initialized with a dynamic table size of 4,096 bytes, the initial value of the
-            SETTINGS_HEADER_TABLE_SIZE setting.
+            target="COMPRESSION" section="6.3"/>).  When a connection is established, the dynamic
+            table size for the decoder and encoder at both endpoints starts at 4,096 bytes, the
+            initial value of the SETTINGS_HEADER_TABLE_SIZE setting.
           </t>
           <t>
             If a change to SETTINGS_HEADER_TABLE_SIZE reduces the maximum below the current size of

--- a/draft-ietf-httpbis-http2bis.xml
+++ b/draft-ietf-httpbis-http2bis.xml
@@ -617,14 +617,16 @@ HTTP Frame {
           </t>
           <t>
             Any change to the maximum value set by the decoder takes effect when the encoder <xref
-            target="SettingsSync">acknowledges settings</xref>.  The first field block sent by an
-            encoder after a change in SETTINGS_HEADER_TABLE_SIZE starts with at least one Dynamic
-            Table Size Update instruction; see <xref target="COMPRESSION" section="4.2"/>.  An
-            encoder sends a Dynamic Table Size Update instruction after acknowledging a change of
-            SETTINGS_HEADER_TABLE_SIZE even if it is not changing the size of the dynamic table or
-            an increase to the maximum size is subsequently reverted before the field block is sent.
-            An encoder MAY treat the absence of Dynamic Table Size Update instructions in a field
-            block following an acknowledgment of a change to SETTINGS_HEADER_TABLE_SIZE as a <xref
+            target="SettingsSync">acknowledges settings</xref>, followed by a Dynamic Table Size
+            Update instruction.
+          </t>
+          <t>
+            If a change to SETTINGS_HEADER_TABLE_SIZE reduces the maximum below the current size of
+            the dynamic table, the encoder starts the next field block with a Dynamic Table Size
+            Update instruction that sets the dynamic table to a size that is less than or equal to
+            the reduced maximum; see <xref target="COMPRESSION" section="4.2"/>.  A decoder MAY
+            treat a field block without a sufficiently small Dynamic Table Size Update instruction
+            that follows an acknowledgment of a reduction of SETTINGS_HEADER_TABLE_SIZE as a <xref
             target="ConnectionErrorHandler">connection error</xref> of type <xref
             target="COMPRESSION_ERROR" format="none">COMPRESSION_ERROR</xref>.
           </t>

--- a/draft-ietf-httpbis-http2bis.xml
+++ b/draft-ietf-httpbis-http2bis.xml
@@ -602,32 +602,33 @@ HTTP Frame {
         <section anchor="dynamic-table">
           <name>Compression State</name>
           <t>
-            Field compression is stateful.  Each endpoint has an encoder context and a decoder
-            context that are used for encoding and decoding all field blocks.  <xref
+            Field compression is stateful.  Each endpoint has an HPACK encoder context and an HPACK
+            decoder context that are used for encoding and decoding all field blocks.  <xref
             target="COMPRESSION" section="4"/> defines the dynamic table, which is the primary state
             for each context.
           </t>
           <t>
-            The dynamic table has a maximum size that is set by a decoder using the
+            The dynamic table has a maximum size that is set by an HPACK decoder. An endpoint
+            communicates the size chosen by its HPACK decoder context using the
             SETTINGS_HEADER_TABLE_SIZE setting; see <xref target="SettingValues"/>.  When a
-            connection is established, the dynamic table size for the decoder and encoder at both
-            endpoints starts at 4,096 bytes, the initial value of the SETTINGS_HEADER_TABLE_SIZE
-            setting.
+            connection is established, the dynamic table size for the HPACK decoder and encoder at
+            both endpoints starts at 4,096 bytes, the initial value of the
+            SETTINGS_HEADER_TABLE_SIZE setting.
           </t>
           <t>
-            Any change to the maximum value set by the decoder using SETTINGS_HEADER_TABLE_SIZE
-            takes effect when the encoder <xref target="SettingsSync">acknowledges settings</xref>.
-            The encoder can set the dynamic table to any size up to the maximum value set by the
-            decoder.  The encoder declares the size of the dynamic table with a Dynamic Table Size
-            Update instruction (<xref target="COMPRESSION" section="6.3"/>).
+            Any change to the maximum value set using SETTINGS_HEADER_TABLE_SIZE takes effect when
+            the endpoint <xref target="SettingsSync">acknowledges settings</xref>.  The HPACK
+            encoder at that endpoint can set the dynamic table to any size up to the maximum value
+            set by the decoder.  An HPACK encoder declares the size of the dynamic table with a
+            Dynamic Table Size Update instruction (<xref target="COMPRESSION" section="6.3"/>).
           </t>
           <t>
             Once an endpoint acknowledges a change to SETTINGS_HEADER_TABLE_SIZE that reduces the
-            maximum below the current size of the dynamic table, the encoder MUST start the next
-            field block with a Dynamic Table Size Update instruction that sets the dynamic table to
-            a size that is less than or equal to the reduced maximum; see <xref target="COMPRESSION"
-            section="4.2"/>.  A decoder MUST treat a field block that follows an acknowledgment of the
-            reduction to the maximum dynamic table size as a <xref
+            maximum below the current size of the dynamic table, its HPACK encoder MUST start the
+            next field block with a Dynamic Table Size Update instruction that sets the dynamic
+            table to a size that is less than or equal to the reduced maximum; see <xref
+            target="COMPRESSION" section="4.2"/>.  An endpoint MUST treat a field block that follows
+            an acknowledgment of the reduction to the maximum dynamic table size as a <xref
             target="ConnectionErrorHandler">connection error</xref> of type <xref
             target="COMPRESSION_ERROR" format="none">COMPRESSION_ERROR</xref> if it does not start
             with an conformant Dynamic Table Size Update instruction.

--- a/draft-ietf-httpbis-http2bis.xml
+++ b/draft-ietf-httpbis-http2bis.xml
@@ -602,9 +602,10 @@ HTTP Frame {
         <section anchor="dynamic-table">
           <name>Compression State</name>
           <t>
-            Field compression is stateful.  One compression context and one decompression context
-            are used for the entire connection.  <xref target="COMPRESSION" section="4"/> defines
-            the dynamic table, which is the primary state that is used for field compression.
+            Field compression is stateful.  Each endpoint has an encoder context and a decoder
+            context that are used for encoding and decoding all field blocks.  <xref
+            target="COMPRESSION" section="4"/> defines the dynamic table, which is the primary state
+            for each context.
           </t>
           <t>
             The dynamic table has a maximum size that is set by a decoder using the

--- a/draft-ietf-httpbis-http2bis.xml
+++ b/draft-ietf-httpbis-http2bis.xml
@@ -631,7 +631,7 @@ HTTP Frame {
             an acknowledgment of the reduction to the maximum dynamic table size as a <xref
             target="ConnectionErrorHandler">connection error</xref> of type <xref
             target="COMPRESSION_ERROR" format="none">COMPRESSION_ERROR</xref> if it does not start
-            with an conformant Dynamic Table Size Update instruction.
+            with a conformant Dynamic Table Size Update instruction.
           </t>
           <aside>
             <t>

--- a/draft-ietf-httpbis-http2bis.xml
+++ b/draft-ietf-httpbis-http2bis.xml
@@ -13,7 +13,7 @@
 <?rfc-ext allow-markup-in-artwork="yes" ?>
 <?rfc-ext include-index="no" ?>
 <!DOCTYPE rfc SYSTEM "rfc2629-xhtml.ent">
-<rfc xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:x="http://purl.org/net/xml2rfc/ext" ipr="trust200902" category="std" docName="draft-ietf-httpbis-http2bis-latest" tocInclude="true" symRefs="true" sortRefs="true" version="3" submissionType="IETF" obsoletes="7540,8740">
+<rfc xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:x="http://purl.org/net/xml2rfc/ext" ipr="trust200902" category="std" docName="draft-ietf-httpbis-http2bis-latest" tocInclude="true" symRefs="true" sortRefs="true" version="3" submissionType="IETF" obsoletes="7540,7541,8740">
   <!--
   <x:feedback template="mailto:ietf-http-wg@w3.org?subject={docname},%20%22{section}%22&amp;body=&lt;{ref}&gt;:"/>
   -->
@@ -49,7 +49,7 @@
         concurrent exchanges on the same connection.
       </t>
       <t>
-        This document obsoletes RFC 7540 and RFC 8740.
+        This document obsoletes RFC 7540 and RFC 8740.  It updates RFC 7541.
       </t>
     </abstract>
     <note title="Discussion Venues" removeInRFC="true">
@@ -599,7 +599,7 @@ HTTP Frame {
           target="COMPRESSION_ERROR" format="none">COMPRESSION_ERROR</xref>.
         </t>
 
-        <section>
+        <section anchor="dynamic-table">
           <name>Compression State</name>
           <t>
             Field compression is stateful.  One compression context and one decompression context
@@ -622,13 +622,25 @@ HTTP Frame {
           </t>
           <t>
             If a change to SETTINGS_HEADER_TABLE_SIZE reduces the maximum below the current size of
-            the dynamic table, the encoder starts the next field block with a Dynamic Table Size
+            the dynamic table, the encoder MUST start the next field block with a Dynamic Table Size
             Update instruction that sets the dynamic table to a size that is less than or equal to
-            the reduced maximum; see <xref target="COMPRESSION" section="4.2"/>.  A decoder MAY
-            treat a field block without a sufficiently small Dynamic Table Size Update instruction
-            that follows an acknowledgment of a reduction of SETTINGS_HEADER_TABLE_SIZE as a <xref
-            target="ConnectionErrorHandler">connection error</xref> of type <xref
-            target="COMPRESSION_ERROR" format="none">COMPRESSION_ERROR</xref>.
+            the reduced maximum.  A decoder MUST treat a field block without a sufficiently small
+            Dynamic Table Size Update instruction that follows an acknowledgment of a reduction of
+            SETTINGS_HEADER_TABLE_SIZE as a <xref target="ConnectionErrorHandler">connection
+            error</xref> of type <xref target="COMPRESSION_ERROR"
+            format="none">COMPRESSION_ERROR</xref>.
+          </t>
+          <aside>
+            <t>
+              Implementers are advised that support for reducing the value of
+              SETTINGS_HEADER_TABLE_SIZE is not interoperable.  This includes use of the connection
+              preface to reduce the value below the initial value of 4,096.
+            </t>
+          </aside>
+          <t>
+            This differs from the requirement in <xref target="COMPRESSION" section="4.2"/> as it
+            allows an encoder to omit the instruction if the dynamic table size does not change.
+            Experience with deployed implementations shows that this is more interoperable.
           </t>
         </section>
       </section>
@@ -4951,6 +4963,10 @@ cookie: e=f
         </li>
         <li>
           <tt>Host</tt> and <tt>:authority</tt> are no longer permitted to disagree.
+        </li>
+        <li>
+          Rules for sending Dynamic Table Size Update instructions after changes in settings have
+          been clarified in <xref target="dynamic-table"/>.
         </li>
       </ul>
       <t>

--- a/draft-ietf-httpbis-http2bis.xml
+++ b/draft-ietf-httpbis-http2bis.xml
@@ -626,11 +626,11 @@ HTTP Frame {
             maximum below the current size of the dynamic table, the encoder MUST start the next
             field block with a Dynamic Table Size Update instruction that sets the dynamic table to
             a size that is less than or equal to the reduced maximum; see <xref target="COMPRESSION"
-            section="4.2"/>.  A decoder MUST treat a field block that follows a reduction to the
-            maximum dynamic table size as a <xref target="ConnectionErrorHandler">connection
-            error</xref> of type <xref target="COMPRESSION_ERROR"
-            format="none">COMPRESSION_ERROR</xref> if it does not start with an conformant Dynamic
-            Table Size Update instruction.
+            section="4.2"/>.  A decoder MUST treat a field block that follows an acknowledgment of the
+            reduction to the maximum dynamic table size as a <xref
+            target="ConnectionErrorHandler">connection error</xref> of type <xref
+            target="COMPRESSION_ERROR" format="none">COMPRESSION_ERROR</xref> if it does not start
+            with an conformant Dynamic Table Size Update instruction.
           </t>
           <aside>
             <t>

--- a/draft-ietf-httpbis-http2bis.xml
+++ b/draft-ietf-httpbis-http2bis.xml
@@ -13,7 +13,7 @@
 <?rfc-ext allow-markup-in-artwork="yes" ?>
 <?rfc-ext include-index="no" ?>
 <!DOCTYPE rfc SYSTEM "rfc2629-xhtml.ent">
-<rfc xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:x="http://purl.org/net/xml2rfc/ext" ipr="trust200902" category="std" docName="draft-ietf-httpbis-http2bis-latest" tocInclude="true" symRefs="true" sortRefs="true" version="3" submissionType="IETF" obsoletes="7540,7541,8740">
+<rfc xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:x="http://purl.org/net/xml2rfc/ext" ipr="trust200902" category="std" docName="draft-ietf-httpbis-http2bis-latest" tocInclude="true" symRefs="true" sortRefs="true" version="3" submissionType="IETF" obsoletes="7540,8740">
   <!--
   <x:feedback template="mailto:ietf-http-wg@w3.org?subject={docname},%20%22{section}%22&amp;body=&lt;{ref}&gt;:"/>
   -->
@@ -49,7 +49,7 @@
         concurrent exchanges on the same connection.
       </t>
       <t>
-        This document obsoletes RFC 7540 and RFC 8740.  It updates RFC 7541.
+        This document obsoletes RFC 7540 and RFC 8740.
       </t>
     </abstract>
     <note title="Discussion Venues" removeInRFC="true">
@@ -608,40 +608,33 @@ HTTP Frame {
           </t>
           <t>
             The dynamic table has a maximum size that is set by a decoder using the
-            SETTINGS_HEADER_TABLE_SIZE setting; see <xref target="SettingValues"/>.  The encoder can
-            set the dynamic table to any size up to the maximum value set by the decoder.  The
-            encoder declares the size of the dynamic table with a Dynamic Table Size Update
-            instruction (<xref target="COMPRESSION" section="6.3"/>).  The encoder at both client
-            and server is initialized with a dynamic table size of 4,096 bytes, the initial value of
-            the SETTINGS_HEADER_TABLE_SIZE setting.
-          </t>
-          <t>
-            Any change to the maximum value set by the decoder takes effect when the encoder <xref
-            target="SettingsSync">acknowledges settings</xref>, followed by a Dynamic Table Size
-            Update instruction.
+            SETTINGS_HEADER_TABLE_SIZE setting; see <xref target="SettingValues"/>.  Any change to
+            the maximum value set by the decoder takes effect when the encoder <xref
+            target="SettingsSync">acknowledges settings</xref>.  The encoder can set the dynamic
+            table to any size up to the maximum value set by the decoder.  The encoder declares the
+            size of the dynamic table with a Dynamic Table Size Update instruction (<xref
+            target="COMPRESSION" section="6.3"/>).  The encoder at both client and server is
+            initialized with a dynamic table size of 4,096 bytes, the initial value of the
+            SETTINGS_HEADER_TABLE_SIZE setting.
           </t>
           <t>
             If a change to SETTINGS_HEADER_TABLE_SIZE reduces the maximum below the current size of
             the dynamic table, the encoder MUST start the next field block with a Dynamic Table Size
             Update instruction that sets the dynamic table to a size that is less than or equal to
-            the reduced maximum.  A decoder MUST treat a field block without a sufficiently small
-            Dynamic Table Size Update instruction that follows an acknowledgment of a reduction of
-            SETTINGS_HEADER_TABLE_SIZE as a <xref target="ConnectionErrorHandler">connection
-            error</xref> of type <xref target="COMPRESSION_ERROR"
-            format="none">COMPRESSION_ERROR</xref>.
+            the reduced maximum; see <xref target="COMPRESSION" section="4.2"/>.  A decoder MUST
+            treat a field block without a sufficiently small Dynamic Table Size Update instruction
+            that follows an acknowledgment of a reduction of SETTINGS_HEADER_TABLE_SIZE as a <xref
+            target="ConnectionErrorHandler">connection error</xref> of type <xref
+            target="COMPRESSION_ERROR" format="none">COMPRESSION_ERROR</xref>.
           </t>
           <aside>
             <t>
-              Implementers are advised that support for reducing the value of
-              SETTINGS_HEADER_TABLE_SIZE is not interoperable.  This includes use of the connection
-              preface to reduce the value below the initial value of 4,096.
+              Implementers are advised that reducing the value of SETTINGS_HEADER_TABLE_SIZE is not
+              widely interoperable.  Use of the connection preface to reduce the value below the
+              initial value of 4,096 is somewhat better supported, but this might fail with some
+              implementations.
             </t>
           </aside>
-          <t>
-            This differs from the requirement in <xref target="COMPRESSION" section="4.2"/> as it
-            allows an encoder to omit the instruction if the dynamic table size does not change.
-            Experience with deployed implementations shows that this is more interoperable.
-          </t>
         </section>
       </section>
     </section>


### PR DESCRIPTION
This reverts commit 290e381719b2fefe4e6182d3be288c48e8f5fd7e.
See #1003 for most of the discussion.

The key change here is to address #1004 by only requiring that the change be signaled when the table size is reduced.  When I dug more into this, it's a more disruptive change, so I've made a bunch of additional changes in support of that.

