### PR TITLE
Pad hexadecimal literals to even digits

### DIFF
--- a/draft-ietf-httpbis-http2bis.xml
+++ b/draft-ietf-httpbis-http2bis.xml
@@ -466,21 +466,21 @@ HTTP Frame {
             <t>
               Flags are assigned semantics specific to the indicated frame type.  Unused flags are
               those that have no defined semantics for a particular frame type. Unused flags MUST be
-              ignored on receipt and MUST be left unset (0x0) when sending.
+              ignored on receipt and MUST be left unset (0x00) when sending.
             </t>
           </dd>
           <dt>Reserved:</dt>
           <dd>
             <t>
                 A reserved 1-bit field.  The semantics of this bit are undefined, and the bit MUST
-                remain unset (0x0) when sending and MUST be ignored when receiving.
+                remain unset (0x00) when sending and MUST be ignored when receiving.
             </t>
           </dd>
           <dt>Stream Identifier:</dt>
           <dd>
             <t>
                 A stream identifier (see <xref target="StreamIdentifiers"/>) expressed as an
-                unsigned 31-bit integer.  The value 0x0 is reserved for frames that are associated
+                unsigned 31-bit integer.  The value 0x00 is reserved for frames that are associated
                 with the connection as a whole as opposed to an individual stream.
             </t>
           </dd>
@@ -1094,7 +1094,7 @@ HTTP Frame {
           <t>
             Streams are identified by an unsigned 31-bit integer.  Streams initiated by a client
             MUST use odd-numbered stream identifiers; those initiated by the server MUST use
-            even-numbered stream identifiers.  A stream identifier of zero (0x0) is used for
+            even-numbered stream identifiers.  A stream identifier of zero (0x00) is used for
             connection control messages; the stream identifier of zero cannot be used to establish a
             new stream.
           </t>
@@ -1499,7 +1499,7 @@ HTTP Frame {
       <section anchor="DATA">
         <name>DATA</name>
         <t>
-          DATA frames (type=0x0) convey arbitrary, variable-length sequences of octets associated
+          DATA frames (type=0x00) convey arbitrary, variable-length sequences of octets associated
           with a stream. One or more DATA frames are used, for instance, to carry HTTP request or
           response message contents.
         </t>
@@ -1512,7 +1512,7 @@ HTTP Frame {
           <artwork type="inline"><![CDATA[
 DATA Frame {
   Length (24),
-  Type (8) = 0x0,
+  Type (8) = 0x00,
 
   Unused Flags (4),
   PADDED Flag (1),
@@ -1556,12 +1556,12 @@ DATA Frame {
           The DATA frame defines the following flags:
         </t>
         <dl newline="false" spacing="normal">
-          <dt>PADDED (0x8):</dt>
+          <dt>PADDED (0x08):</dt>
           <dd>
               When set, the PADDED flag indicates that the Pad Length field and any padding that it describes
               are present.
             </dd>
-          <dt>END_STREAM (0x1):</dt>
+          <dt>END_STREAM (0x01):</dt>
           <dd>
               When set, the END_STREAM flag indicates that this frame is the last that the endpoint will send for
               the identified stream.  Setting this flag causes the stream to enter one of <xref target="StreamStates">the "half-closed" states or the "closed" state</xref>.
@@ -1577,7 +1577,7 @@ DATA Frame {
         </aside>
         <t>
           DATA frames MUST be associated with a stream. If a DATA frame is received whose stream
-          identifier field is 0x0, the recipient MUST respond with a <xref target="ConnectionErrorHandler">connection error</xref> of type
+          identifier field is 0x00, the recipient MUST respond with a <xref target="ConnectionErrorHandler">connection error</xref> of type
           <xref target="PROTOCOL_ERROR" format="none">PROTOCOL_ERROR</xref>.
         </t>
         <t>
@@ -1604,7 +1604,7 @@ DATA Frame {
       <section anchor="HEADERS">
         <name>HEADERS</name>
         <t>
-          The HEADERS frame (type=0x1) is used to <xref target="StreamStates">open a stream</xref>,
+          The HEADERS frame (type=0x01) is used to <xref target="StreamStates">open a stream</xref>,
           and additionally carries a field block fragment. Despite the name, a HEADERS frame can carry
           a header section or a trailer section. HEADERS frames can be sent on a stream
           in the "idle", "reserved (local)", "open", or "half-closed (remote)" state.
@@ -1614,7 +1614,7 @@ DATA Frame {
           <artwork type="inline"><![CDATA[
 HEADERS Frame {
   Length (24),
-  Type (8) = 0x1,
+  Type (8) = 0x01,
 
   Unused Flags (2),
   PRIORITY Flag (1),
@@ -1682,14 +1682,14 @@ HEADERS Frame {
               fields are present.
             </t>
           </dd>
-          <dt>PADDED (0x8):</dt>
+          <dt>PADDED (0x08):</dt>
           <dd>
             <t>
                 When set, the PADDED flag indicates that the Pad Length field and any padding that it
                 describes are present.
             </t>
           </dd>
-          <dt>END_HEADERS (0x4):</dt>
+          <dt>END_HEADERS (0x04):</dt>
           <dd>
             <t>
                 When set, the END_HEADERS flag indicates that this frame contains an entire <xref target="FieldBlock">field block</xref> and is not followed by any
@@ -1702,7 +1702,7 @@ HEADERS Frame {
                 <xref target="PROTOCOL_ERROR" format="none">PROTOCOL_ERROR</xref>.
             </t>
           </dd>
-          <dt>END_STREAM (0x1):</dt>
+          <dt>END_STREAM (0x01):</dt>
           <dd>
             <t>
                 When set, the END_STREAM flag indicates that the <xref target="FieldBlock">field block</xref> is
@@ -1723,7 +1723,7 @@ HEADERS Frame {
         </t>
         <t>
           HEADERS frames MUST be associated with a stream. If a HEADERS frame is received whose
-          stream identifier field is 0x0, the recipient MUST respond with a <xref target="ConnectionErrorHandler">connection error</xref> of type
+          stream identifier field is 0x00, the recipient MUST respond with a <xref target="ConnectionErrorHandler">connection error</xref> of type
           <xref target="PROTOCOL_ERROR" format="none">PROTOCOL_ERROR</xref>.
         </t>
         <t>
@@ -1745,15 +1745,15 @@ HEADERS Frame {
       <section anchor="PRIORITY">
         <name>PRIORITY</name>
         <t>
-          The PRIORITY frame (type=0x2) is deprecated; see <xref target="PriorityHere"/>.  A
+          The PRIORITY frame (type=0x02) is deprecated; see <xref target="PriorityHere"/>.  A
           PRIORITY frame can be sent in any stream state, including idle or closed streams.
         </t>
         <figure anchor="PRIORITYFrameFormat">
           <name>PRIORITY Frame Format</name>
           <artwork type="inline"><![CDATA[
 PRIORITY Frame {
-  Length (24) = 0x5,
-  Type (8) = 0x2,
+  Length (24) = 0x05,
+  Type (8) = 0x02,
 
   Unused Flags (8),
 
@@ -1789,7 +1789,7 @@ PRIORITY Frame {
         </t>
         <t>
           The PRIORITY frame always identifies a stream.  If a PRIORITY frame is received with a
-          stream identifier of 0x0, the recipient MUST respond with a <xref target="ConnectionErrorHandler">connection error</xref> of type <xref target="PROTOCOL_ERROR" format="none">PROTOCOL_ERROR</xref>.
+          stream identifier of 0x00, the recipient MUST respond with a <xref target="ConnectionErrorHandler">connection error</xref> of type <xref target="PROTOCOL_ERROR" format="none">PROTOCOL_ERROR</xref>.
         </t>
         <t>
           Sending or receiving a PRIORITY frame does not affect the state of any stream (<xref target="StreamStates"/>).  The PRIORITY frame can be sent on a stream in any state,
@@ -1803,7 +1803,7 @@ PRIORITY Frame {
       <section anchor="RST_STREAM">
         <name>RST_STREAM</name>
         <t>
-          The RST_STREAM frame (type=0x3) allows for immediate termination of a stream.  RST_STREAM
+          The RST_STREAM frame (type=0x03) allows for immediate termination of a stream.  RST_STREAM
           is sent to request cancellation of a stream or to indicate that an error condition has
           occurred.
         </t>
@@ -1811,8 +1811,8 @@ PRIORITY Frame {
           <name>RST_STREAM Frame Format</name>
           <artwork type="inline"><![CDATA[
 RST_STREAM Frame {
-  Length (24) = 0x4,
-  Type (8) = 0x3,
+  Length (24) = 0x04,
+  Type (8) = 0x03,
 
   Unused Flags (8),
 
@@ -1841,7 +1841,7 @@ RST_STREAM Frame {
         </t>
         <t>
           RST_STREAM frames MUST be associated with a stream.  If a RST_STREAM frame is received
-          with a stream identifier of 0x0, the recipient MUST treat this as a <xref target="ConnectionErrorHandler">connection error</xref> of type
+          with a stream identifier of 0x00, the recipient MUST treat this as a <xref target="ConnectionErrorHandler">connection error</xref> of type
           <xref target="PROTOCOL_ERROR" format="none">PROTOCOL_ERROR</xref>.
         </t>
         <t>
@@ -1857,7 +1857,7 @@ RST_STREAM Frame {
       <section anchor="SETTINGS">
         <name>SETTINGS</name>
         <t>
-          The SETTINGS frame (type=0x4) conveys configuration parameters that affect how endpoints
+          The SETTINGS frame (type=0x04) conveys configuration parameters that affect how endpoints
           communicate, such as preferences and constraints on peer behavior.  The SETTINGS frame is
           also used to acknowledge the receipt of those settings.  Individually, a configuration
           parameter from a SETTINGS frame is referred to as a "setting".
@@ -1885,7 +1885,7 @@ RST_STREAM Frame {
           frame defines the ACK flag:
         </t>
         <dl newline="false" spacing="normal">
-          <dt>ACK (0x1):</dt>
+          <dt>ACK (0x01):</dt>
           <dd>
               When set, the ACK flag indicates that this frame acknowledges receipt and application of the
               peer's SETTINGS frame.  When this bit is set, the frame payload of the SETTINGS frame MUST
@@ -1896,8 +1896,8 @@ RST_STREAM Frame {
         </dl>
         <t>
           SETTINGS frames always apply to a connection, never a single stream.  The stream
-          identifier for a SETTINGS frame MUST be zero (0x0). If an endpoint receives a SETTINGS
-          frame whose stream identifier field is anything other than 0x0, the endpoint MUST respond
+          identifier for a SETTINGS frame MUST be zero (0x00). If an endpoint receives a SETTINGS
+          frame whose stream identifier field is anything other than 0x00, the endpoint MUST respond
           with a <xref target="ConnectionErrorHandler">connection error</xref> of type
           <xref target="PROTOCOL_ERROR" format="none">PROTOCOL_ERROR</xref>.
         </t>
@@ -1921,7 +1921,7 @@ RST_STREAM Frame {
             <artwork type="inline"><![CDATA[
 SETTINGS Frame {
   Length (24),
-  Type (8) = 0x4,
+  Type (8) = 0x04,
 
   Unused Flags (7),
   ACK Flag (1),
@@ -1960,7 +1960,7 @@ Setting {
             The following settings are defined:
           </t>
           <dl newline="false" spacing="normal">
-            <dt anchor="SETTINGS_HEADER_TABLE_SIZE">SETTINGS_HEADER_TABLE_SIZE (0x1):</dt>
+            <dt anchor="SETTINGS_HEADER_TABLE_SIZE">SETTINGS_HEADER_TABLE_SIZE (0x01):</dt>
             <dd>
               <t>
                   Allows the sender to inform the remote endpoint of the maximum size of the
@@ -1969,7 +1969,7 @@ Setting {
                   compression format inside a field block (see <xref target="COMPRESSION"/>). The initial value is 4,096 octets.
               </t>
             </dd>
-            <dt anchor="SETTINGS_ENABLE_PUSH">SETTINGS_ENABLE_PUSH (0x2):</dt>
+            <dt anchor="SETTINGS_ENABLE_PUSH">SETTINGS_ENABLE_PUSH (0x02):</dt>
             <dd>
               <t>
                 This setting can be used to disable <xref target="PushResources">server
@@ -1994,7 +1994,7 @@ Setting {
                 <xref target="PROTOCOL_ERROR" format="none">PROTOCOL_ERROR</xref>.
               </t>
             </dd>
-            <dt anchor="SETTINGS_MAX_CONCURRENT_STREAMS">SETTINGS_MAX_CONCURRENT_STREAMS (0x3):</dt>
+            <dt anchor="SETTINGS_MAX_CONCURRENT_STREAMS">SETTINGS_MAX_CONCURRENT_STREAMS (0x03):</dt>
             <dd>
               <t>
                   Indicates the maximum number of concurrent streams that the sender will allow.
@@ -2011,7 +2011,7 @@ Setting {
                   accept requests, closing the connection is more appropriate.
               </t>
             </dd>
-            <dt anchor="SETTINGS_INITIAL_WINDOW_SIZE">SETTINGS_INITIAL_WINDOW_SIZE (0x4):</dt>
+            <dt anchor="SETTINGS_INITIAL_WINDOW_SIZE">SETTINGS_INITIAL_WINDOW_SIZE (0x04):</dt>
             <dd>
               <t>
                   Indicates the sender's initial window size (in units of octets) for stream-level flow
@@ -2026,7 +2026,7 @@ Setting {
                   type <xref target="FLOW_CONTROL_ERROR" format="none">FLOW_CONTROL_ERROR</xref>.
               </t>
             </dd>
-            <dt anchor="SETTINGS_MAX_FRAME_SIZE">SETTINGS_MAX_FRAME_SIZE (0x5):</dt>
+            <dt anchor="SETTINGS_MAX_FRAME_SIZE">SETTINGS_MAX_FRAME_SIZE (0x05):</dt>
             <dd>
               <t>
                   Indicates the size of the largest frame payload that the sender is willing to
@@ -2040,7 +2040,7 @@ Setting {
                   of type <xref target="PROTOCOL_ERROR" format="none">PROTOCOL_ERROR</xref>.
               </t>
             </dd>
-            <dt anchor="SETTINGS_MAX_HEADER_LIST_SIZE">SETTINGS_MAX_HEADER_LIST_SIZE (0x6):</dt>
+            <dt anchor="SETTINGS_MAX_HEADER_LIST_SIZE">SETTINGS_MAX_HEADER_LIST_SIZE (0x06):</dt>
             <dd>
               <t>
                   This advisory setting informs a peer of the maximum size of field section that the
@@ -2089,7 +2089,7 @@ Setting {
       <section anchor="PUSH_PROMISE">
         <name>PUSH_PROMISE</name>
         <t>
-          The PUSH_PROMISE frame (type=0x5) is used to notify the peer endpoint in advance of
+          The PUSH_PROMISE frame (type=0x05) is used to notify the peer endpoint in advance of
           streams the sender intends to initiate.  The PUSH_PROMISE frame includes the unsigned
           31-bit identifier of the stream the endpoint plans to create along with a field section
           that provides additional context for the stream.  <xref target="PushResources"/> contains a
@@ -2100,7 +2100,7 @@ Setting {
           <artwork type="inline"><![CDATA[
 PUSH_PROMISE Frame {
   Length (24),
-  Type (8) = 0x5,
+  Type (8) = 0x05,
 
   Unused Flags (4),
   PADDED Flag (1),
@@ -2155,14 +2155,14 @@ PUSH_PROMISE Frame {
           The PUSH_PROMISE frame defines the following flags:
         </t>
         <dl newline="false" spacing="normal">
-          <dt>PADDED (0x8):</dt>
+          <dt>PADDED (0x08):</dt>
           <dd>
             <t>
                 When set, the PADDED flag indicates that the Pad Length field and any padding that it
                 describes are present.
             </t>
           </dd>
-          <dt>END_HEADERS (0x4):</dt>
+          <dt>END_HEADERS (0x04):</dt>
           <dd>
             <t>
                 When set, the END_HEADERS flag indicates that this frame contains an entire <xref target="FieldBlock">field block</xref> and is not followed by any
@@ -2180,7 +2180,7 @@ PUSH_PROMISE Frame {
           PUSH_PROMISE frames MUST only be sent on a peer-initiated stream that is in either the
           "open" or "half-closed (remote)" state. The stream identifier of a PUSH_PROMISE frame
           indicates the stream it is associated with.  If the stream identifier field specifies the
-          value 0x0, a recipient MUST respond with a <xref target="ConnectionErrorHandler">connection error</xref> of type
+          value 0x00, a recipient MUST respond with a <xref target="ConnectionErrorHandler">connection error</xref> of type
           <xref target="PROTOCOL_ERROR" format="none">PROTOCOL_ERROR</xref>.
         </t>
         <t>
@@ -2235,7 +2235,7 @@ PUSH_PROMISE Frame {
       <section anchor="PING">
         <name>PING</name>
         <t>
-          The PING frame (type=0x6) is a mechanism for measuring a minimal round-trip time from the
+          The PING frame (type=0x06) is a mechanism for measuring a minimal round-trip time from the
           sender, as well as determining whether an idle connection is still functional.  PING
           frames can be sent from any endpoint.
         </t>
@@ -2243,8 +2243,8 @@ PUSH_PROMISE Frame {
           <name>PING Frame Format</name>
           <artwork type="inline"><![CDATA[
 PING Frame {
-  Length (24) = 0x8,
-  Type (8) = 0x6,
+  Length (24) = 0x08,
+  Type (8) = 0x06,
 
   Unused Flags (7),
   ACK Flag (1),
@@ -2272,7 +2272,7 @@ PING Frame {
           The PING frame defines the following flags:
         </t>
         <dl newline="false" spacing="normal">
-          <dt>ACK (0x1):</dt>
+          <dt>ACK (0x01):</dt>
           <dd>
               When set, the ACK flag indicates that this PING frame is a PING response.  An endpoint MUST
               set this flag in PING responses.  An endpoint MUST NOT respond to PING frames
@@ -2281,7 +2281,7 @@ PING Frame {
         </dl>
         <t>
           PING frames are not associated with any individual stream. If a PING frame is received
-          with a stream identifier field value other than 0x0, the recipient MUST respond with a
+          with a stream identifier field value other than 0x00, the recipient MUST respond with a
           <xref target="ConnectionErrorHandler">connection error</xref> of type
           <xref target="PROTOCOL_ERROR" format="none">PROTOCOL_ERROR</xref>.
         </t>
@@ -2293,7 +2293,7 @@ PING Frame {
       <section anchor="GOAWAY">
         <name>GOAWAY</name>
         <t>
-          The GOAWAY frame (type=0x7) is used to initiate shutdown of a connection or to signal
+          The GOAWAY frame (type=0x07) is used to initiate shutdown of a connection or to signal
           serious error conditions.  GOAWAY allows an endpoint to gracefully stop accepting new
           streams while still finishing processing of previously established streams.  This enables
           administrative actions, like server maintenance.
@@ -2339,7 +2339,7 @@ PING Frame {
           <artwork type="inline"><![CDATA[
 GOAWAY Frame {
   Length (24),
-  Type (8) = 0x7,
+  Type (8) = 0x07,
 
   Unused Flags (8),
 
@@ -2361,7 +2361,7 @@ GOAWAY Frame {
         </t>
         <t>
           The GOAWAY frame applies to the connection, not a specific stream.  An endpoint MUST treat
-          a <xref target="GOAWAY" format="none">GOAWAY</xref> frame with a stream identifier other than 0x0 as a <xref target="ConnectionErrorHandler">connection error</xref> of type
+          a <xref target="GOAWAY" format="none">GOAWAY</xref> frame with a stream identifier other than 0x00 as a <xref target="ConnectionErrorHandler">connection error</xref> of type
           <xref target="PROTOCOL_ERROR" format="none">PROTOCOL_ERROR</xref>.
         </t>
         <t>
@@ -2439,7 +2439,7 @@ GOAWAY Frame {
       <section anchor="WINDOW_UPDATE">
         <name>WINDOW_UPDATE</name>
         <t>
-          The WINDOW_UPDATE frame (type=0x8) is used to implement flow control; see <xref target="FlowControl"/> for an overview.
+          The WINDOW_UPDATE frame (type=0x08) is used to implement flow control; see <xref target="FlowControl"/> for an overview.
         </t>
         <t>
           Flow control operates at two levels: on each individual stream and on the entire
@@ -2463,8 +2463,8 @@ GOAWAY Frame {
           <name>WINDOW_UPDATE Frame Format</name>
           <artwork type="inline"><![CDATA[
 WINDOW_UPDATE Frame {
-  Length (24) = 0x4,
-  Type (8) = 0x8,
+  Length (24) = 0x04,
+  Type (8) = 0x08,
 
   Unused Flags (8),
 
@@ -2630,7 +2630,7 @@ WINDOW_UPDATE Frame {
       <section anchor="CONTINUATION">
         <name>CONTINUATION</name>
         <t>
-          The CONTINUATION frame (type=0x9) is used to continue a sequence of <xref target="FieldBlock">field block fragments</xref>.  Any number of CONTINUATION frames can
+          The CONTINUATION frame (type=0x09) is used to continue a sequence of <xref target="FieldBlock">field block fragments</xref>.  Any number of CONTINUATION frames can
           be sent, as long as the preceding frame is on the same stream and is a
           <xref target="HEADERS" format="none">HEADERS</xref>, <xref target="PUSH_PROMISE" format="none">PUSH_PROMISE</xref>, or CONTINUATION frame without the
           END_HEADERS flag set.
@@ -2640,7 +2640,7 @@ WINDOW_UPDATE Frame {
           <artwork type="inline"><![CDATA[
 CONTINUATION Frame {
   Length (24),
-  Type (8) = 0x9,
+  Type (8) = 0x09,
 
   Unused Flags (5),
   END_HEADERS Flag (1),
@@ -2662,7 +2662,7 @@ CONTINUATION Frame {
           The CONTINUATION frame defines the following flag:
         </t>
         <dl newline="false" spacing="normal">
-          <dt>END_HEADERS (0x4):</dt>
+          <dt>END_HEADERS (0x04):</dt>
           <dd>
             <t>
                 When set, the END_HEADERS flag indicates that this frame ends a <xref target="FieldBlock">field
@@ -2681,7 +2681,7 @@ CONTINUATION Frame {
         </t>
         <t>
           CONTINUATION frames MUST be associated with a stream. If a CONTINUATION frame is received
-          whose stream identifier field is 0x0, the recipient MUST respond with a <xref target="ConnectionErrorHandler">connection error</xref> of type PROTOCOL_ERROR.
+          whose stream identifier field is 0x00, the recipient MUST respond with a <xref target="ConnectionErrorHandler">connection error</xref> of type PROTOCOL_ERROR.
         </t>
         <t>
           A CONTINUATION frame MUST be preceded by a <xref target="HEADERS" format="none">HEADERS</xref>,
@@ -2705,68 +2705,68 @@ CONTINUATION Frame {
         The following error codes are defined:
       </t>
       <dl newline="false" spacing="normal">
-        <dt>NO_ERROR (0x0):</dt>
+        <dt>NO_ERROR (0x00):</dt>
         <dd anchor="NO_ERROR">
             The associated condition is not a result of an error.  For example, a
             <xref target="GOAWAY" format="none">GOAWAY</xref> might include this code to indicate graceful shutdown of a
             connection.
           </dd>
-        <dt>PROTOCOL_ERROR (0x1):</dt>
+        <dt>PROTOCOL_ERROR (0x01):</dt>
         <dd anchor="PROTOCOL_ERROR">
             The endpoint detected an unspecific protocol error.  This error is for use when a more
             specific error code is not available.
           </dd>
-        <dt>INTERNAL_ERROR (0x2):</dt>
+        <dt>INTERNAL_ERROR (0x02):</dt>
         <dd anchor="INTERNAL_ERROR">
             The endpoint encountered an unexpected internal error.
           </dd>
-        <dt>FLOW_CONTROL_ERROR (0x3):</dt>
+        <dt>FLOW_CONTROL_ERROR (0x03):</dt>
         <dd anchor="FLOW_CONTROL_ERROR">
             The endpoint detected that its peer violated the flow-control protocol.
           </dd>
-        <dt>SETTINGS_TIMEOUT (0x4):</dt>
+        <dt>SETTINGS_TIMEOUT (0x04):</dt>
         <dd anchor="SETTINGS_TIMEOUT">
             The endpoint sent a <xref target="SETTINGS" format="none">SETTINGS</xref> frame but did not receive a response in a
             timely manner.  See <xref target="SettingsSync"/> ("Settings Synchronization").
           </dd>
-        <dt>STREAM_CLOSED (0x5):</dt>
+        <dt>STREAM_CLOSED (0x05):</dt>
         <dd anchor="STREAM_CLOSED">
             The endpoint received a frame after a stream was half-closed.
           </dd>
-        <dt>FRAME_SIZE_ERROR (0x6):</dt>
+        <dt>FRAME_SIZE_ERROR (0x06):</dt>
         <dd anchor="FRAME_SIZE_ERROR">
             The endpoint received a frame with an invalid size.
           </dd>
-        <dt>REFUSED_STREAM (0x7):</dt>
+        <dt>REFUSED_STREAM (0x07):</dt>
         <dd anchor="REFUSED_STREAM">
             The endpoint refused the stream prior to performing any application processing (see
             <xref target="Reliability"/> for details).
           </dd>
-        <dt>CANCEL (0x8):</dt>
+        <dt>CANCEL (0x08):</dt>
         <dd anchor="CANCEL">
             Used by the endpoint to indicate that the stream is no longer needed.
           </dd>
-        <dt>COMPRESSION_ERROR (0x9):</dt>
+        <dt>COMPRESSION_ERROR (0x09):</dt>
         <dd anchor="COMPRESSION_ERROR">
             The endpoint is unable to maintain the field section compression context for the
             connection.
           </dd>
-        <dt>CONNECT_ERROR (0xa):</dt>
+        <dt>CONNECT_ERROR (0x0a):</dt>
         <dd anchor="CONNECT_ERROR">
             The connection established in response to a <xref target="CONNECT">CONNECT
             request</xref> was reset or abnormally closed.
           </dd>
-        <dt>ENHANCE_YOUR_CALM (0xb):</dt>
+        <dt>ENHANCE_YOUR_CALM (0x0b):</dt>
         <dd anchor="ENHANCE_YOUR_CALM">
             The endpoint detected that its peer is exhibiting a behavior that might be generating
             excessive load.
           </dd>
-        <dt>INADEQUATE_SECURITY (0xc):</dt>
+        <dt>INADEQUATE_SECURITY (0x0c):</dt>
         <dd anchor="INADEQUATE_SECURITY">
             The underlying transport has properties that do not meet minimum security
             requirements (see <xref target="TLSUsage"/>).
           </dd>
-        <dt>HTTP_1_1_REQUIRED (0xd):</dt>
+        <dt>HTTP_1_1_REQUIRED (0x0d):</dt>
         <dd anchor="HTTP_1_1_REQUIRED">
             The endpoint requires that HTTP/1.1 be used instead of HTTP/2.
           </dd>
@@ -2959,12 +2959,12 @@ CONTINUATION Frame {
               colon (ASCII COLON, 0x3a).
             </li>
             <li>
-              A field value MUST NOT contain the zero value (ASCII NUL, 0x0), line feed (ASCII LF,
-              0xa), or carriage return (ASCII CR, 0xd) at any position.
+              A field value MUST NOT contain the zero value (ASCII NUL, 0x00), line feed (ASCII LF,
+              0x0a), or carriage return (ASCII CR, 0x0d) at any position.
             </li>
             <li>
               A field value MUST NOT start or end with an ASCII whitespace character (ASCII SP or
-              HTAB, 0x20 or 0x9).
+              HTAB, 0x20 or 0x09).
             </li>
           </ul>
           <aside>


### PR DESCRIPTION
We decided to do this for QUIC and it does improve readability and
consistency.

I did this manually, rather than trying to be clever with regexs.  I'd
appreciate a second pair of eyes.

I searched for `0x[0-9a-f](?:[0-9a-f]{2})*[^0-9a-f]` and found nothing;
same for `0x[0-9a-f]*[A-F][0-9a-f]*` (in case we had stray uppercase
strings).