### PR TITLE
Add some warnings about concatenation of URI parts

### DIFF
--- a/draft-ietf-httpbis-http2bis.xml
+++ b/draft-ietf-httpbis-http2bis.xml
@@ -3883,6 +3883,13 @@ cookie: e=f
           could be exploited by an attacker.
         </t>
         <t>
+          <xref target="HttpHeaders"/> does not include specific rules for validation of
+          pseudo-header fields.  If the values of these fields are used, additional validation is
+          necessary.  This is particularly important where <tt>:scheme</tt>, <tt>:authority</tt>,
+          and <tt>:path</tt> are combined to form a single URI string (<xref target="RFC3986"/>).
+          Simple concatenation is not secure unless the input values are fully validated.
+        </t>
+        <t>
           An intermediary can reject fields that contain invalid field names or values for other
           reasons, in particular those that do not conform to the HTTP ABNF grammar from <xref target="HTTP" section="5"/>. Intermediaries that do not perform any validation of fields
           other than the minimum required by <xref target="HttpHeaders"/> could forward messages

--- a/draft-ietf-httpbis-http2bis.xml
+++ b/draft-ietf-httpbis-http2bis.xml
@@ -3885,9 +3885,12 @@ cookie: e=f
         <t>
           <xref target="HttpHeaders"/> does not include specific rules for validation of
           pseudo-header fields.  If the values of these fields are used, additional validation is
-          necessary.  This is particularly important where <tt>:scheme</tt>, <tt>:authority</tt>,
-          and <tt>:path</tt> are combined to form a single URI string (<xref target="RFC3986"/>).
-          Simple concatenation is not secure unless the input values are fully validated.
+          necessary. This is particularly important where <tt>:scheme</tt>, <tt>:authority</tt>, and
+          <tt>:path</tt> are combined to form a single URI string (<xref
+          target="RFC3986"/>). Similar problems might occur when that URI or just <tt>:path</tt> are
+          combined with <tt>:method</tt> to construct a request line (as in <xref target="HTTP11"
+          section="3"/>). Simple concatenation is not secure unless the input values are fully
+          validated.
         </t>
         <t>
           An intermediary can reject fields that contain invalid field names or values for other


### PR DESCRIPTION
It's going to happen anyway, but we can at least warn people.

This doesn't specify what validation is necessary in any detail (that is
somewhat involved), it only notes that simple concatenation is almost
certainly not secure.

Closes #1015.