### PR TITLE
Apply textual changes from RFC Editors

### DIFF
--- a/draft-ietf-httpbis-http2bis.xml
+++ b/draft-ietf-httpbis-http2bis.xml
@@ -2481,8 +2481,8 @@ WINDOW_UPDATE Frame {
         </t>
         <t>
           WINDOW_UPDATE can be sent by a peer that has sent a frame with the END_STREAM flag set.
-          This means that a receiver could receive a WINDOW_UPDATE frame on a "half-closed (remote)"
-          or "closed" stream.  A receiver MUST NOT treat this as an error (see <xref target="StreamStates"/>).
+          This means that a receiver could receive a WINDOW_UPDATE frame on a stream in a "half-closed (remote)"
+          or "closed" state.  A receiver MUST NOT treat this as an error (see <xref target="StreamStates"/>).
         </t>
         <t>
           A receiver that receives a flow-controlled frame MUST always account for its contribution
@@ -2663,7 +2663,7 @@ CONTINUATION Frame {
         </t>
         <t>
           CONTINUATION frames MUST be associated with a stream. If a CONTINUATION frame is received
-          whose Stream Identifier field is 0x00, the recipient MUST respond with a <xref target="ConnectionErrorHandler">connection error</xref> of type PROTOCOL_ERROR.
+          with a Stream Identifier field of 0x00, the recipient MUST respond with a <xref target="ConnectionErrorHandler">connection error</xref> of type PROTOCOL_ERROR.
         </t>
         <t>
           A CONTINUATION frame MUST be preceded by a <xref target="HEADERS" format="none">HEADERS</xref>,
@@ -4951,7 +4951,7 @@ cookie: e=f
       </t>
       <ul spacing="normal">
         <li>
-          Use of TLS 1.3 was defined based on <xref target="RFC8740" format="default"/>, which this document obsoletes.
+          Use of TLS 1.3 was defined based on <xref target="RFC8740"/>, which this document obsoletes.
         </li>
         <li>
           The priority scheme defined in RFC 7540 is deprecated.  Definitions for the format of the

--- a/draft-ietf-httpbis-http2bis.xml
+++ b/draft-ietf-httpbis-http2bis.xml
@@ -1,4 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
+
+<!DOCTYPE rfc [
+ <!ENTITY nbsp    "&#160;">
+ <!ENTITY zwsp   "&#8203;">
+ <!ENTITY nbhy   "&#8209;">
+ <!ENTITY wj     "&#8288;">
+]>
+
 <rfc xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:x="http://purl.org/net/xml2rfc/ext" ipr="trust200902" category="std" docName="draft-ietf-httpbis-http2bis-latest" tocInclude="true" symRefs="true" sortRefs="true" version="3" submissionType="IETF" obsoletes="7540,8740">
   <front>
     <title>HTTP/2</title>
@@ -32,19 +40,9 @@
         concurrent exchanges on the same connection.
       </t>
       <t>
-        This document obsoletes RFC 7540 and RFC 8740.
+        This document obsoletes RFCs 7540 and 8740.
       </t>
     </abstract>
-    <note title="Discussion Venues" removeInRFC="true">
-      <t>
-        Discussion of this document takes place on the HTTPBIS Working Group mailing list
-        (ietf-http-wg@w3.org), which is archived at <eref target="https://lists.w3.org/Archives/Public/ietf-http-wg/"/>.
-      </t>
-      <t>
-        Source for this draft and an issue tracker can be found at
-        <eref target="https://github.com/httpwg/http2-spec"/>.
-      </t>
-    </note>
   </front>
   <middle>
     <section anchor="intro">
@@ -57,7 +55,7 @@
       <t>
         Making multiple concurrent requests can reduce latency and improve
         application performance. HTTP/1.0 allowed only one request to be
-        outstanding at a time on a given TCP <xref target="TCP"/> connection. HTTP/1.1 (<xref target="HTTP11"/>)
+        outstanding at a time on a given TCP <xref target="TCP"/> connection. HTTP/1.1 <xref target="HTTP11"/>
         added request pipelining, but this only partially addressed request
         concurrency and still suffers from application-layer head-of-line
         blocking. Therefore, HTTP/1.0 and HTTP/1.1 clients use multiple connections
@@ -87,8 +85,7 @@
         message framing.
       </t>
       <t>
-        This document obsoletes <xref target="RFC7540">RFC 7540</xref> and <xref
-        target="RFC8740">RFC 8740</xref>.  <xref target="revision-updates"/> lists notable changes.
+        This document obsoletes RFCs 7540 and 8740.  <xref target="revision-updates"/> lists notable changes.
       </t>
     </section>
     <section anchor="Overview">
@@ -159,7 +156,7 @@
           </li>
         </ul>
         <t>
-          While some of the frame and stream layer concepts are isolated from HTTP, this
+          While some of the frame- and stream-layer concepts are isolated from HTTP, this
           specification does not define a completely generic frame layer. The frame and stream
           layers are tailored to the needs of HTTP.
         </t>
@@ -180,9 +177,9 @@
           from decimal literals.
         </t>
         <t>
-          This specification describes binary formats using the convention described in <xref
+          This specification describes binary formats using the conventions described in <xref
           target="QUIC" section="1.3">RFC 9000</xref>.  Note that this format uses network byte
-          order and high-valued bits are listed before low-valued bits.
+          order and that high-valued bits are listed before low-valued bits.
         </t>
         <t>
           The following terms are used:
@@ -254,16 +251,16 @@
         HTTP/2.
       </t>
       <t>
-        HTTP/2 uses the "http" and "https" URI schemes defined in <xref target="HTTP"
-        section="4.2"/>, with the same default port numbers as HTTP/1.1 (<xref
-        target="HTTP11"/>). These URIs do not include any indication about what HTTP versions an
+        HTTP/2 uses the "<tt>http</tt>" and "<tt>https</tt>" URI schemes defined in <xref target="HTTP"
+        section="4.2"/>, with the same default port numbers as HTTP/1.1 <xref
+        target="HTTP11"/>. These URIs do not include any indication about what HTTP versions an
         upstream server (the immediate peer to which the client wishes to establish a connection)
         supports.
       </t>
       <t>
-        The means by which support for HTTP/2 is determined is different for "http" and "https"
-        URIs.  Discovery for "https" URIs is described in <xref target="discover-https"/>. HTTP/2
-        support for "http" URIs can only be discovered by out-of-band means, and requires prior knowledge
+        The means by which support for HTTP/2 is determined is different for "<tt>http</tt>" and "<tt>https</tt>"
+        URIs.  Discovery for "<tt>https</tt>" URIs is described in <xref target="discover-https"/>. HTTP/2
+        support for "<tt>http</tt>" URIs can only be discovered by out-of-band means and requires prior knowledge
         of the support as described in <xref target="known-http"/>.
       </t>
       <section anchor="versioning">
@@ -278,7 +275,7 @@
             <t>
                 The string "h2" identifies the protocol where HTTP/2 uses Transport Layer Security
                 (TLS); see <xref target="TLSUsage"/>.  This identifier is used in the <xref
-                target="TLS-ALPN">TLS application-layer protocol negotiation (ALPN) extension</xref>
+                target="TLS-ALPN">TLS Application-Layer Protocol Negotiation (ALPN) extension</xref>
                 field and in any place where HTTP/2 over TLS is identified.
             </t>
             <t>
@@ -297,11 +294,10 @@
         </ul>
       </section>
       <section anchor="discover-https">
-        <name>Starting HTTP/2 for "https" URIs</name>
+        <name>Starting HTTP/2 for "<tt>https</tt>" URIs</name>
         <t>
-          A client that makes a request to an "https" URI uses <xref target="TLS13">TLS</xref> with
-          the <xref target="TLS-ALPN">application-layer protocol negotiation (ALPN)
-            extension</xref>.
+          A client that makes a request to an "<tt>https</tt>" URI uses <xref target="TLS13">TLS</xref> with
+          the <xref target="TLS-ALPN">ALPN extension</xref>.
         </t>
         <t>
           HTTP/2 over TLS uses the "h2" protocol identifier.  The "h2c" protocol identifier MUST NOT
@@ -469,7 +465,7 @@ HTTP Frame {
           </dd>
         </dl>
         <t>
-          The structure and content of the frame payload is dependent entirely on the frame type.
+          The structure and content of the frame payload are dependent entirely on the frame type.
         </t>
       </section>
       <section anchor="FrameSize">
@@ -516,7 +512,7 @@ HTTP Frame {
         <t>
           Field section compression is the process of compressing a set of field lines (<xref target="HTTP" section="5.2"/>) to form a
           field block.  Field section decompression is the process of decoding a field block into a
-          set of field lines.  Details of HTTP/2 field section compression and decompression is
+          set of field lines.  Details of HTTP/2 field section compression and decompression are
           defined in <xref target="COMPRESSION"/>, which, for historical reasons, refers to these
           processes as header compression and decompression.
         </t>
@@ -540,7 +536,7 @@ HTTP Frame {
         </t>
         <t>
           A field section is a collection of field lines.  Each of the field lines in a
-          field block carry a single value.  The serialized field block is then divided into one or
+          field block carries a single value.  The serialized field block is then divided into one or
           more octet sequences, called field block fragments.  The first field block fragment is transmitted within the frame
           payload of <xref target="HEADERS">HEADERS</xref> or <xref target="PUSH_PROMISE">PUSH_PROMISE</xref>, each of which could be followed by <xref target="CONTINUATION">CONTINUATION</xref> frames to carry subsequent field block fragments.
         </t>
@@ -751,8 +747,8 @@ HTTP Frame {
                     <text x="52" y="196">send H</text>
                     <text x="236" y="196">open</text>
                     <text x="420" y="196">recv H</text>
-                    <text x="100" y="260">half</text>
-                    <text x="372" y="260">half</text>
+                    <text x="100" y="260">half-</text>
+                    <text x="372" y="260">half-</text>
                     <text x="100" y="276">closed</text>
                     <text x="276" y="276">send R /</text>
                     <text x="372" y="276">closed</text>
@@ -791,7 +787,7 @@ HTTP Frame {
     |          |    /        |        |        \    |          |
     |          v   v         +---+----+         v   v          |
     |      +----------+          |           +----------+      |
-    |      |   half   |          |           |   half   |      |
+    |      |   half-  |          |           |   half-  |      |
     |      |  closed  |          | send R /  |  closed  |      |
     |      | (remote) |          | recv R    | (local)  |      |
     |      +----+-----+          |           +-----+----+      |
@@ -878,7 +874,7 @@ HTTP Frame {
             <t>
                 Receiving any frame other than <xref target="HEADERS" format="none">HEADERS</xref> or <xref target="PRIORITY" format="none">PRIORITY</xref> on
                 a stream in this state MUST be treated as a <xref target="ConnectionErrorHandler">connection error</xref> of type
-                <xref target="PROTOCOL_ERROR" format="none">PROTOCOL_ERROR</xref>. If this stream is server-initiated, as described in
+                <xref target="PROTOCOL_ERROR" format="none">PROTOCOL_ERROR</xref>. If this stream is initiated by the server, as described in
                 <xref target="StreamIdentifiers"/>, then receiving a <xref target="HEADERS" format="none">HEADERS</xref> frame MUST also
                 be treated as a <xref target="ConnectionErrorHandler">connection error</xref> of type
                 <xref target="PROTOCOL_ERROR" format="none">PROTOCOL_ERROR</xref>.
@@ -1039,7 +1035,7 @@ HTTP Frame {
               header compression state for <xref target="HEADERS" format="none">HEADERS</xref> and
               <xref target="PUSH_PROMISE" format="none">PUSH_PROMISE</xref> frames.  Receiving a <xref target="PUSH_PROMISE" format="none">PUSH_PROMISE</xref> frame also causes the promised
               stream to become "reserved (remote)", even when the <xref target="PUSH_PROMISE" format="none">PUSH_PROMISE</xref> frame is received on a closed stream. Additionally, the
-              content of <xref target="DATA" format="none">DATA</xref> frames count toward the
+              content of <xref target="DATA" format="none">DATA</xref> frames counts toward the
               connection flow-control window.
             </t>
             <t>
@@ -1067,7 +1063,7 @@ HTTP Frame {
         </t>
         <t>
           The rules in this section only apply to frames defined in this document.  Receipt of
-          frames for which the semantics are unknown cannot be treated as an error as the conditions
+          frames for which the semantics are unknown cannot be treated as an error, as the conditions
           for sending and receiving those frames are also unknown; see <xref
           target="extensibility"/>.
         </t>
@@ -1148,7 +1144,7 @@ HTTP Frame {
           Using streams for multiplexing introduces contention over use of the TCP connection,
           resulting in blocked streams.  A flow-control scheme ensures that streams on the same
           connection do not destructively interfere with each other.  Flow control is used for both
-          individual streams and for the connection as a whole.
+          individual streams and the connection as a whole.
         </t>
         <t>
           HTTP/2 provides for flow control through use of the <xref target="WINDOW_UPDATE">WINDOW_UPDATE frame</xref>.
@@ -1235,7 +1231,7 @@ HTTP Frame {
             TCP receive buffer as soon as data is available.  Failure to read promptly could lead to
             a deadlock when critical frames, such as <xref target="WINDOW_UPDATE"
             format="none">WINDOW_UPDATE</xref>, are not read and acted upon. Reading frames promptly
-            does not expose endpoints to resource exhaustion attacks as HTTP/2 flow control limits
+            does not expose endpoints to resource exhaustion attacks, as HTTP/2 flow control limits
             resource commitments.
           </t>
         </section>
@@ -1250,7 +1246,7 @@ HTTP Frame {
           <t>
             Sending timely <xref target="WINDOW_UPDATE" format="none">WINDOW_UPDATE</xref> frames
             can improve performance. Endpoints will want to balance the need to improve receive
-            throughput with the need to manage resource exhaustion risks, and should take careful
+            throughput with the need to manage resource exhaustion risks and should take careful
             note of <xref target="dos"/> in defining their strategy to manage window sizes.
           </t>
         </section>
@@ -1274,7 +1270,7 @@ HTTP Frame {
           <name>Background on Priority in RFC 7540</name>
           <t>
             RFC 7540 defined a rich system for signaling priority of requests.  However, this system
-            proved to be complex and it was not uniformly implemented.
+            proved to be complex, and it was not uniformly implemented.
           </t>
           <t>
             The flexible scheme meant that it was possible for clients to express priorities in very
@@ -1284,12 +1280,12 @@ HTTP Frame {
             client signals when prioritizing their handling of requests.
           </t>
           <t>
-            In short, the prioritization signaling in <xref target="RFC7540">RFC7540</xref> was not
+            In short, the prioritization signaling in <xref target="RFC7540">RFC 7540</xref> was not
             successful.
           </t>
         </section>
         <section anchor="PriorityHere">
-          <name>Priority Signaling in this Document</name>
+          <name>Priority Signaling in This Document</name>
           <t>
             This update to HTTP/2 deprecates the priority signaling defined in <xref target="RFC7540">RFC 7540</xref>.  The bulk of the text related to priority signals is
             not included in this document.  The description of frame fields and some of the
@@ -1303,7 +1299,7 @@ HTTP Frame {
           <t>
             Signaling priority information is necessary to attain good performance in many cases.
             Where signaling priority information is important, endpoints are encouraged to use an
-            alternative scheme, such as <xref target="I-D.ietf-httpbis-priority"/>.
+            alternative scheme, such as the scheme described in <xref target="I-D.ietf-httpbis-priority"/>.
           </t>
           <t>
             Though the priority signaling from RFC 7540 was not widely adopted, the information it
@@ -1317,14 +1313,14 @@ HTTP Frame {
             the absence of any priority signals.  Servers MAY interpret the complete absence of
             signals as an indication that the client has not implemented the feature.  The defaults
             described in <xref target="RFC7540" section="5.3.5"/> are known to have poor performance
-            under most conditions and their use is unlikely to be deliberate.
+            under most conditions, and their use is unlikely to be deliberate.
           </t>
         </section>
       </section>
       <section anchor="ErrorHandler">
         <name>Error Handling</name>
         <t>
-          HTTP/2 framing permits two classes of error:
+          HTTP/2 framing permits two classes of errors:
         </t>
         <ul spacing="normal">
           <li>
@@ -1476,8 +1472,8 @@ HTTP Frame {
       <name>Frame Definitions</name>
       <t>
         This specification defines a number of frame types, each identified by a unique 8-bit type
-        code. Each frame type serves a distinct purpose in the establishment and management either
-        of the connection as a whole or of individual streams.
+        code. Each frame type serves a distinct purpose in the establishment and management of either
+        the connection as a whole or individual streams.
       </t>
       <t>
         The transmission of specific frame types can alter the state of a connection. If endpoints
@@ -1573,7 +1569,7 @@ DATA Frame {
           DATA frames are subject to flow control and can only be sent when a stream is in the
           "open" or "half-closed (remote)" state. The entire DATA frame payload is included in flow
           control, including the Pad Length and Padding fields if present.  If a DATA frame is received
-          whose stream is not in "open" or "half-closed (local)" state, the recipient MUST respond
+          whose stream is not in the "open" or "half-closed (local)" state, the recipient MUST respond
           with a <xref target="StreamErrorHandler">stream error</xref> of type
           <xref target="STREAM_CLOSED" format="none">STREAM_CLOSED</xref>.
         </t>
@@ -1952,7 +1948,7 @@ Setting {
             <dt anchor="SETTINGS_HEADER_TABLE_SIZE">SETTINGS_HEADER_TABLE_SIZE (0x01):</dt>
             <dd>
               <t>
-                  Allows the sender to inform the remote endpoint of the maximum size of the
+                  This setting allows the sender to inform the remote endpoint of the maximum size of the
                   compression table used to decode field blocks, in units of octets. The encoder can select
                   any size equal to or less than this value by using signaling specific to the
                   compression format inside a field block (see <xref target="COMPRESSION"/>). The initial value is 4,096 octets.
@@ -1970,15 +1966,15 @@ Setting {
                 target="PROTOCOL_ERROR" format="none">PROTOCOL_ERROR</xref>.
               </t>
               <t>
-                The initial value of SETTINGS_ENABLE_PUSH is 1.  For a client this value indicates that it
-                is willing to receive PUSH_PROMISE frames.  For a server this initial value has no effect, and
+                The initial value of SETTINGS_ENABLE_PUSH is 1.  For a client, this value indicates that it
+                is willing to receive PUSH_PROMISE frames.  For a server, this initial value has no effect, and
                 is equivalent to the value 0.  Any value other than 0 or 1 MUST be treated as a
                 <xref target="ConnectionErrorHandler">connection error</xref> of type
                 <xref target="PROTOCOL_ERROR" format="none">PROTOCOL_ERROR</xref>.
               </t>
               <t>
                 A server MUST NOT explicitly set this value to 1.  A server MAY choose to omit this
-                setting when it sends a SETTINGS frame, but if a server does include a value it MUST
+                setting when it sends a SETTINGS frame, but if a server does include a value, it MUST
                 be 0.  A client MUST treat receipt of a SETTINGS frame with SETTINGS_ENABLE_PUSH set
                 to 1 as a <xref target="ConnectionErrorHandler">connection error</xref> of type
                 <xref target="PROTOCOL_ERROR" format="none">PROTOCOL_ERROR</xref>.
@@ -1987,7 +1983,7 @@ Setting {
             <dt anchor="SETTINGS_MAX_CONCURRENT_STREAMS">SETTINGS_MAX_CONCURRENT_STREAMS (0x03):</dt>
             <dd>
               <t>
-                  Indicates the maximum number of concurrent streams that the sender will allow.
+                  This setting indicates the maximum number of concurrent streams that the sender will allow.
                   This limit is directional: it applies to the number of streams that the sender
                   permits the receiver to create. Initially, there is no limit to this value.  It is
                   recommended that this value be no smaller than 100, so as to not unnecessarily
@@ -2004,7 +2000,7 @@ Setting {
             <dt anchor="SETTINGS_INITIAL_WINDOW_SIZE">SETTINGS_INITIAL_WINDOW_SIZE (0x04):</dt>
             <dd>
               <t>
-                  Indicates the sender's initial window size (in units of octets) for stream-level flow
+                  This setting indicates the sender's initial window size (in units of octets) for stream-level flow
                   control.  The initial value is 2<sup>16</sup>-1 (65,535) octets.
               </t>
               <t>
@@ -2019,7 +2015,7 @@ Setting {
             <dt anchor="SETTINGS_MAX_FRAME_SIZE">SETTINGS_MAX_FRAME_SIZE (0x05):</dt>
             <dd>
               <t>
-                  Indicates the size of the largest frame payload that the sender is willing to
+                  This setting indicates the size of the largest frame payload that the sender is willing to
                   receive, in units of octets.
               </t>
               <t>
@@ -2033,7 +2029,7 @@ Setting {
             <dt anchor="SETTINGS_MAX_HEADER_LIST_SIZE">SETTINGS_MAX_HEADER_LIST_SIZE (0x06):</dt>
             <dd>
               <t>
-                  This advisory setting informs a peer of the maximum size of field section that the
+                  This advisory setting informs a peer of the maximum field section size that the
                   sender is prepared to accept, in units of octets. The value is based on the uncompressed
                   size of field lines, including the length of the name and value in units of octets plus
                   an overhead of 32 octets for each field line.
@@ -2072,7 +2068,7 @@ Setting {
             target="ConnectionErrorHandler">connection error</xref> of type <xref
             target="SETTINGS_TIMEOUT" format="none">SETTINGS_TIMEOUT</xref>. In setting a timeout,
             some allowance needs to be made for processing delays at the peer; a timeout that is
-            solely based on the round trip time between endpoints might result in spurious errors.
+            solely based on the round-trip time between endpoints might result in spurious errors.
           </t>
         </section>
       </section>
@@ -2286,7 +2282,7 @@ PING Frame {
         </t>
         <t>
           There is an inherent race condition between an endpoint starting new streams and the
-          remote sending a GOAWAY frame.  To deal with this case, the GOAWAY contains the stream
+          remote peer sending a GOAWAY frame.  To deal with this case, the GOAWAY contains the stream
           identifier of the last peer-initiated stream that was or might be processed on the
           sending endpoint in this connection.  For instance, if the server sends a GOAWAY frame,
           the identified stream is the highest-numbered stream initiated by the client.
@@ -2375,7 +2371,7 @@ GOAWAY Frame {
           using a new connection.
         </t>
         <t>
-          Activity on streams numbered lower or equal to the last stream identifier might still
+          Activity on streams numbered lower than or equal to the last stream identifier might still
           complete successfully.  The sender of a GOAWAY frame might gracefully shut down a
           connection by sending a GOAWAY frame, maintaining the connection in an "open" state until
           all in-progress streams complete.
@@ -2405,7 +2401,7 @@ GOAWAY Frame {
           receiver with identifiers higher than the identified last stream.  However, any frames
           that alter connection state cannot be completely ignored.  For instance,
           <xref target="HEADERS" format="none">HEADERS</xref>, <xref target="PUSH_PROMISE" format="none">PUSH_PROMISE</xref>, and <xref target="CONTINUATION" format="none">CONTINUATION</xref> frames
-          MUST be minimally processed to ensure the state maintained for field section compression is
+          MUST be minimally processed to ensure that the state maintained for field section compression is
           consistent (see <xref target="FieldBlock"/>); similarly, DATA frames MUST be counted
           toward the connection flow-control window.  Failure to process these frames can cause flow
           control or field section compression state to become unsynchronized.
@@ -2485,8 +2481,8 @@ WINDOW_UPDATE Frame {
         </t>
         <t>
           WINDOW_UPDATE can be sent by a peer that has sent a frame with the END_STREAM flag set.
-          This means that a receiver could receive a WINDOW_UPDATE frame on a stream in the "half-closed (remote)"
-          or "closed" state.  A receiver MUST NOT treat this as an error (see <xref target="StreamStates"/>).
+          This means that a receiver could receive a WINDOW_UPDATE frame on a "half-closed (remote)"
+          or "closed" stream.  A receiver MUST NOT treat this as an error (see <xref target="StreamStates"/>).
         </t>
         <t>
           A receiver that receives a flow-controlled frame MUST always account for its contribution
@@ -2667,7 +2663,7 @@ CONTINUATION Frame {
         </t>
         <t>
           CONTINUATION frames MUST be associated with a stream. If a CONTINUATION frame is received
-          with a Stream Identifier field of 0x00, the recipient MUST respond with a <xref target="ConnectionErrorHandler">connection error</xref> of type PROTOCOL_ERROR.
+          whose Stream Identifier field is 0x00, the recipient MUST respond with a <xref target="ConnectionErrorHandler">connection error</xref> of type PROTOCOL_ERROR.
         </t>
         <t>
           A CONTINUATION frame MUST be preceded by a <xref target="HEADERS" format="none">HEADERS</xref>,
@@ -2730,7 +2726,7 @@ CONTINUATION Frame {
           </dd>
         <dt>CANCEL (0x08):</dt>
         <dd anchor="CANCEL">
-            Used by the endpoint to indicate that the stream is no longer needed.
+            The endpoint uses this error code to indicate that the stream is no longer needed.
           </dd>
         <dt>COMPRESSION_ERROR (0x09):</dt>
         <dd anchor="COMPRESSION_ERROR">
@@ -2922,13 +2918,13 @@ CONTINUATION Frame {
             might be able to convey.  HTTP/2 implementations SHOULD validate field names and values
             according to their definitions in Sections <xref target="HTTP" section="5.1"
             sectionFormat="bare"/> and <xref target="HTTP" section="5.5" sectionFormat="bare"/> of <xref
-            target="HTTP"/> respectively and treat messages that contain prohibited characters as
+            target="HTTP"/>, respectively, and treat messages that contain prohibited characters as
             <xref target="malformed">malformed</xref>.
           </t>
           <t>
             Failure to validate fields can be exploited for request smuggling attacks.  In
             particular, unvalidated fields might enable attacks when messages are forwarded using
-            <xref target="HTTP11">HTTP/1.1</xref>, where characters such as CR, LF, and COLON are
+            <xref target="HTTP11">HTTP/1.1</xref>, where characters such as carriage return (CR), line feed (LF), and COLON are
             used as delimiters.  Implementations MUST perform the following minimal validation of
             field names and values:
           </t>
@@ -2955,7 +2951,7 @@ CONTINUATION Frame {
           </ul>
           <aside>
           <t>
-            Note: An implementation that validates fields according the definitions in Sections
+            Note: An implementation that validates fields according to the definitions in Sections
             <xref target="HTTP" section="5.1" sectionFormat="bare"/> and <xref target="HTTP"
             section="5.5" sectionFormat="bare"/> of <xref target="HTTP"/> only needs an additional check
             that field names do not include uppercase characters.
@@ -3016,10 +3012,10 @@ CONTINUATION Frame {
           <name>Compressing the Cookie Header Field</name>
           <t>
             The <xref target="COOKIE">Cookie header field</xref> uses a semicolon (";") to delimit
-            cookie-pairs (or "crumbs").  This header field contains multiple values but does not use
+            cookie-pairs (or "crumbs").  This header field contains multiple values, but does not use
             a COMMA (",") as a separator, thereby preventing cookie-pairs from being sent on
             multiple field lines (see <xref target="HTTP" section="5.2"/>).  This can significantly
-            reduce compression efficiency as updates to individual cookie-pairs would invalidate any
+            reduce compression efficiency, as updates to individual cookie-pairs would invalidate any
             field lines that are stored in the HPACK table.
           </t>
           <t>
@@ -3046,7 +3042,7 @@ cookie: e=f
       <section anchor="PseudoHeaderFields">
         <name>HTTP Control Data</name>
         <t>
-          HTTP/2 uses special pseudo-header fields beginning with ':' character (ASCII 0x3a) to
+          HTTP/2 uses special pseudo-header fields beginning with a ':' character (ASCII 0x3a) to
           convey message control data (see <xref target="HTTP" section="6.2"/>).
         </t>
         <t>
@@ -3153,7 +3149,7 @@ cookie: e=f
               <t>
                   The "<tt>:path</tt>" pseudo-header field includes the path and
                   query parts of the target URI (the <tt>absolute-path</tt>
-                  production and optionally a '?' character followed by the
+                  production and, optionally, a '?' character followed by the
                   <tt>query</tt> production; see <xref target="HTTP" section="4.1"/>).
                   A request in asterisk form (for OPTIONS) includes the value '*' for the
                   "<tt>:path</tt>" pseudo-header field.
@@ -3167,7 +3163,7 @@ cookie: e=f
                 <li>
                   an OPTIONS request for an "<tt>http</tt>" or "<tt>https</tt>" URI that does not include a path
                   component; these MUST include a "<tt>:path</tt>" pseudo-header field with a value
-                  of '*' (see <xref target="HTTP" section="7.1"/>)
+                  of '*' (see <xref target="HTTP" section="7.1"/>).
                 </li>
                 <li>
                   <xref target="CONNECT">CONNECT requests</xref>, where the "<tt>:path</tt>" pseudo-header field is omitted.
@@ -3177,8 +3173,8 @@ cookie: e=f
           </ul>
           <t>
             All HTTP/2 requests MUST include exactly one valid value for the "<tt>:method</tt>",
-            "<tt>:scheme</tt>", and "<tt>:path</tt>" pseudo-header fields, unless it is a <xref
-            target="CONNECT">CONNECT request</xref>. An HTTP request that omits mandatory
+            "<tt>:scheme</tt>", and "<tt>:path</tt>" pseudo-header fields, unless they are <xref
+            target="CONNECT">CONNECT requests</xref>. An HTTP request that omits mandatory
             pseudo-header fields is <xref target="malformed">malformed</xref>.
           </t>
           <t>
@@ -3222,7 +3218,7 @@ cookie: e=f
           account factors such as caching, content negotiation, and user behavior. Errors in
           prediction can lead to performance degradation, due to the opportunity cost that the
           additional data on the wire represents. In particular, pushing any significant amount of
-          data can cause contention issues with more-important responses.
+          data can cause contention issues with responses that are more important.
         </t>
         <t>
           A client can request that server push be disabled, though this is negotiated for each hop
@@ -3236,7 +3232,7 @@ cookie: e=f
           or a trailer section. Clients that receive a promised request that is not cacheable, that
           is not known to be safe, or that indicates the presence of request content MUST reset the
           promised stream with a <xref target="StreamErrorHandler">stream error</xref> of type
-          <xref target="PROTOCOL_ERROR" format="none">PROTOCOL_ERROR</xref>. Note this could result
+          <xref target="PROTOCOL_ERROR" format="none">PROTOCOL_ERROR</xref>. Note that this could result
           in the promised stream being reset if the client does not recognize a newly defined
           method as being safe.
         </t>
@@ -3245,7 +3241,7 @@ cookie: e=f
           stored by the client, if it implements an HTTP cache. Pushed responses are considered
           successfully validated on the origin server (e.g., if the "no-cache" cache response
           directive is present; see <xref target="CACHE" section="5.2.2.4"/>) while the stream
-          identified by the promised stream ID is still open.
+          identified by the promised stream identifier is still open.
         </t>
         <t>
           Pushed responses that are not cacheable MUST NOT be stored by any HTTP cache. They MAY
@@ -3377,7 +3373,7 @@ cookie: e=f
             authoritative (see <xref target="authority"/>) or the proxy that provided the pushed
             response is configured for the corresponding request. For example, a server that offers
             a certificate for only the <tt>example.com</tt> DNS-ID (see <xref target="RFC6125"/>)
-            is not permitted to push a response for <tt>https://www.example.org/doc</tt>.
+            is not permitted to push a response for &lt;<tt>https://www.example.org/doc</tt>&gt;.
           </t>
           <t>
             The response for a <xref target="PUSH_PROMISE" format="none">PUSH_PROMISE</xref> stream begins with a
@@ -3398,7 +3394,7 @@ cookie: e=f
           The CONNECT method (<xref target="HTTP" section="9.3.6"/>) is
           used to convert an HTTP connection into a tunnel to a remote host.
           CONNECT is primarily used with HTTP proxies to establish a TLS session with an origin
-          server for the purposes of interacting with <tt>https</tt> resources.
+          server for the purposes of interacting with "<tt>https</tt>" resources.
         </t>
         <t>
           In HTTP/2, the CONNECT method establishes a tunnel over a single HTTP/2 stream to a
@@ -3427,7 +3423,7 @@ cookie: e=f
           A proxy that supports CONNECT establishes a <xref target="TCP">TCP connection</xref> to
           the host and port identified in the "<tt>:authority</tt>" pseudo-header field. Once
           this connection is successfully established, the proxy sends a <xref target="HEADERS" format="none">HEADERS</xref>
-          frame containing a 2xx series status code to the client, as defined in <xref target="HTTP" section="9.3.6"/>.
+          frame containing a 2xx-series status code to the client, as defined in <xref target="HTTP" section="9.3.6"/>.
         </t>
         <t>
           After the initial <xref target="HEADERS" format="none">HEADERS</xref> frame sent by each
@@ -3469,7 +3465,7 @@ cookie: e=f
         <t>
           The semantics of 101 (Switching Protocols) aren't applicable to a multiplexed protocol.
           Similar functionality might be enabled through the use of <xref target="RFC8441">extended
-          CONNECT</xref> and other protocols are able to use the same mechanisms that HTTP/2 uses to
+          CONNECT</xref>, and other protocols are able to use the same mechanisms that HTTP/2 uses to
           negotiate their use (see <xref target="starting"/>).
         </t>
       </section>
@@ -3752,7 +3748,7 @@ cookie: e=f
         <t>
           Requirements for deployments of HTTP/2 that negotiate <xref target="TLS13">TLS 1.3</xref>
           are included in <xref target="tls13features"/>.  Deployments of TLS 1.2 are subject to
-          the requirements in <xref target="tls12features"/> and <xref target="tls12ciphers"/>.
+          the requirements in Sections&nbsp;<xref target="tls12features" format="counter"/> and <xref target="tls12ciphers" format="counter"/>.
           Implementations are encouraged to provide defaults that comply, but it is recognized that
           deployments are ultimately responsible for compliance.
         </t>
@@ -3770,7 +3766,7 @@ cookie: e=f
           <t>
             A deployment of HTTP/2 over TLS 1.2 MUST disable compression. TLS compression can lead
             to the exposure of information that would not otherwise be revealed <xref
-            target="RFC3749"/>. Generic compression is unnecessary since HTTP/2 provides
+            target="RFC3749"/>. Generic compression is unnecessary, since HTTP/2 provides
             compression features that are more aware of context and therefore likely to be more
             appropriate for use for performance, security, or other reasons.
 
@@ -3793,13 +3789,13 @@ cookie: e=f
             This effectively prevents the use of renegotiation in response to a request for a
             specific protected resource.  A future specification might provide a way to support this
             use case. Alternatively, a server might use an <xref target="ErrorHandler">
-            error</xref> of type <xref target="HTTP_1_1_REQUIRED" format="none">HTTP_1_1_REQUIRED</xref> to request the client
+            error</xref> of type <xref target="HTTP_1_1_REQUIRED" format="none">HTTP_1_1_REQUIRED</xref> to request that the client
             use a protocol that supports renegotiation.
           </t>
           <t>
             Implementations MUST support ephemeral key exchange sizes of at least 2048 bits for
             cipher suites that use ephemeral finite field Diffie-Hellman (DHE) (<xref
-            target="TLS12" section="8.1.2"/> and 224 bits for cipher suites that use ephemeral elliptic curve
+            target="TLS12" section="8.1.2"/>) and 224 bits for cipher suites that use ephemeral elliptic curve
             Diffie-Hellman (ECDHE) <xref target="RFC8422"/>. Clients MUST accept DHE sizes of up to
             4096 bits. Endpoints MAY treat negotiation of key sizes smaller than the lower limits
             as a <xref target="ConnectionErrorHandler">connection error</xref> of type <xref
@@ -3810,8 +3806,7 @@ cookie: e=f
         <section anchor="tls12ciphers">
           <name>TLS 1.2 Cipher Suites</name>
           <t>
-            A deployment of HTTP/2 over TLS 1.2 SHOULD NOT use any of the cipher suites that are
-            listed in the  <xref target="BadCipherSuites">list of prohibited cipher suites</xref>.
+            A deployment of HTTP/2 over TLS 1.2 SHOULD NOT use any of the prohibited cipher suites listed in <xref target="BadCipherSuites"/>.
           </t>
           <t>
             Endpoints MAY choose to generate a <xref target="ConnectionErrorHandler">connection
@@ -3932,24 +3927,24 @@ cookie: e=f
           <xref target="HttpHeaders"/> does not include specific rules for validation of
           pseudo-header fields.  If the values of these fields are used, additional validation is
           necessary. This is particularly important where "<tt>:scheme</tt>", "<tt>:authority</tt>", and
-          "<tt>:path</tt>" are combined to form a single URI string (<xref
-          target="RFC3986"/>). Similar problems might occur when that URI or just "<tt>:path</tt>" are
+          "<tt>:path</tt>" are combined to form a single URI string <xref
+          target="RFC3986"/>. Similar problems might occur when that URI or just "<tt>:path</tt>" is
           combined with "<tt>:method</tt>" to construct a request line (as in <xref target="HTTP11"
           section="3"/>). Simple concatenation is not secure unless the input values are fully
           validated.
         </t>
         <t>
           An intermediary can reject fields that contain invalid field names or values for other
-          reasons, in particular those that do not conform to the HTTP ABNF grammar from <xref target="HTTP" section="5"/>. Intermediaries that do not perform any validation of fields
+          reasons -- in particular, those fields that do not conform to the HTTP ABNF grammar from <xref target="HTTP" section="5"/>. Intermediaries that do not perform any validation of fields
           other than the minimum required by <xref target="HttpHeaders"/> could forward messages
           that contain invalid field names or values.
         </t>
         <t>
-          An intermediary that receives any field that requires removal before forwarding
+          An intermediary that receives any fields that require removal before forwarding
           (see <xref target="HTTP" section="7.6.1"/>) MUST remove or replace those header fields when
           forwarding messages. Additionally, intermediaries should take care when forwarding messages
           containing <tt>Content-Length</tt> fields to ensure that the message is <xref target="malformed">well-formed</xref>.
-          This ensures that if the message is translated into HTTP/1.1 at any point the framing will be correct.
+          This ensures that if the message is translated into HTTP/1.1 at any point, the framing will be correct.
         </t>
       </section>
       <section>
@@ -3992,8 +3987,8 @@ cookie: e=f
           error</xref> of type <xref target="ENHANCE_YOUR_CALM" format="none">ENHANCE_YOUR_CALM</xref>.
         </t>
         <t>
-          A number of HTTP/2 implementations were found to be vulnerable to denial of service <xref target="NFLX-2019-002"/>.  The following lists known ways that implementations might be
-          subject to denial of service attack:
+          A number of HTTP/2 implementations were found to be vulnerable to denial of service <xref target="NFLX-2019-002"/>.  Below is a list of known ways that implementations might be
+          subject to denial-of-service attacks:
         </t>
         <ul>
           <li>
@@ -4020,7 +4015,7 @@ cookie: e=f
             </ul>
           </li>
           <li>
-            An attacker can provide large amounts of flow-control credit at the HTTP/2 layer, but
+            An attacker can provide large amounts of flow-control credit at the HTTP/2 layer but
             withhold credit at the TCP layer, preventing frames from being sent.  An endpoint that
             constructs and remembers frames for sending without considering TCP limits might be
             subject to resource exhaustion.
@@ -4115,7 +4110,7 @@ cookie: e=f
           compressed content-codings (<xref target="HTTP" section="8.4.1"/>).
         </t>
         <t>
-          There are demonstrable attacks on compression that exploit the characteristics of the web
+          There are demonstrable attacks on compression that exploit the characteristics of the Web
           (e.g., <xref target="BREACH"/>).  The attacker induces multiple requests containing
           varying plaintext, observing the length of the resulting ciphertext in each, which
           reveals a shorter length when a guess about the secret is correct.
@@ -4145,7 +4140,7 @@ cookie: e=f
         </t>
         <t>
           Padding can be used to obscure the exact size of frame content and is provided to
-          mitigate specific attacks within HTTP, for example, attacks where compressed content
+          mitigate specific attacks within HTTP -- for example, attacks where compressed content
           includes both attacker-controlled plaintext and secret data (e.g., <xref target="BREACH"/>).
         </t>
         <t>
@@ -4158,7 +4153,7 @@ cookie: e=f
           be possible if an attacker can control plaintext.
         </t>
         <t>
-          Intermediaries SHOULD retain padding for <xref target="DATA" format="none">DATA</xref> frames, but MAY drop padding
+          Intermediaries SHOULD retain padding for <xref target="DATA" format="none">DATA</xref> frames but MAY drop padding
           for <xref target="HEADERS" format="none">HEADERS</xref> and <xref target="PUSH_PROMISE" format="none">PUSH_PROMISE</xref> frames.  A valid reason for an
           intermediary to change the amount of padding of frames is to improve the protections that
           padding provides.
@@ -4208,7 +4203,7 @@ cookie: e=f
     <section anchor="iana">
       <name>IANA Considerations</name>
       <t>
-        This revision of the document marks the <tt>HTTP2-Settings</tt> header field and the
+        This revision of HTTP/2 marks the <tt>HTTP2-Settings</tt> header field and the
         <tt>h2c</tt> upgrade token, both defined in <xref target="RFC7540"/>, as obsolete.
       </t>
       <t>
@@ -4218,23 +4213,28 @@ cookie: e=f
         HTTP/2, but are not redefined in this document.
       </t>
       <t>
-        IANA is requested to update references to RFC 7540 in the following registries to refer to
-        this document: Application-Layer Protocol Negotiation (ALPN) Protocol IDs, HTTP/2 Frame
-        Type, HTTP/2 Settings, HTTP/2 Error Code, and HTTP Method Registry.  The registration of the
-        <tt>PRI</tt> method needs to be updated to refer to <xref target="preface"/>; all other
-        section numbers have not changed.
+        IANA has updated references to RFC 7540 in the
+        following registries to refer to this document: "TLS
+        Application-Layer Protocol Negotiation (ALPN) Protocol IDs",
+        "HTTP/2 Frame Type", "HTTP/2 Settings", "HTTP/2 Error Code",
+        and "HTTP Method Registry".  The registration of the
+        <tt>PRI</tt> method has been updated to refer to <xref
+        target="preface"/>; all other section numbers have not
+        changed.
       </t>
       <t>
-        IANA is requested to change the policy on those portions of the "HTTP/2 Frame Type" and
-        "HTTP/2 Settings" registries that were reserved for Experimental Use in RFC 7540. These
-        portions of the registry shall operate on the same policy as the remainder of each registry.
+        IANA has changed the policy on those portions of the "HTTP/2
+        Frame Type" and "HTTP/2 Settings" registries that were
+        reserved for Experimental Use in RFC 7540. These portions of
+        the registries shall operate on the same policy as the
+        remainder of each registry.
       </t>
       <section anchor="HTTP2-Settings">
         <name>HTTP2-Settings Header Field Registration</name>
         <t>
           This section marks the <tt>HTTP2-Settings</tt> header field registered by <xref
-          target="RFC7540" section="11.5"/> in the Hypertext Transfer Protocol (HTTP) Field Name
-          Registry as obsolete.  This capability has been removed: see <xref target="versioning"/>.
+          target="RFC7540" section="11.5"/> in the "Hypertext Transfer Protocol (HTTP) Field Name
+          Registry" as obsolete.  This capability has been removed: see <xref target="versioning"/>.
           The registration is updated to include the details as required by <xref target="HTTP"
           section="18.4"/>:
         </t>
@@ -4243,19 +4243,19 @@ cookie: e=f
           <dd>HTTP2-Settings</dd>
           <dt>Status:</dt>
           <dd>obsoleted</dd>
-          <dt>Ref.:</dt>
+          <dt>Reference:</dt>
           <dd>
             <xref target="RFC7540" section="3.2.1"/>
           </dd>
           <dt>Comments:</dt>
-          <dd>Obsolete; see <xref target="HTTP2-Settings"/> of this document</dd>
+          <dd>Obsolete; see <xref target="HTTP2-Settings"/> of this document.</dd>
         </dl>
       </section>
       <section anchor="iana-h2c">
         <name>The h2c Upgrade Token</name>
         <t>
           This section records the <tt>h2c</tt> upgrade token registered by <xref target="RFC7540"
-          section="11.8"/> in the Hypertext Transfer Protocol (HTTP) Upgrade Token Registry as
+          section="11.8"/> in the "Hypertext Transfer Protocol (HTTP) Upgrade Token Registry" as
           obsolete.  This capability has been removed: see <xref target="versioning"/>.  The
           registration is updated as follows:
         </t>
@@ -4951,7 +4951,7 @@ cookie: e=f
       </t>
       <ul spacing="normal">
         <li>
-          Use of TLS 1.3 was defined based on RFC 8740, which this document obsoletes.
+          Use of TLS 1.3 was defined based on <xref target="RFC8740" format="default"/>, which this document obsoletes.
         </li>
         <li>
           The priority scheme defined in RFC 7540 is deprecated.  Definitions for the format of the
@@ -4969,15 +4969,15 @@ cookie: e=f
         </li>
         <li>
           Validation for field names and values has been narrowed.  The validation that is mandatory
-          for intermediaries is precisely defined and error reporting for requests has been amended
+          for intermediaries is precisely defined, and error reporting for requests has been amended
           to encourage sending 400-series status codes.
         </li>
         <li>
-          The ranges of codepoints for settings and frame types that were reserved for "Experimental
-          Use" are now available for general use.
+          The ranges of codepoints for settings and frame types that were reserved for Experimental
+          Use are now available for general use.
         </li>
         <li>
-          Connection-specific header fields - which are prohibited - are more precisely and
+          Connection-specific header fields -- which are prohibited -- are more precisely and
           comprehensively identified.
         </li>
         <li>
@@ -4996,17 +4996,17 @@ cookie: e=f
       </t>
     </section>
     <section numbered="false">
-      <name>Contributors</name>
-      <t>
-        The previous version of this document was authored by Mike Belshe and Roberto Peon.
-      </t>
-    </section>
-    <section numbered="false">
       <name>Acknowledgments</name>
       <t>
         Credit for non-trivial input to this document is owed to a large number of people who have
-        contributed to the HTTP working group over the years.  <xref target="RFC7540"/> contains a
+        contributed to the HTTP Working Group over the years.  <xref target="RFC7540"/> contains a
         more extensive list of people that deserve acknowledgment for their contributions.</t>
+    </section>
+    <section numbered="false">
+      <name>Contributors</name>
+      <t>
+        <contact fullname="Mike Belshe"/> and <contact fullname="Roberto Peon"/> authored the text that this document is based on.
+      </t>
     </section>
   </back>
 </rfc>


### PR DESCRIPTION
This PR contains textual changes made by the RFC editors, along with a
couple of XML changes where they were uncontroversial or necessary for
the text. I left out any change the RFC editors made that conflicted
substatially with changes we made in response to their comments.