### PR TITLE
Restore change to Experimental Use policies

### DIFF
--- a/draft-ietf-httpbis-http2bis.xml
+++ b/draft-ietf-httpbis-http2bis.xml
@@ -4156,6 +4156,11 @@ cookie: e=f
         <tt>PRI</tt> method needs to be updated to refer to <xref target="preface"/>; all other
         section numbers have not changed.
       </t>
+      <t>
+        IANA is requested to change the policy on those portions of the "HTTP/2 Frame Type" and
+        "HTTP/2 Settings" registries that were reserved for Experimental Use in RFC 7540. These
+        portions of the registry shall operate on the same policy as the remainder of each registry.
+      </t>
       <section anchor="HTTP2-Settings">
         <name>HTTP2-Settings Header Field Registration</name>
         <t>


### PR DESCRIPTION
This change was lost in a major refactoring of the section accidentally.
Restore that.