### PR TITLE
Shorter name

### DIFF
--- a/draft-ietf-httpbis-http2bis.xml
+++ b/draft-ietf-httpbis-http2bis.xml
@@ -18,7 +18,7 @@
   <x:feedback template="mailto:ietf-http-wg@w3.org?subject={docname},%20%22{section}%22&amp;body=&lt;{ref}&gt;:"/>
   -->
   <front>
-    <title abbrev="HTTP/2">Hypertext Transfer Protocol Version 2 (HTTP/2)</title>
+    <title>HTTP/2</title>
     <seriesInfo name="Internet-Draft" value="draft-ietf-httpbis-http2bis-latest"/>
     <author initials="M." surname="Thomson" fullname="Martin Thomson" role="editor">
       <organization>Mozilla</organization>


### PR DESCRIPTION
draft-ietf-httpbis-messaging is now going to be known as "HTTP/1.1".
Follow suit.