### PR TITLE
Address IANA note

### DIFF
--- a/draft-ietf-httpbis-http2bis.xml
+++ b/draft-ietf-httpbis-http2bis.xml
@@ -4252,7 +4252,7 @@ cookie: e=f
           <dt>Field Name:</dt>
           <dd>HTTP2-Settings</dd>
           <dt>Status:</dt>
-          <dd>Standard</dd>
+          <dd>obsoleted</dd>
           <dt>Ref.:</dt>
           <dd>
             <xref target="RFC7540" section="3.2.1"/>


### PR DESCRIPTION
Standard is not a status a header field can have, it turns out.

There isn't necessarily time in the process to make this change, but as a just-in-case measure I opened this. IANA has correctly updated the assignment anyway.