### PR TITLE
bandwidth * delay product

### DIFF
--- a/draft-ietf-httpbis-http2bis.xml
+++ b/draft-ietf-httpbis-http2bis.xml
@@ -1223,13 +1223,13 @@ HTTP Frame {
             Deployments with constrained resources (for example, memory) can employ flow control to
             limit the amount of memory a peer can consume.  Note, however, that this can lead to
             suboptimal use of available network resources if flow control is enabled without
-            knowledge of the bandwidth-delay product (see <xref target="RFC7323"/>).
+            knowledge of the bandwidth * delay product (see <xref target="RFC7323"/>).
           </t>
           <t>
-            Even with full awareness of the current bandwidth-delay product, implementation of flow
-            control can be difficult.  Endpoints MUST read and process HTTP/2 frames from the TCP
-            receive buffer as soon as data is available.  Failure to read promptly could lead to a
-            deadlock when critical frames, such as <xref target="WINDOW_UPDATE"
+            Even with full awareness of the current bandwidth * delay product, implementation of
+            flow control can be difficult.  Endpoints MUST read and process HTTP/2 frames from the
+            TCP receive buffer as soon as data is available.  Failure to read promptly could lead to
+            a deadlock when critical frames, such as <xref target="WINDOW_UPDATE"
             format="none">WINDOW_UPDATE</xref>, are not read and acted upon. Reading frames promptly
             does not expose endpoints to resource exhaustion attacks as HTTP/2 flow control limits
             resource commitments.
@@ -1238,14 +1238,16 @@ HTTP Frame {
         <section anchor="FlowControlPerformance">
           <name>Flow Control Performance</name>
           <t>
-            If an endpoint cannot ensure that its peer always has available flow control window space that is greater than the peer's
-            bandwidth-delay product on this connection, its receive throughput will be limited by HTTP/2 flow control. This will result
-            in degraded performance.
+            If an endpoint cannot ensure that its peer always has available flow control window
+            space that is greater than the peer's bandwidth * delay product on this connection, its
+            receive throughput will be limited by HTTP/2 flow control. This will result in degraded
+            performance.
           </t>
           <t>
-            Sending timely <xref target="WINDOW_UPDATE" format="none">WINDOW_UPDATE</xref> frames can improve performance. Endpoints will
-            want to balance the need to improve receive throughput with the need to manage resource exhaustion risks, and should take
-            careful note of <xref target="dos"/> in defining their strategy to manage window sizes.
+            Sending timely <xref target="WINDOW_UPDATE" format="none">WINDOW_UPDATE</xref> frames
+            can improve performance. Endpoints will want to balance the need to improve receive
+            throughput with the need to manage resource exhaustion risks, and should take careful
+            note of <xref target="dos"/> in defining their strategy to manage window sizes.
           </t>
         </section>
       </section>

--- a/draft-ietf-httpbis-http2bis.xml
+++ b/draft-ietf-httpbis-http2bis.xml
@@ -1236,7 +1236,7 @@ HTTP Frame {
           </t>
         </section>
         <section anchor="FlowControlPerformance">
-          <name>Flow Control Performance</name>
+          <name>Flow-Control Performance</name>
           <t>
             If an endpoint cannot ensure that its peer always has available flow control window
             space that is greater than the peer's bandwidth * delay product on this connection, its


### PR DESCRIPTION
This looks terrible, but it's the form that the RFC we cite uses (also,
RFC 1323).

Closes #1032.