### PR TITLE
Quote pseudo field names

### DIFF
--- a/draft-ietf-httpbis-http2bis.xml
+++ b/draft-ietf-httpbis-http2bis.xml
@@ -3077,40 +3077,40 @@ cookie: e=f
           <ul spacing="normal">
             <li>
               <t>
-                  The <tt>:method</tt> pseudo-header field includes the HTTP
+                  The "<tt>:method</tt>" pseudo-header field includes the HTTP
                   method (<xref target="HTTP" section="9"/>).
               </t>
             </li>
             <li>
               <t>
-                The <tt>:scheme</tt> pseudo-header field includes the scheme portion of the request
+                The "<tt>:scheme</tt>" pseudo-header field includes the scheme portion of the request
                 target. The scheme is taken from the target URI (<xref target="RFC3986"
                 section="3.1"/>) when generating a request directly, or from the scheme of a
                 translated request (for example, see <xref target="HTTP11" section="3.3"/>). Scheme
                 is omitted for <xref target="CONNECT">CONNECT requests</xref>.
               </t>
-              <t><tt>:scheme</tt> is not restricted to <tt>http</tt> and <tt>https</tt> schemed
+              <t>"<tt>:scheme</tt>" is not restricted to <tt>http</tt> and <tt>https</tt> schemed
                 URIs.  A proxy or gateway can translate requests for non-HTTP schemes, enabling
                 the use of HTTP to interact with non-HTTP services.
               </t>
             </li>
             <li>
               <t>
-                The <tt>:authority</tt> pseudo-header field conveys the authority portion (<xref
+                The "<tt>:authority</tt>" pseudo-header field conveys the authority portion (<xref
                 target="RFC3986" section="3.2"/>) of the target URI (<xref target="HTTP"
                 section="7.1"/>). The recipient of a HTTP/2 request MUST NOT use the <tt>Host</tt>
-                header field to determine the target URI if <tt>:authority</tt> is present.
+                header field to determine the target URI if "<tt>:authority</tt>" is present.
               </t>
               <t>
-                Clients that generate HTTP/2 requests directly MUST use the <tt>:authority</tt>
+                Clients that generate HTTP/2 requests directly MUST use the "<tt>:authority</tt>"
                 pseudo-header field to convey authority information, unless there is no authority
-                information to convey (in which case it MUST NOT generate :authority).
+                information to convey (in which case it MUST NOT generate "<tt>:authority</tt>").
               </t>
               <t>
                 Clients MUST NOT generate a request with a <tt>Host</tt> header field that differs
-                from the <tt>:authority</tt> pseudo-header field.  A
+                from the "<tt>:authority</tt>" pseudo-header field.  A
                 server SHOULD treat a request as malformed if it contains a <tt>Host</tt> header
-                field that identifies a different entity to the <tt>:authority</tt> pseudo-header
+                field that identifies a different entity to the "<tt>:authority</tt>" pseudo-header
                 field.  The values of fields need to be normalized to compare them (see <xref
                 target="RFC3986" section="6.2"/>).  An origin server can apply any normalization
                 method, whereas other servers MUST perform scheme-based normalization (see <xref
@@ -3118,15 +3118,15 @@ cookie: e=f
               </t>
               <t>
                 An intermediary that forwards a request over HTTP/2 MUST construct an
-                <tt>:authority</tt> pseudo-header field using the authority information from the
+                "<tt>:authority</tt>" pseudo-header field using the authority information from the
                 control data of the original request, unless the original request's target URI
                 does not contain authority information (in which case it MUST NOT generate
-                <tt>:authority</tt>). Note that the <tt>Host</tt> header field is not the sole
+                "<tt>:authority</tt>"). Note that the <tt>Host</tt> header field is not the sole
                 source of this information; see <xref target="HTTP" section="7.2"/>.
               </t>
               <t>
                 An intermediary that needs to generate a <tt>Host</tt> header field (which might be
-                necessary to construct an HTTP/1.1 request) MUST use the value from the <tt>:authority</tt>
+                necessary to construct an HTTP/1.1 request) MUST use the value from the "<tt>:authority</tt>"
                 pseudo-header field as the value of the <tt>Host</tt> field,
                 unless the intermediary also changes the request target. This replaces any existing
                 <tt>Host</tt> field to avoid potential vulnerabilities in HTTP routing.
@@ -3140,18 +3140,18 @@ cookie: e=f
                 include authority information; see <xref target="HTTP" section="7.1"/>.
               </t>
               <t>
-                <tt>:authority</tt> MUST NOT include the deprecated userinfo subcomponent for
+                "<tt>:authority</tt>" MUST NOT include the deprecated userinfo subcomponent for
                 <tt>http</tt> or <tt>https</tt> schemed URIs.
               </t>
             </li>
             <li>
               <t>
-                  The <tt>:path</tt> pseudo-header field includes the path and
+                  The "<tt>:path</tt>" pseudo-header field includes the path and
                   query parts of the target URI (the <tt>absolute-path</tt>
                   production and optionally a '?' character followed by the
                   <tt>query</tt> production; see <xref target="HTTP" section="4.1"/>).
                   A request in asterisk form (for OPTIONS) includes the value '*' for the
-                  <tt>:path</tt> pseudo-header field.
+                  "<tt>:path</tt>" pseudo-header field.
               </t>
               <t>
                   This pseudo-header field MUST NOT be empty for <tt>http</tt> or <tt>https</tt>
@@ -3161,18 +3161,18 @@ cookie: e=f
               <ul>
                 <li>
                   an OPTIONS request for an <tt>http</tt> or <tt>https</tt> URI that does not include a path
-                  component; these MUST include a <tt>:path</tt> pseudo-header field with a value
+                  component; these MUST include a "<tt>:path</tt>" pseudo-header field with a value
                   of '*' (see <xref target="HTTP" section="7.1"/>)
                 </li>
                 <li>
-                  <xref target="CONNECT">CONNECT requests</xref>, where the <tt>:path</tt> pseudo-header field is omitted.
+                  <xref target="CONNECT">CONNECT requests</xref>, where the "<tt>:path</tt>" pseudo-header field is omitted.
                 </li>
               </ul>
             </li>
           </ul>
           <t>
-            All HTTP/2 requests MUST include exactly one valid value for the <tt>:method</tt>,
-            <tt>:scheme</tt>, and <tt>:path</tt> pseudo-header fields, unless it is a <xref
+            All HTTP/2 requests MUST include exactly one valid value for the "<tt>:method</tt>",
+            "<tt>:scheme</tt>", and "<tt>:path</tt>" pseudo-header fields, unless it is a <xref
             target="CONNECT">CONNECT request</xref>. An HTTP request that omits mandatory
             pseudo-header fields is <xref target="malformed">malformed</xref>.
           </t>
@@ -3185,7 +3185,7 @@ cookie: e=f
         <section anchor="HttpResponse">
           <name>Response Pseudo-Header Fields</name>
           <t>
-            For HTTP/2 responses, a single <tt>:status</tt> pseudo-header
+            For HTTP/2 responses, a single "<tt>:status</tt>" pseudo-header
             field is defined that carries the HTTP status code field (see
             <xref target="HTTP" section="15"/>). This pseudo-header field MUST be included in all
             responses, including interim responses; otherwise, the response is
@@ -3247,7 +3247,7 @@ cookie: e=f
           be made available to the application separately.
         </t>
         <t>
-          The server MUST include a value in the <tt>:authority</tt> pseudo-header field for which
+          The server MUST include a value in the "<tt>:authority</tt>" pseudo-header field for which
           the server is authoritative (see <xref target="authority"/>). A client MUST treat a <xref
           target="PUSH_PROMISE" format="none">PUSH_PROMISE</xref> for which the server is not
           authoritative as a <xref target="StreamErrorHandler">stream error</xref> of type <xref
@@ -3290,10 +3290,10 @@ cookie: e=f
             The header fields in <xref target="PUSH_PROMISE" format="none">PUSH_PROMISE</xref> and
             any subsequent <xref target="CONTINUATION" format="none">CONTINUATION</xref> frames MUST
             be a valid and complete set of <xref target="HttpRequest">request header
-            fields</xref>. The server MUST include a method in the <tt>:method</tt> pseudo-header
+            fields</xref>. The server MUST include a method in the "<tt>:method</tt>" pseudo-header
             field that is safe and cacheable. If a client receives a <xref target="PUSH_PROMISE"
             format="none">PUSH_PROMISE</xref> that does not include a complete and valid set of
-            header fields or the <tt>:method</tt> pseudo-header field identifies a method that is
+            header fields or the "<tt>:method</tt>" pseudo-header field identifies a method that is
             not safe, it MUST respond on the promised stream with a <xref
             target="StreamErrorHandler">stream error</xref> of type <xref target="PROTOCOL_ERROR"
             format="none">PROTOCOL_ERROR</xref>.
@@ -3403,14 +3403,14 @@ cookie: e=f
         </t>
         <ul spacing="normal">
           <li>
-              The <tt>:method</tt> pseudo-header field is set to <tt>CONNECT</tt>.
+              The "<tt>:method</tt>" pseudo-header field is set to <tt>CONNECT</tt>.
             </li>
           <li>
-              The <tt>:scheme</tt> and <tt>:path</tt> pseudo-header
+              The "<tt>:scheme</tt>" and "<tt>:path</tt>" pseudo-header
               fields MUST be omitted.
             </li>
           <li>
-              The <tt>:authority</tt> pseudo-header field contains the host and port to
+              The "<tt>:authority</tt>" pseudo-header field contains the host and port to
               connect to (equivalent to the authority-form of the request-target of CONNECT
               requests; see <xref target="HTTP11" section="3.2.3"/>).
             </li>
@@ -3420,7 +3420,7 @@ cookie: e=f
         </t>
         <t>
           A proxy that supports CONNECT establishes a <xref target="TCP">TCP connection</xref> to
-          the host and port identified in the <tt>:authority</tt> pseudo-header field. Once
+          the host and port identified in the "<tt>:authority</tt>" pseudo-header field. Once
           this connection is successfully established, the proxy sends a <xref target="HEADERS" format="none">HEADERS</xref>
           frame containing a 2xx series status code to the client, as defined in <xref target="HTTP" section="9.3.6"/>.
         </t>
@@ -3926,10 +3926,10 @@ cookie: e=f
         <t>
           <xref target="HttpHeaders"/> does not include specific rules for validation of
           pseudo-header fields.  If the values of these fields are used, additional validation is
-          necessary. This is particularly important where <tt>:scheme</tt>, <tt>:authority</tt>, and
-          <tt>:path</tt> are combined to form a single URI string (<xref
-          target="RFC3986"/>). Similar problems might occur when that URI or just <tt>:path</tt> are
-          combined with <tt>:method</tt> to construct a request line (as in <xref target="HTTP11"
+          necessary. This is particularly important where "<tt>:scheme</tt>", "<tt>:authority</tt>", and
+          "<tt>:path</tt>" are combined to form a single URI string (<xref
+          target="RFC3986"/>). Similar problems might occur when that URI or just "<tt>:path</tt>" are
+          combined with "<tt>:method</tt>" to construct a request line (as in <xref target="HTTP11"
           section="3"/>). Simple concatenation is not secure unless the input values are fully
           validated.
         </t>
@@ -4972,7 +4972,7 @@ cookie: e=f
           comprehensively identified.
         </li>
         <li>
-          <tt>Host</tt> and <tt>:authority</tt> are no longer permitted to disagree.
+          <tt>Host</tt> and "<tt>:authority</tt>" are no longer permitted to disagree.
         </li>
         <li>
           Rules for sending Dynamic Table Size Update instructions after changes in settings have


### PR DESCRIPTION
I had to add `<tt>` to one use of :authority.

Closes #1040.