### PR TITLE
Use quotes for scheme names

### DIFF
--- a/draft-ietf-httpbis-http2bis.xml
+++ b/draft-ietf-httpbis-http2bis.xml
@@ -3089,7 +3089,7 @@ cookie: e=f
                 translated request (for example, see <xref target="HTTP11" section="3.3"/>). Scheme
                 is omitted for <xref target="CONNECT">CONNECT requests</xref>.
               </t>
-              <t><tt>:scheme</tt> is not restricted to <tt>http</tt> and <tt>https</tt> schemed
+              <t><tt>:scheme</tt> is not restricted to "<tt>http</tt>" and "<tt>https</tt>" schemed
                 URIs.  A proxy or gateway can translate requests for non-HTTP schemes, enabling
                 the use of HTTP to interact with non-HTTP services.
               </t>
@@ -3141,7 +3141,7 @@ cookie: e=f
               </t>
               <t>
                 <tt>:authority</tt> MUST NOT include the deprecated userinfo subcomponent for
-                <tt>http</tt> or <tt>https</tt> schemed URIs.
+                "<tt>http</tt>" or "<tt>https</tt>" schemed URIs.
               </t>
             </li>
             <li>
@@ -3154,13 +3154,13 @@ cookie: e=f
                   <tt>:path</tt> pseudo-header field.
               </t>
               <t>
-                  This pseudo-header field MUST NOT be empty for <tt>http</tt> or <tt>https</tt>
-                  URIs; <tt>http</tt> or <tt>https</tt> URIs that do not contain a path component
+                  This pseudo-header field MUST NOT be empty for "<tt>http</tt>" or "<tt>https</tt>"
+                  URIs; "<tt>http</tt>" or "<tt>https</tt>" URIs that do not contain a path component
                   MUST include a value of '/'. The exceptions to this rule are:
               </t>
               <ul>
                 <li>
-                  an OPTIONS request for an <tt>http</tt> or <tt>https</tt> URI that does not include a path
+                  an OPTIONS request for an "<tt>http</tt>" or "<tt>https</tt>" URI that does not include a path
                   component; these MUST include a <tt>:path</tt> pseudo-header field with a value
                   of '*' (see <xref target="HTTP" section="7.1"/>)
                 </li>
@@ -3883,8 +3883,8 @@ cookie: e=f
         <t>
           HTTP/2 relies on the HTTP definition of authority for determining whether a server is
           authoritative in providing a given response (see <xref target="HTTP" section="4.3"/>).
-          This relies on local name resolution for the "http" URI scheme and the authenticated server
-          identity for the "https" scheme.
+          This relies on local name resolution for the "<tt>http</tt>" URI scheme and the authenticated server
+          identity for the "<tt>https</tt>" scheme.
         </t>
       </section>
       <section>


### PR DESCRIPTION
Also, use `<tt>`.

Closes #1041.