### PR TITLE
Values in the first; a value in the second

### DIFF
--- a/draft-ietf-httpbis-http2bis.xml
+++ b/draft-ietf-httpbis-http2bis.xml
@@ -4161,7 +4161,7 @@ cookie: e=f
         <name>Privacy Considerations</name>
         <t>
           Several characteristics of HTTP/2 provide an observer an opportunity to correlate actions
-          of a single client or server over time.  These include the value of settings, the manner
+          of a single client or server over time.  These include the values of settings, the manner
           in which flow-control windows are managed, the way priorities are allocated to streams,
           the timing of reactions to stimulus, and the handling of any features that are controlled by
           settings.
@@ -4193,8 +4193,8 @@ cookie: e=f
           as sources of timing variability.
         </t>
         <t>
-          Ensuring that processing time is not dependent on the value of secrets is the best defense
-          against any form of timing attack.
+          Ensuring that processing time is not dependent on the value of a secret is the best
+          defense against any form of timing attack.
         </t>
       </section>
     </section>


### PR DESCRIPTION
Values is correct in the first case, but the second should be "a value"
by which it means "any value".

Closes #1064.