### PR TITLE
Éric Vyncke's feedback.

### DIFF
--- a/draft-ietf-httpbis-http2bis.xml
+++ b/draft-ietf-httpbis-http2bis.xml
@@ -300,17 +300,9 @@
           </li>
           <li>
             <t>
-                The string "h2c" identifies the protocol where HTTP/2 is run over cleartext TCP.
-                This identifier is used in any place where HTTP/2 over TCP is identified.
-            </t>
-            <t>
-                The "h2c" string is reserved from the ALPN identifier space but describes a protocol
-                that does not use TLS.  The security properties of HTTP/2 as defined in this
-                document do not hold unless TLS is used; see <xref target="security"/>.
-            </t>
-            <t>
                 The "h2c" string was previously used as a token for use in the HTTP Upgrade mechanism's
-                Upgrade header field (<xref target="HTTP" section="7.8"/>). This usage was never widely
+                Upgrade header field (<xref target="HTTP" section="7.8"/>) and as an identifier for the
+                protocol where HTTP/2 is run over cleartext TCP. This usage was never widely
                 deployed, and is deprecated by this document.
             </t>
           </li>
@@ -1136,7 +1128,7 @@ HTTP Frame {
           </t>
           <ol spacing="normal" type="1">
             <li>
-                Flow control is specific to a connection.  Both types of flow control are between
+                Flow control is specific to a connection.  HTTP/2 flow control operates between
                 the endpoints of a single hop and not over the entire end-to-end path.
               </li>
             <li>
@@ -2194,7 +2186,7 @@ PUSH_PROMISE Frame {
           <name>PING Frame Format</name>
           <artwork type="inline"><![CDATA[
 PING Frame {
-  Length (24),
+  Length (24) = 0x8,
   Type (8) = 0x6,
 
   Unused Flags (7),
@@ -4886,6 +4878,9 @@ cookie: e=f
       offer an ephemeral key exchange and those that are based on the TLS null, stream, or block
       cipher type (as defined in <xref target="TLS12" section="6.2.3"/>).  Additional cipher suites
       with these properties could be defined; these would not be explicitly prohibited.</t></aside>
+      <t>
+        For more details, see <xref target="tls12ciphers"/>
+      </t>
     </section>
     <section anchor="revision-updates">
       <name>Changes from RFC 7540</name>


### PR DESCRIPTION
Tweaked the mention of h2c to avoid describing it with much depth.
Clarified "both types of flow control".
Express that there's only one valid length for PING frames.
Add a reference to the TLS Ciphers section from Appendix A.