### PR TITLE
Run the tool I used to clean RFC 9000 on this one

### DIFF
--- a/draft-ietf-httpbis-http2bis.xml
+++ b/draft-ietf-httpbis-http2bis.xml
@@ -1,12 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
-
-<!DOCTYPE rfc [
- <!ENTITY nbsp    "&#160;">
- <!ENTITY zwsp   "&#8203;">
- <!ENTITY nbhy   "&#8209;">
- <!ENTITY wj     "&#8288;">
-]>
-
+<?xml version="1.0" encoding="UTF-8"?>
 <rfc xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:x="http://purl.org/net/xml2rfc/ext" ipr="trust200902" category="std" docName="draft-ietf-httpbis-http2bis-latest" tocInclude="true" symRefs="true" sortRefs="true" version="3" submissionType="IETF" obsoletes="7540,8740">
   <front>
     <title>HTTP/2</title>
@@ -32,134 +24,92 @@
     <keyword>SPDY</keyword>
     <keyword>Web</keyword>
     <abstract>
-      <t>
-        This specification describes an optimized expression of the semantics of the Hypertext
+      <t>This specification describes an optimized expression of the semantics of the Hypertext
         Transfer Protocol (HTTP), referred to as HTTP version 2 (HTTP/2). HTTP/2 enables a more
         efficient use of network resources and a
         reduced latency by introducing field compression and allowing multiple
-        concurrent exchanges on the same connection.
-      </t>
-      <t>
-        This document obsoletes RFCs 7540 and 8740.
-      </t>
+        concurrent exchanges on the same connection.</t>
+      <t>This document obsoletes RFCs 7540 and 8740.</t>
     </abstract>
   </front>
   <middle>
     <section anchor="intro">
       <name>Introduction</name>
-      <t>
-        The performance of applications using the Hypertext Transfer Protocol
+      <t>The performance of applications using the Hypertext Transfer Protocol
         (HTTP, <xref target="HTTP"/>) is linked to how each version of HTTP uses the underlying
-        transport, and the conditions under which the transport operates.
-      </t>
-      <t>
-        Making multiple concurrent requests can reduce latency and improve
+        transport, and the conditions under which the transport operates.</t>
+      <t>Making multiple concurrent requests can reduce latency and improve
         application performance. HTTP/1.0 allowed only one request to be
         outstanding at a time on a given TCP <xref target="TCP"/> connection. HTTP/1.1 <xref target="HTTP11"/>
         added request pipelining, but this only partially addressed request
         concurrency and still suffers from application-layer head-of-line
         blocking. Therefore, HTTP/1.0 and HTTP/1.1 clients use multiple connections
-        to a server to make concurrent requests.
-      </t>
-      <t>
-        Furthermore, HTTP fields are often repetitive and verbose, causing unnecessary
+        to a server to make concurrent requests.</t>
+      <t>Furthermore, HTTP fields are often repetitive and verbose, causing unnecessary
         network traffic as well as causing the initial TCP congestion
         window to quickly fill. This can result in excessive latency when multiple requests are
-        made on a new TCP connection.
-      </t>
-      <t>
-        HTTP/2 addresses these issues by defining an optimized mapping of HTTP's semantics to an
+        made on a new TCP connection.</t>
+      <t>HTTP/2 addresses these issues by defining an optimized mapping of HTTP's semantics to an
         underlying connection. Specifically, it allows interleaving of messages on the same
         connection and uses an efficient coding for HTTP fields. It also allows prioritization of
         requests, letting more important requests complete more quickly, further improving
-        performance.
-      </t>
-      <t>
-        The resulting protocol is more friendly to the network because fewer TCP connections can
+        performance.</t>
+      <t>The resulting protocol is more friendly to the network because fewer TCP connections can
         be used in comparison to HTTP/1.x. This means less competition with other flows and
         longer-lived connections, which in turn lead to better utilization of available network
-        capacity. Note, however, that TCP head-of-line blocking is not addressed by this protocol.
-      </t>
-      <t>
-        Finally, HTTP/2 also enables more efficient processing of messages through use of binary
-        message framing.
-      </t>
-      <t>
-        This document obsoletes RFCs 7540 and 8740.  <xref target="revision-updates"/> lists notable changes.
-      </t>
+        capacity. Note, however, that TCP head-of-line blocking is not addressed by this protocol.</t>
+      <t>Finally, HTTP/2 also enables more efficient processing of messages through use of binary
+        message framing.</t>
+      <t>This document obsoletes RFCs 7540 and 8740.  <xref target="revision-updates"/> lists notable changes.</t>
     </section>
     <section anchor="Overview">
       <name>HTTP/2 Protocol Overview</name>
-      <t>
-        HTTP/2 provides an optimized transport for HTTP semantics.  HTTP/2 supports all of the core
-        features of HTTP but aims to be more efficient than HTTP/1.1.
-      </t>
-      <t>
-        HTTP/2 is a connection-oriented application-layer protocol that runs over a TCP connection
-        (<xref target="TCP"/>). The client is the TCP connection initiator.
-      </t>
-      <t>
-        The basic protocol unit in HTTP/2 is a <xref target="FrameHeader">frame</xref>.  Each frame
+      <t>HTTP/2 provides an optimized transport for HTTP semantics.  HTTP/2 supports all of the core
+        features of HTTP but aims to be more efficient than HTTP/1.1.</t>
+      <t>HTTP/2 is a connection-oriented application-layer protocol that runs over a TCP connection
+        (<xref target="TCP"/>). The client is the TCP connection initiator.</t>
+      <t>The basic protocol unit in HTTP/2 is a <xref target="FrameHeader">frame</xref>.  Each frame
         type serves a different purpose.  For example, <xref target="HEADERS" format="none">HEADERS</xref> and
         <xref target="DATA" format="none">DATA</xref> frames form the basis of <xref target="HttpFraming">HTTP requests and
         responses</xref>; other frame types like <xref target="SETTINGS" format="none">SETTINGS</xref>,
         <xref target="WINDOW_UPDATE" format="none">WINDOW_UPDATE</xref>, and <xref target="PUSH_PROMISE" format="none">PUSH_PROMISE</xref> are used in support of other
-        HTTP/2 features.
-      </t>
-      <t>
-        Multiplexing of requests is achieved by having each HTTP request/response exchange
+        HTTP/2 features.</t>
+      <t>Multiplexing of requests is achieved by having each HTTP request/response exchange
         associated with its own <xref target="StreamsLayer">stream</xref>. Streams are largely
         independent of each other, so a blocked or stalled request or response does not prevent
-        progress on other streams.
-      </t>
-      <t>
-        Effective use of multiplexing depends on flow control and prioritization.  <xref
-        target="FlowControl">Flow control</xref> ensures that it is possible to efficiently use
+        progress on other streams.</t>
+      <t>Effective use of multiplexing depends on flow control and prioritization.  <xref target="FlowControl">Flow control</xref> ensures that it is possible to efficiently use
         multiplexed streams by restricting data that is transmitted to what the receiver is able to
         handle.  <xref target="StreamPriority">Prioritization</xref> ensures that limited resources
         are used most effectively.  This revision of HTTP/2 deprecates the priority signaling scheme
-        from <xref target="RFC7540"/>.
-      </t>
-      <t>
-        Because HTTP fields used in a connection can contain large amounts of redundant
+        from <xref target="RFC7540"/>.</t>
+      <t>Because HTTP fields used in a connection can contain large amounts of redundant
         data, frames that contain them are <xref target="FieldBlock">compressed</xref>. This has
         especially advantageous impact upon request sizes in the common case, allowing many
-        requests to be compressed into one packet.
-      </t>
-      <t>
-        Finally, HTTP/2 adds a new, optional interaction mode whereby a server can <xref target="PushResources">push
+        requests to be compressed into one packet.</t>
+      <t>Finally, HTTP/2 adds a new, optional interaction mode whereby a server can <xref target="PushResources">push
         responses to a client</xref>.  This is intended to allow a server to speculatively send data to a
         client that the server anticipates the client will need, trading off some network usage
         against a potential latency gain.  The server does this by synthesizing a request, which it
         sends as a <xref target="PUSH_PROMISE" format="none">PUSH_PROMISE</xref> frame.  The server is then able to send a response to
-        the synthetic request on a separate stream.
-      </t>
+        the synthetic request on a separate stream.</t>
       <section>
         <name>Document Organization</name>
-        <t>
-          The HTTP/2 specification is split into four parts:
-        </t>
+        <t>The HTTP/2 specification is split into four parts:</t>
         <ul spacing="normal">
           <li><xref target="starting">Starting HTTP/2</xref> covers how an HTTP/2 connection is
-              initiated.
-            </li>
-          <li>
-              The <xref target="FramingLayer">frame</xref> and <xref target="StreamsLayer">stream</xref> layers describe the way HTTP/2 frames are
-              structured and formed into multiplexed streams.
-            </li>
+              initiated.</li>
+          <li>The <xref target="FramingLayer">frame</xref> and <xref target="StreamsLayer">stream</xref> layers describe the way HTTP/2 frames are
+              structured and formed into multiplexed streams.</li>
           <li><xref target="FrameTypes">Frame</xref> and <xref target="ErrorCodes">error</xref>
-              definitions include details of the frame and error types used in HTTP/2.
-            </li>
+              definitions include details of the frame and error types used in HTTP/2.</li>
           <li><xref target="HttpLayer">HTTP mappings</xref> and <xref target="HttpExtra">additional
               requirements</xref> describe how HTTP semantics are expressed using frames and
-              streams.
-          </li>
+              streams.</li>
         </ul>
-        <t>
-          While some of the frame- and stream-layer concepts are isolated from HTTP, this
+        <t>While some of the frame- and stream-layer concepts are isolated from HTTP, this
           specification does not define a completely generic frame layer. The frame and stream
-          layers are tailored to the needs of HTTP.
-        </t>
+          layers are tailored to the needs of HTTP.</t>
       </section>
       <section>
         <name>Conventions and Terminology</name>
@@ -167,237 +117,153 @@
         "<bcp14>REQUIRED</bcp14>", "<bcp14>SHALL</bcp14>", "<bcp14>SHALL NOT</bcp14>",
         "<bcp14>SHOULD</bcp14>", "<bcp14>SHOULD NOT</bcp14>", "<bcp14>RECOMMENDED</bcp14>",
         "<bcp14>NOT RECOMMENDED</bcp14>", "<bcp14>MAY</bcp14>", and "<bcp14>OPTIONAL</bcp14>" in
-        this document are to be interpreted as described in BCP&#xa0;14 <xref target="RFC2119"
-        format="default"/> <xref target="RFC8174" format="default"/> when, and only when, they
+        this document are to be interpreted as described in BCP 14 <xref target="RFC2119" format="default"/> <xref target="RFC8174" format="default"/> when, and only when, they
         appear in all capitals, as shown here.</t>
-        <t>
-          All numeric values are in network byte order.  Values are unsigned unless otherwise
+        <t>All numeric values are in network byte order.  Values are unsigned unless otherwise
           indicated.  Literal values are provided in decimal or hexadecimal as appropriate.
           Hexadecimal literals are prefixed with "<tt>0x</tt>" to distinguish them
-          from decimal literals.
-        </t>
-        <t>
-          This specification describes binary formats using the conventions described in <xref
-          target="QUIC" section="1.3">RFC 9000</xref>.  Note that this format uses network byte
-          order and that high-valued bits are listed before low-valued bits.
-        </t>
-        <t>
-          The following terms are used:
-        </t>
+          from decimal literals.</t>
+        <t>This specification describes binary formats using the conventions described in <xref target="QUIC" section="1.3">RFC 9000</xref>.  Note that this format uses network byte
+          order and that high-valued bits are listed before low-valued bits.</t>
+        <t>The following terms are used:</t>
         <dl newline="false" spacing="normal">
           <dt>client:</dt>
-          <dd>
-              The endpoint that initiates an HTTP/2 connection.  Clients send HTTP requests and
-              receive HTTP responses.
-            </dd>
+          <dd>The endpoint that initiates an HTTP/2 connection.  Clients send HTTP requests and
+              receive HTTP responses.</dd>
           <dt>connection:</dt>
-          <dd>
-              A transport-layer connection between two endpoints.
-            </dd>
+          <dd>A transport-layer connection between two endpoints.</dd>
           <dt>connection error:</dt>
-          <dd>
-              An error that affects the entire HTTP/2 connection.
-            </dd>
+          <dd>An error that affects the entire HTTP/2 connection.</dd>
           <dt>endpoint:</dt>
-          <dd>
-              Either the client or server of the connection.
-            </dd>
+          <dd>Either the client or server of the connection.</dd>
           <dt>frame:</dt>
-          <dd>
-              The smallest unit of communication within an HTTP/2 connection, consisting of a header
-              and a variable-length sequence of octets structured according to the frame type.
-            </dd>
+          <dd>The smallest unit of communication within an HTTP/2 connection, consisting of a header
+              and a variable-length sequence of octets structured according to the frame type.</dd>
           <dt>peer:</dt>
-          <dd>
-              An endpoint.  When discussing a particular endpoint, "peer" refers to the endpoint
-              that is remote to the primary subject of discussion.
-            </dd>
+          <dd>An endpoint.  When discussing a particular endpoint, "peer" refers to the endpoint
+              that is remote to the primary subject of discussion.</dd>
           <dt>receiver:</dt>
-          <dd>
-              An endpoint that is receiving frames.
-            </dd>
+          <dd>An endpoint that is receiving frames.</dd>
           <dt>sender:</dt>
-          <dd>
-              An endpoint that is transmitting frames.
-            </dd>
+          <dd>An endpoint that is transmitting frames.</dd>
           <dt>server:</dt>
-          <dd>
-              The endpoint that accepts an HTTP/2 connection.  Servers receive HTTP requests and
-              send HTTP responses.
-            </dd>
+          <dd>The endpoint that accepts an HTTP/2 connection.  Servers receive HTTP requests and
+              send HTTP responses.</dd>
           <dt>stream:</dt>
-          <dd>
-              A bidirectional flow of frames within the HTTP/2 connection.
-            </dd>
+          <dd>A bidirectional flow of frames within the HTTP/2 connection.</dd>
           <dt>stream error:</dt>
-          <dd>
-              An error on the individual HTTP/2 stream.
-            </dd>
+          <dd>An error on the individual HTTP/2 stream.</dd>
         </dl>
-        <t>
-          Finally, the terms "gateway", "intermediary", "proxy", and "tunnel" are defined in
+        <t>Finally, the terms "gateway", "intermediary", "proxy", and "tunnel" are defined in
           <xref target="HTTP" section="3.7"/>.  Intermediaries act as both client
-          and server at different times.
-        </t>
-        <t>
-          The term "content" as it applies to message bodies is defined in <xref target="HTTP" section="6.4"/>.
-        </t>
+          and server at different times.</t>
+        <t>The term "content" as it applies to message bodies is defined in <xref target="HTTP" section="6.4"/>.</t>
       </section>
     </section>
     <section anchor="starting">
       <name>Starting HTTP/2</name>
-      <t>
-        Implementations that generate HTTP requests need to discover whether a server supports
-        HTTP/2.
-      </t>
-      <t>
-        HTTP/2 uses the "<tt>http</tt>" and "<tt>https</tt>" URI schemes defined in <xref target="HTTP"
-        section="4.2"/>, with the same default port numbers as HTTP/1.1 <xref
-        target="HTTP11"/>. These URIs do not include any indication about what HTTP versions an
+      <t>Implementations that generate HTTP requests need to discover whether a server supports
+        HTTP/2.</t>
+      <t>HTTP/2 uses the "<tt>http</tt>" and "<tt>https</tt>" URI schemes defined in <xref target="HTTP" section="4.2"/>, with the same default port numbers as HTTP/1.1 <xref target="HTTP11"/>. These URIs do not include any indication about what HTTP versions an
         upstream server (the immediate peer to which the client wishes to establish a connection)
-        supports.
-      </t>
-      <t>
-        The means by which support for HTTP/2 is determined is different for "<tt>http</tt>" and "<tt>https</tt>"
+        supports.</t>
+      <t>The means by which support for HTTP/2 is determined is different for "<tt>http</tt>" and "<tt>https</tt>"
         URIs.  Discovery for "<tt>https</tt>" URIs is described in <xref target="discover-https"/>. HTTP/2
         support for "<tt>http</tt>" URIs can only be discovered by out-of-band means and requires prior knowledge
-        of the support as described in <xref target="known-http"/>.
-      </t>
+        of the support as described in <xref target="known-http"/>.</t>
       <section anchor="versioning">
         <name>HTTP/2 Version Identification</name>
-        <t>
-          The protocol defined in this document has two identifiers. Creating a connection based on
+        <t>The protocol defined in this document has two identifiers. Creating a connection based on
           either implies the use of the transport, framing, and message semantics described in this
-          document.
-        </t>
+          document.</t>
         <ul spacing="normal">
           <li>
-            <t>
-                The string "h2" identifies the protocol where HTTP/2 uses Transport Layer Security
-                (TLS); see <xref target="TLSUsage"/>.  This identifier is used in the <xref
-                target="TLS-ALPN">TLS Application-Layer Protocol Negotiation (ALPN) extension</xref>
-                field and in any place where HTTP/2 over TLS is identified.
-            </t>
-            <t>
-                The "h2" string is serialized into an ALPN protocol identifier as the two-octet
-                sequence: 0x68, 0x32.
-            </t>
+            <t>The string "h2" identifies the protocol where HTTP/2 uses Transport Layer Security
+                (TLS); see <xref target="TLSUsage"/>.  This identifier is used in the <xref target="TLS-ALPN">TLS Application-Layer Protocol Negotiation (ALPN) extension</xref>
+                field and in any place where HTTP/2 over TLS is identified.</t>
+            <t>The "h2" string is serialized into an ALPN protocol identifier as the two-octet
+                sequence: 0x68, 0x32.</t>
           </li>
           <li>
-            <t>
-                The "h2c" string was previously used as a token for use in the HTTP Upgrade
+            <t>The "h2c" string was previously used as a token for use in the HTTP Upgrade
                 mechanism's Upgrade header field (<xref target="HTTP" section="7.8"/>). This usage
                 was never widely deployed and is deprecated by this document. The same applies to the
-                HTTP2-Settings header field, which was used with the upgrade to "h2c".
-            </t>
+                HTTP2-Settings header field, which was used with the upgrade to "h2c".</t>
           </li>
         </ul>
       </section>
       <section anchor="discover-https">
         <name>Starting HTTP/2 for "<tt>https</tt>" URIs</name>
-        <t>
-          A client that makes a request to an "<tt>https</tt>" URI uses <xref target="TLS13">TLS</xref> with
-          the <xref target="TLS-ALPN">ALPN extension</xref>.
-        </t>
-        <t>
-          HTTP/2 over TLS uses the "h2" protocol identifier.  The "h2c" protocol identifier MUST NOT
+        <t>A client that makes a request to an "<tt>https</tt>" URI uses <xref target="TLS13">TLS</xref> with
+          the <xref target="TLS-ALPN">ALPN extension</xref>.</t>
+        <t>HTTP/2 over TLS uses the "h2" protocol identifier.  The "h2c" protocol identifier <bcp14>MUST NOT</bcp14>
           be sent by a client or selected by a server; the "h2c" protocol identifier describes a
-          protocol that does not use TLS.
-        </t>
-        <t>
-          Once TLS negotiation is complete, both the client and the server MUST send a <xref target="preface">connection preface</xref>.
-        </t>
+          protocol that does not use TLS.</t>
+        <t>Once TLS negotiation is complete, both the client and the server <bcp14>MUST</bcp14> send a <xref target="preface">connection preface</xref>.</t>
       </section>
       <section anchor="known-http">
         <name>Starting HTTP/2 with Prior Knowledge</name>
-        <t>
-          A client can learn that a particular server supports HTTP/2 by other means.  For example,
-          a client could be configured with knowledge that a server supports HTTP/2.
-        </t>
-        <t>
-          A client that knows that a server supports HTTP/2 can establish a TCP connection and send
+        <t>A client can learn that a particular server supports HTTP/2 by other means.  For example,
+          a client could be configured with knowledge that a server supports HTTP/2.</t>
+        <t>A client that knows that a server supports HTTP/2 can establish a TCP connection and send
           the <xref target="preface">connection preface</xref> followed by HTTP/2 frames.
           Servers can identify these connections by the presence of the connection preface. This
           only affects the establishment of HTTP/2 connections over cleartext TCP; HTTP/2 connections
-          over TLS MUST use <xref target="TLS-ALPN">protocol negotiation in
-          TLS</xref>.
-        </t>
-        <t>
-          Likewise, the server MUST send a <xref target="preface">connection preface</xref>.
-        </t>
-        <t>
-          Without additional information, prior support for HTTP/2 is not a strong signal that a
+          over TLS <bcp14>MUST</bcp14> use <xref target="TLS-ALPN">protocol negotiation in
+          TLS</xref>.</t>
+        <t>Likewise, the server <bcp14>MUST</bcp14> send a <xref target="preface">connection preface</xref>.</t>
+        <t>Without additional information, prior support for HTTP/2 is not a strong signal that a
           given server will support HTTP/2 for future connections. For example, it is possible for
           server configurations to change, for configurations to differ between instances in
-          clustered servers, or for network conditions to change.
-        </t>
+          clustered servers, or for network conditions to change.</t>
       </section>
       <section anchor="preface">
         <name>HTTP/2 Connection Preface</name>
-        <t>
-          In HTTP/2, each endpoint is required to send a connection preface as a final confirmation
+        <t>In HTTP/2, each endpoint is required to send a connection preface as a final confirmation
           of the protocol in use and to establish the initial settings for the HTTP/2 connection.
-          The client and server each send a different connection preface.
-        </t>
-        <t>
-          The client connection preface starts with a sequence of 24 octets, which in hex notation
-          is:
-        </t>
+          The client and server each send a different connection preface.</t>
+        <t>The client connection preface starts with a sequence of 24 octets, which in hex notation
+          is:</t>
         <artwork type="inline"><![CDATA[
   0x505249202a20485454502f322e300d0a0d0a534d0d0a0d0a
 ]]></artwork>
-        <t>
-          That is, the connection preface starts with the string "<tt>PRI *
+        <t>That is, the connection preface starts with the string "<tt>PRI *
           HTTP/2.0\r\n\r\nSM\r\n\r\n</tt>". This sequence
-          MUST be followed by a <xref target="SETTINGS" format="none">SETTINGS</xref> frame (<xref target="SETTINGS"/>), which
-          MAY be empty. The client sends the client connection preface as the first
-          application data octets of a connection.
-        </t>
+          <bcp14>MUST</bcp14> be followed by a <xref target="SETTINGS" format="none">SETTINGS</xref> frame (<xref target="SETTINGS"/>), which
+          <bcp14>MAY</bcp14> be empty. The client sends the client connection preface as the first
+          application data octets of a connection.</t>
         <aside>
           <t>Note:
             The client connection preface is selected so that a large proportion of HTTP/1.1 or
             HTTP/1.0 servers and intermediaries do not attempt to process further frames.  Note
-            that this does not address the concerns raised in <xref target="TALKING"/>.
-        </t>
+            that this does not address the concerns raised in <xref target="TALKING"/>.</t>
         </aside>
-        <t>
-          The server connection preface consists of a potentially empty <xref target="SETTINGS" format="none">SETTINGS</xref>
-          frame (<xref target="SETTINGS"/>) that MUST be the first frame the server sends in the
-          HTTP/2 connection.
-        </t>
-        <t>
-          The <xref target="SETTINGS" format="none">SETTINGS</xref> frames received from a peer as part of the connection preface
-          MUST be acknowledged (see <xref target="SettingsSync"/>) after sending the connection
-          preface.
-        </t>
-        <t>
-          To avoid unnecessary latency, clients are permitted to send additional frames to the
+        <t>The server connection preface consists of a potentially empty <xref target="SETTINGS" format="none">SETTINGS</xref>
+          frame (<xref target="SETTINGS"/>) that <bcp14>MUST</bcp14> be the first frame the server sends in the
+          HTTP/2 connection.</t>
+        <t>The <xref target="SETTINGS" format="none">SETTINGS</xref> frames received from a peer as part of the connection preface
+          <bcp14>MUST</bcp14> be acknowledged (see <xref target="SettingsSync"/>) after sending the connection
+          preface.</t>
+        <t>To avoid unnecessary latency, clients are permitted to send additional frames to the
           server immediately after sending the client connection preface, without waiting to receive
           the server connection preface.  It is important to note, however, that the server
           connection preface <xref target="SETTINGS" format="none">SETTINGS</xref> frame might include settings that necessarily
           alter how a client is expected to communicate with the server. Upon receiving the
           <xref target="SETTINGS" format="none">SETTINGS</xref> frame, the client is expected to honor any settings established.
           In some configurations, it is possible for the server to transmit <xref target="SETTINGS" format="none">SETTINGS</xref>
-          before the client sends additional frames, providing an opportunity to avoid this issue.
-        </t>
-        <t>
-          Clients and servers MUST treat an invalid connection preface as a <xref target="ConnectionErrorHandler">connection error</xref> of type
+          before the client sends additional frames, providing an opportunity to avoid this issue.</t>
+        <t>Clients and servers <bcp14>MUST</bcp14> treat an invalid connection preface as a <xref target="ConnectionErrorHandler">connection error</xref> of type
           <xref target="PROTOCOL_ERROR" format="none">PROTOCOL_ERROR</xref>.  A <xref target="GOAWAY" format="none">GOAWAY</xref> frame (<xref target="GOAWAY"/>)
-          MAY be omitted in this case, since an invalid preface indicates that the peer is not using
-          HTTP/2.
-        </t>
+          <bcp14>MAY</bcp14> be omitted in this case, since an invalid preface indicates that the peer is not using
+          HTTP/2.</t>
       </section>
     </section>
     <section anchor="FramingLayer">
       <name>HTTP Frames</name>
-      <t>
-        Once the HTTP/2 connection is established, endpoints can begin exchanging frames.
-      </t>
+      <t>Once the HTTP/2 connection is established, endpoints can begin exchanging frames.</t>
       <section anchor="FrameHeader">
         <name>Frame Format</name>
-        <t>
-          All frames begin with a fixed 9-octet header followed by a variable-length frame payload.
-        </t>
+        <t>All frames begin with a fixed 9-octet header followed by a variable-length frame payload.</t>
         <figure anchor="FrameLayout">
           <name>Frame Layout</name>
           <artwork type="inline"><![CDATA[
@@ -414,261 +280,171 @@ HTTP Frame {
 }
 ]]></artwork>
         </figure>
-        <t>
-          The fields of the frame header are defined as:
-        </t>
+        <t>The fields of the frame header are defined as:</t>
         <dl newline="false" spacing="normal">
           <dt>Length:</dt>
           <dd>
-            <t>
-                The length of the frame payload expressed as an unsigned 24-bit integer in units of octets.  Values
-                greater than 2<sup>14</sup> (16,384) MUST NOT be sent unless the receiver has
-                set a larger value for <xref target="SETTINGS_MAX_FRAME_SIZE" format="none">SETTINGS_MAX_FRAME_SIZE</xref>.
-            </t>
-            <t>
-                The 9 octets of the frame header are not included in this value.
-            </t>
+            <t>The length of the frame payload expressed as an unsigned 24-bit integer in units of octets.  Values
+                greater than 2<sup>14</sup> (16,384) <bcp14>MUST NOT</bcp14> be sent unless the receiver has
+                set a larger value for <xref target="SETTINGS_MAX_FRAME_SIZE" format="none">SETTINGS_MAX_FRAME_SIZE</xref>.</t>
+            <t>The 9 octets of the frame header are not included in this value.</t>
           </dd>
           <dt>Type:</dt>
           <dd>
-            <t>
-                The 8-bit type of the frame.  The frame type determines the format and semantics of
+            <t>The 8-bit type of the frame.  The frame type determines the format and semantics of
                 the frame.  Frames defined in this document are listed in <xref target="FrameTypes"/>.
-                Implementations MUST ignore and discard frames of unknown types.
-            </t>
+                Implementations <bcp14>MUST</bcp14> ignore and discard frames of unknown types.</t>
           </dd>
           <dt>Flags:</dt>
           <dd>
-            <t>
-                An 8-bit field reserved for boolean flags specific to the frame type.
-            </t>
-            <t>
-              Flags are assigned semantics specific to the indicated frame type.  Unused flags are
-              those that have no defined semantics for a particular frame type. Unused flags MUST be
-              ignored on receipt and MUST be left unset (0x00) when sending.
-            </t>
+            <t>An 8-bit field reserved for boolean flags specific to the frame type.</t>
+            <t>Flags are assigned semantics specific to the indicated frame type.  Unused flags are
+              those that have no defined semantics for a particular frame type. Unused flags <bcp14>MUST</bcp14> be
+              ignored on receipt and <bcp14>MUST</bcp14> be left unset (0x00) when sending.</t>
           </dd>
           <dt>Reserved:</dt>
           <dd>
-            <t>
-                A reserved 1-bit field.  The semantics of this bit are undefined, and the bit MUST
-                remain unset (0x00) when sending and MUST be ignored when receiving.
-            </t>
+            <t>A reserved 1-bit field.  The semantics of this bit are undefined, and the bit <bcp14>MUST</bcp14>
+                remain unset (0x00) when sending and <bcp14>MUST</bcp14> be ignored when receiving.</t>
           </dd>
           <dt>Stream Identifier:</dt>
           <dd>
-            <t>
-                A stream identifier (see <xref target="StreamIdentifiers"/>) expressed as an
+            <t>A stream identifier (see <xref target="StreamIdentifiers"/>) expressed as an
                 unsigned 31-bit integer.  The value 0x00 is reserved for frames that are associated
-                with the connection as a whole as opposed to an individual stream.
-            </t>
+                with the connection as a whole as opposed to an individual stream.</t>
           </dd>
         </dl>
-        <t>
-          The structure and content of the frame payload are dependent entirely on the frame type.
-        </t>
+        <t>The structure and content of the frame payload are dependent entirely on the frame type.</t>
       </section>
       <section anchor="FrameSize">
         <name>Frame Size</name>
-        <t>
-          The size of a frame payload is limited by the maximum size that a receiver advertises in
+        <t>The size of a frame payload is limited by the maximum size that a receiver advertises in
           the <xref target="SETTINGS_MAX_FRAME_SIZE" format="none">SETTINGS_MAX_FRAME_SIZE</xref> setting.  This setting can have any value
           between 2<sup>14</sup> (16,384) and 2<sup>24</sup>-1 (16,777,215) octets,
-          inclusive.
-        </t>
-        <t>
-          All implementations MUST be capable of receiving and minimally processing frames up to
+          inclusive.</t>
+        <t>All implementations <bcp14>MUST</bcp14> be capable of receiving and minimally processing frames up to
           2<sup>14</sup> octets in length, plus the 9-octet <xref target="FrameHeader">frame
-          header</xref>.  The size of the frame header is not included when describing frame sizes.
-        </t>
+          header</xref>.  The size of the frame header is not included when describing frame sizes.</t>
         <aside>
           <t>Note: Certain frame types, such as <xref target="PING">PING</xref>, impose additional limits
-            on the amount of frame payload data allowed.
-          </t>
+            on the amount of frame payload data allowed.</t>
         </aside>
-        <t>
-          An endpoint MUST send an error code of <xref target="FRAME_SIZE_ERROR"
-          format="none">FRAME_SIZE_ERROR</xref> if a frame exceeds the size defined in <xref
-          target="SETTINGS_MAX_FRAME_SIZE" format="none">SETTINGS_MAX_FRAME_SIZE</xref>, exceeds any
+        <t>An endpoint <bcp14>MUST</bcp14> send an error code of <xref target="FRAME_SIZE_ERROR" format="none">FRAME_SIZE_ERROR</xref> if a frame exceeds the size defined in <xref target="SETTINGS_MAX_FRAME_SIZE" format="none">SETTINGS_MAX_FRAME_SIZE</xref>, exceeds any
           limit defined for the frame type, or is too small to contain mandatory frame data. A frame
-          size error in a frame that could alter the state of the entire connection MUST be treated
+          size error in a frame that could alter the state of the entire connection <bcp14>MUST</bcp14> be treated
           as a <xref target="ConnectionErrorHandler">connection error</xref>; this includes any
-          frame carrying a <xref target="FieldBlock">field block</xref> (that is, <xref
-          target="HEADERS" format="none">HEADERS</xref>, <xref target="PUSH_PROMISE"
-          format="none">PUSH_PROMISE</xref>, and <xref target="CONTINUATION"
-          format="none">CONTINUATION</xref>), a <xref target="SETTINGS"
-          format="none">SETTINGS</xref> frame, and any frame with a stream identifier of 0.
-        </t>
-        <t>
-          Endpoints are not obligated to use all available space in a frame. Responsiveness can be
+          frame carrying a <xref target="FieldBlock">field block</xref> (that is, <xref target="HEADERS" format="none">HEADERS</xref>, <xref target="PUSH_PROMISE" format="none">PUSH_PROMISE</xref>, and <xref target="CONTINUATION" format="none">CONTINUATION</xref>), a <xref target="SETTINGS" format="none">SETTINGS</xref> frame, and any frame with a stream identifier of 0.</t>
+        <t>Endpoints are not obligated to use all available space in a frame. Responsiveness can be
           improved by using frames that are smaller than the permitted maximum size. Sending large
           frames can result in delays in sending time-sensitive frames (such as
           <xref target="RST_STREAM" format="none">RST_STREAM</xref>, <xref target="WINDOW_UPDATE" format="none">WINDOW_UPDATE</xref>, or <xref target="PRIORITY" format="none">PRIORITY</xref>),
-          which, if blocked by the transmission of a large frame, could affect performance.
-        </t>
+          which, if blocked by the transmission of a large frame, could affect performance.</t>
       </section>
       <section anchor="FieldBlock">
         <name>Field Section Compression and Decompression</name>
-        <t>
-          Field section compression is the process of compressing a set of field lines (<xref target="HTTP" section="5.2"/>) to form a
+        <t>Field section compression is the process of compressing a set of field lines (<xref target="HTTP" section="5.2"/>) to form a
           field block.  Field section decompression is the process of decoding a field block into a
           set of field lines.  Details of HTTP/2 field section compression and decompression are
           defined in <xref target="COMPRESSION"/>, which, for historical reasons, refers to these
-          processes as header compression and decompression.
-        </t>
-        <t>
-          Each field block carries all of the compressed field lines of a single field section.
-          Header sections also include control data associated with the message in the form of <xref
-          target="PseudoHeaderFields">pseudo-header fields</xref> that use the same format as a
-          field line.
-        </t>
+          processes as header compression and decompression.</t>
+        <t>Each field block carries all of the compressed field lines of a single field section.
+          Header sections also include control data associated with the message in the form of <xref target="PseudoHeaderFields">pseudo-header fields</xref> that use the same format as a
+          field line.</t>
         <aside>
-          <t>
-            Note: <xref target="RFC7540">RFC 7540</xref> used the term "header block" in place of
-            the more generic "field block".
-          </t>
+          <t>Note: <xref target="RFC7540">RFC 7540</xref> used the term "header block" in place of
+            the more generic "field block".</t>
         </aside>
-        <t>
-          Field blocks carry control data and header sections for requests, responses, promised
+        <t>Field blocks carry control data and header sections for requests, responses, promised
           requests, and pushed responses (see <xref target="PushResources"/>).  All these messages,
           except for interim responses and requests contained in <xref target="PUSH_PROMISE">PUSH_PROMISE</xref> frames, can optionally include a field block that
-          carries a trailer section.
-        </t>
-        <t>
-          A field section is a collection of field lines.  Each of the field lines in a
+          carries a trailer section.</t>
+        <t>A field section is a collection of field lines.  Each of the field lines in a
           field block carries a single value.  The serialized field block is then divided into one or
           more octet sequences, called field block fragments.  The first field block fragment is transmitted within the frame
-          payload of <xref target="HEADERS">HEADERS</xref> or <xref target="PUSH_PROMISE">PUSH_PROMISE</xref>, each of which could be followed by <xref target="CONTINUATION">CONTINUATION</xref> frames to carry subsequent field block fragments.
-        </t>
-        <t>
-          The <xref target="COOKIE">Cookie header field</xref> is treated specially by the HTTP
-          mapping (see <xref target="CompressCookie"/>).
-        </t>
-        <t>
-          A receiving endpoint reassembles the field block by concatenating its fragments and then
-          decompresses the block to reconstruct the field section.
-        </t>
-        <t>
-          A complete field section consists of either:
-        </t>
+          payload of <xref target="HEADERS">HEADERS</xref> or <xref target="PUSH_PROMISE">PUSH_PROMISE</xref>, each of which could be followed by <xref target="CONTINUATION">CONTINUATION</xref> frames to carry subsequent field block fragments.</t>
+        <t>The <xref target="COOKIE">Cookie header field</xref> is treated specially by the HTTP
+          mapping (see <xref target="CompressCookie"/>).</t>
+        <t>A receiving endpoint reassembles the field block by concatenating its fragments and then
+          decompresses the block to reconstruct the field section.</t>
+        <t>A complete field section consists of either:</t>
         <ul spacing="normal">
-          <li>
-              a single <xref target="HEADERS" format="none">HEADERS</xref> or <xref target="PUSH_PROMISE" format="none">PUSH_PROMISE</xref> frame,
-              with the END_HEADERS flag set, or
-            </li>
-          <li>
-              a <xref target="HEADERS" format="none">HEADERS</xref> or <xref target="PUSH_PROMISE" format="none">PUSH_PROMISE</xref> frame with the END_HEADERS
+          <li>a single <xref target="HEADERS" format="none">HEADERS</xref> or <xref target="PUSH_PROMISE" format="none">PUSH_PROMISE</xref> frame,
+              with the END_HEADERS flag set, or</li>
+          <li>a <xref target="HEADERS" format="none">HEADERS</xref> or <xref target="PUSH_PROMISE" format="none">PUSH_PROMISE</xref> frame with the END_HEADERS
               flag unset and one or more <xref target="CONTINUATION" format="none">CONTINUATION</xref> frames,
-              where the last <xref target="CONTINUATION" format="none">CONTINUATION</xref> frame has the END_HEADERS flag set.
-            </li>
+              where the last <xref target="CONTINUATION" format="none">CONTINUATION</xref> frame has the END_HEADERS flag set.</li>
         </ul>
-        <t>
-          Each field block is processed as a discrete unit.
-          Field blocks MUST be transmitted as a contiguous sequence of frames, with no interleaved
+        <t>Each field block is processed as a discrete unit.
+          Field blocks <bcp14>MUST</bcp14> be transmitted as a contiguous sequence of frames, with no interleaved
           frames of any other type or from any other stream.  The last frame in a sequence of
           <xref target="HEADERS" format="none">HEADERS</xref> or <xref target="CONTINUATION" format="none">CONTINUATION</xref> frames has the END_HEADERS flag set.
           The last frame in a sequence of <xref target="PUSH_PROMISE" format="none">PUSH_PROMISE</xref> or <xref target="CONTINUATION" format="none">CONTINUATION</xref>
           frames has the END_HEADERS flag set.  This allows a field block to be logically
-          equivalent to a single frame.
-        </t>
-        <t>
-          Field block fragments can only be sent as the frame payload of <xref target="HEADERS" format="none">HEADERS</xref>,
+          equivalent to a single frame.</t>
+        <t>Field block fragments can only be sent as the frame payload of <xref target="HEADERS" format="none">HEADERS</xref>,
           <xref target="PUSH_PROMISE" format="none">PUSH_PROMISE</xref>, or <xref target="CONTINUATION" format="none">CONTINUATION</xref> frames because these frames
           carry data that can modify the compression context maintained by a receiver.  An endpoint
           receiving <xref target="HEADERS" format="none">HEADERS</xref>, <xref target="PUSH_PROMISE" format="none">PUSH_PROMISE</xref>, or
           <xref target="CONTINUATION" format="none">CONTINUATION</xref> frames needs to reassemble field blocks and perform
-          decompression even if the frames are to be discarded.  A receiver MUST terminate the
+          decompression even if the frames are to be discarded.  A receiver <bcp14>MUST</bcp14> terminate the
           connection with a <xref target="ConnectionErrorHandler">connection error</xref> of type
-          <xref target="COMPRESSION_ERROR" format="none">COMPRESSION_ERROR</xref> if it does not decompress a field block.
-        </t>
-        <t>
-          A decoding error in a field block MUST be treated as a <xref
-          target="ConnectionErrorHandler">connection error</xref> of type <xref
-          target="COMPRESSION_ERROR" format="none">COMPRESSION_ERROR</xref>.
-        </t>
-
+          <xref target="COMPRESSION_ERROR" format="none">COMPRESSION_ERROR</xref> if it does not decompress a field block.</t>
+        <t>A decoding error in a field block <bcp14>MUST</bcp14> be treated as a <xref target="ConnectionErrorHandler">connection error</xref> of type <xref target="COMPRESSION_ERROR" format="none">COMPRESSION_ERROR</xref>.</t>
         <section anchor="dynamic-table">
           <name>Compression State</name>
-          <t>
-            Field compression is stateful.  Each endpoint has an HPACK encoder context and an HPACK
+          <t>Field compression is stateful.  Each endpoint has an HPACK encoder context and an HPACK
             decoder context that are used for encoding and decoding all field blocks on a
             connection.  <xref target="COMPRESSION" section="4"/> defines the dynamic table, which
-            is the primary state for each context.
-          </t>
-          <t>
-            The dynamic table has a maximum size that is set by an HPACK decoder. An endpoint
+            is the primary state for each context.</t>
+          <t>The dynamic table has a maximum size that is set by an HPACK decoder. An endpoint
             communicates the size chosen by its HPACK decoder context using the
             SETTINGS_HEADER_TABLE_SIZE setting; see <xref target="SettingValues"/>.  When a
             connection is established, the dynamic table size for the HPACK decoder and encoder at
             both endpoints starts at 4,096 bytes, the initial value of the
-            SETTINGS_HEADER_TABLE_SIZE setting.
-          </t>
-          <t>
-            Any change to the maximum value set using SETTINGS_HEADER_TABLE_SIZE takes effect when
+            SETTINGS_HEADER_TABLE_SIZE setting.</t>
+          <t>Any change to the maximum value set using SETTINGS_HEADER_TABLE_SIZE takes effect when
             the endpoint <xref target="SettingsSync">acknowledges settings</xref>.  The HPACK
             encoder at that endpoint can set the dynamic table to any size up to the maximum value
             set by the decoder.  An HPACK encoder declares the size of the dynamic table with a
-            Dynamic Table Size Update instruction (<xref target="COMPRESSION" section="6.3"/>).
-          </t>
-          <t>
-            Once an endpoint acknowledges a change to SETTINGS_HEADER_TABLE_SIZE that reduces the
-            maximum below the current size of the dynamic table, its HPACK encoder MUST start the
+            Dynamic Table Size Update instruction (<xref target="COMPRESSION" section="6.3"/>).</t>
+          <t>Once an endpoint acknowledges a change to SETTINGS_HEADER_TABLE_SIZE that reduces the
+            maximum below the current size of the dynamic table, its HPACK encoder <bcp14>MUST</bcp14> start the
             next field block with a Dynamic Table Size Update instruction that sets the dynamic
-            table to a size that is less than or equal to the reduced maximum; see <xref
-            target="COMPRESSION" section="4.2"/>.  An endpoint MUST treat a field block that follows
-            an acknowledgment of the reduction to the maximum dynamic table size as a <xref
-            target="ConnectionErrorHandler">connection error</xref> of type <xref
-            target="COMPRESSION_ERROR" format="none">COMPRESSION_ERROR</xref> if it does not start
-            with a conformant Dynamic Table Size Update instruction.
-          </t>
+            table to a size that is less than or equal to the reduced maximum; see <xref target="COMPRESSION" section="4.2"/>.  An endpoint <bcp14>MUST</bcp14> treat a field block that follows
+            an acknowledgment of the reduction to the maximum dynamic table size as a <xref target="ConnectionErrorHandler">connection error</xref> of type <xref target="COMPRESSION_ERROR" format="none">COMPRESSION_ERROR</xref> if it does not start
+            with a conformant Dynamic Table Size Update instruction.</t>
           <aside>
-            <t>
-              Implementers are advised that reducing the value of SETTINGS_HEADER_TABLE_SIZE is not
+            <t>Implementers are advised that reducing the value of SETTINGS_HEADER_TABLE_SIZE is not
               widely interoperable.  Use of the connection preface to reduce the value below the
               initial value of 4,096 is somewhat better supported, but this might fail with some
-              implementations.
-            </t>
+              implementations.</t>
           </aside>
         </section>
       </section>
     </section>
     <section anchor="StreamsLayer">
       <name>Streams and Multiplexing</name>
-      <t>
-        A "stream" is an independent, bidirectional sequence of frames exchanged between the client
-        and server within an HTTP/2 connection.  Streams have several important characteristics:
-      </t>
+      <t>A "stream" is an independent, bidirectional sequence of frames exchanged between the client
+        and server within an HTTP/2 connection.  Streams have several important characteristics:</t>
       <ul spacing="normal">
-        <li>
-            A single HTTP/2 connection can contain multiple concurrently open streams, with either
-            endpoint interleaving frames from multiple streams.
-          </li>
-        <li>
-            Streams can be established and used unilaterally or shared by either endpoint.
-          </li>
-        <li>
-            Streams can be closed by either endpoint.
-          </li>
-        <li>
-            The order in which frames are sent is significant. Recipients process frames
+        <li>A single HTTP/2 connection can contain multiple concurrently open streams, with either
+            endpoint interleaving frames from multiple streams.</li>
+        <li>Streams can be established and used unilaterally or shared by either endpoint.</li>
+        <li>Streams can be closed by either endpoint.</li>
+        <li>The order in which frames are sent is significant. Recipients process frames
             in the order they are received.  In particular, the order of <xref target="HEADERS" format="none">HEADERS</xref>
-            and <xref target="DATA" format="none">DATA</xref> frames is semantically significant.
-          </li>
-        <li>
-            Streams are identified by an integer.  Stream identifiers are assigned to streams by the
-            endpoint initiating the stream.
-          </li>
+            and <xref target="DATA" format="none">DATA</xref> frames is semantically significant.</li>
+        <li>Streams are identified by an integer.  Stream identifiers are assigned to streams by the
+            endpoint initiating the stream.</li>
       </ul>
       <section anchor="StreamStates">
         <name>Stream States</name>
-        <t>
-          The lifecycle of a stream is shown in <xref target="StreamStatesFigure"/>.
-        </t>
+        <t>The lifecycle of a stream is shown in <xref target="StreamStatesFigure"/>.</t>
         <figure anchor="StreamStatesFigure">
           <name>Stream States</name>
           <artset>
-            <artwork type="svg">
-              <svg xmlns="http://www.w3.org/2000/svg" version="1.1" height="480" width="488" viewBox="0 0 488 480" class="diagram" text-anchor="middle" font-family="monospace" font-size="13px">
+            <artwork type="svg"><![CDATA[
+              ]]>              <svg xmlns="http://www.w3.org/2000/svg" version="1.1" height="480" width="488" viewBox="0 0 488 480" class="diagram" text-anchor="middle" font-family="monospace" font-size="13px">
                 <g transform="translate(8,16)">
                   <path d="M 0,112 L 0,416" fill="none" stroke="black"/>
                   <path d="M 56,80 L 56,144" fill="none" stroke="black"/>
@@ -769,7 +545,8 @@ HTTP Frame {
                   </g>
                 </g>
               </svg>
-            </artwork>
+<![CDATA[
+            ]]></artwork>
             <artwork type="ascii-art"><![CDATA[
                              +--------+
                      send PP |        | recv PP
@@ -816,682 +593,459 @@ HTTP Frame {
           <dt><tt>PP</tt>:</dt>
           <dd><xref target="PUSH_PROMISE" format="none">PUSH_PROMISE</xref> frame (with implied <xref target="CONTINUATION" format="none">CONTINUATION</xref> frames); state transitions are for the promised stream</dd>
         </dl>
-        <t>
-          Note that this diagram shows stream state transitions and the frames and flags that affect
+        <t>Note that this diagram shows stream state transitions and the frames and flags that affect
           those transitions only.  In this regard, <xref target="CONTINUATION" format="none">CONTINUATION</xref> frames do not result
           in state transitions; they are effectively part of the <xref target="HEADERS" format="none">HEADERS</xref> or
           <xref target="PUSH_PROMISE" format="none">PUSH_PROMISE</xref> that they follow.  For the purpose of state transitions, the
           END_STREAM flag is processed as a separate event to the frame that bears it; a
-          <xref target="HEADERS" format="none">HEADERS</xref> frame with the END_STREAM flag set can cause two state transitions.
-        </t>
-        <t>
-          Both endpoints have a subjective view of the state of a stream that could be different
+          <xref target="HEADERS" format="none">HEADERS</xref> frame with the END_STREAM flag set can cause two state transitions.</t>
+        <t>Both endpoints have a subjective view of the state of a stream that could be different
           when frames are in transit.  Endpoints do not coordinate the creation of streams; they are
           created unilaterally by either endpoint.  The negative consequences of a mismatch in
           states are limited to the "closed" state after sending <xref target="RST_STREAM" format="none">RST_STREAM</xref>, where
-          frames might be received for some time after closing.
-        </t>
-        <t>
-          Streams have the following states:
-        </t>
+          frames might be received for some time after closing.</t>
+        <t>Streams have the following states:</t>
         <dl newline="false" spacing="normal">
           <dt>idle:</dt>
           <dd>
-            <t>
-                All streams start in the "idle" state.
-            </t>
-            <t>
-                The following transitions are valid from this state:
-            </t>
+            <t>All streams start in the "idle" state.</t>
+            <t>The following transitions are valid from this state:</t>
             <ul spacing="normal">
-              <li>
-                    Sending a <xref target="HEADERS" format="none">HEADERS</xref> frame as a client, or receiving a HEADERS frame
+              <li>Sending a <xref target="HEADERS" format="none">HEADERS</xref> frame as a client, or receiving a HEADERS frame
                     as a server, causes the stream to become "open".  The stream identifier is selected as described in
                     <xref target="StreamIdentifiers"/>.  The same <xref target="HEADERS" format="none">HEADERS</xref> frame can also
-                    cause a stream to immediately become "half-closed".
-                  </li>
-              <li>
-                    Sending a <xref target="PUSH_PROMISE" format="none">PUSH_PROMISE</xref> frame on another stream reserves the idle
+                    cause a stream to immediately become "half-closed".</li>
+              <li>Sending a <xref target="PUSH_PROMISE" format="none">PUSH_PROMISE</xref> frame on another stream reserves the idle
                     stream that is identified for later use.  The stream state for the reserved
-                    stream transitions to "reserved (local)".  Only a server may send <xref target="PUSH_PROMISE" format="none">PUSH_PROMISE</xref> frames.
-                  </li>
-              <li>
-                    Receiving a <xref target="PUSH_PROMISE" format="none">PUSH_PROMISE</xref> frame on another stream reserves an idle
+                    stream transitions to "reserved (local)".  Only a server may send <xref target="PUSH_PROMISE" format="none">PUSH_PROMISE</xref> frames.</li>
+              <li>Receiving a <xref target="PUSH_PROMISE" format="none">PUSH_PROMISE</xref> frame on another stream reserves an idle
                     stream that is identified for later use.  The stream state for the reserved
-                    stream transitions to "reserved (remote)".  Only a client may receive <xref target="PUSH_PROMISE" format="none">PUSH_PROMISE</xref> frames.
-                  </li>
-              <li>
-                    Note that the <xref target="PUSH_PROMISE" format="none">PUSH_PROMISE</xref> frame is not sent on the idle
+                    stream transitions to "reserved (remote)".  Only a client may receive <xref target="PUSH_PROMISE" format="none">PUSH_PROMISE</xref> frames.</li>
+              <li>Note that the <xref target="PUSH_PROMISE" format="none">PUSH_PROMISE</xref> frame is not sent on the idle
                     stream but references the newly reserved stream in the Promised Stream ID
-                    field.
-              </li>
-              <li>
-                Opening a stream with a higher-valued stream identifier causes the stream to
+                    field.</li>
+              <li>Opening a stream with a higher-valued stream identifier causes the stream to
                 transition immediately to a "closed" state; note that this transition is not shown
-                in the diagram.
-              </li>
+                in the diagram.</li>
             </ul>
-            <t>
-                Receiving any frame other than <xref target="HEADERS" format="none">HEADERS</xref> or <xref target="PRIORITY" format="none">PRIORITY</xref> on
-                a stream in this state MUST be treated as a <xref target="ConnectionErrorHandler">connection error</xref> of type
+            <t>Receiving any frame other than <xref target="HEADERS" format="none">HEADERS</xref> or <xref target="PRIORITY" format="none">PRIORITY</xref> on
+                a stream in this state <bcp14>MUST</bcp14> be treated as a <xref target="ConnectionErrorHandler">connection error</xref> of type
                 <xref target="PROTOCOL_ERROR" format="none">PROTOCOL_ERROR</xref>. If this stream is initiated by the server, as described in
-                <xref target="StreamIdentifiers"/>, then receiving a <xref target="HEADERS" format="none">HEADERS</xref> frame MUST also
+                <xref target="StreamIdentifiers"/>, then receiving a <xref target="HEADERS" format="none">HEADERS</xref> frame <bcp14>MUST</bcp14> also
                 be treated as a <xref target="ConnectionErrorHandler">connection error</xref> of type
-                <xref target="PROTOCOL_ERROR" format="none">PROTOCOL_ERROR</xref>.
-            </t>
+                <xref target="PROTOCOL_ERROR" format="none">PROTOCOL_ERROR</xref>.</t>
           </dd>
           <dt>reserved (local):</dt>
           <dd>
-            <t>
-
-                A stream in the "reserved (local)" state is one that has been promised by sending a
+            <t>A stream in the "reserved (local)" state is one that has been promised by sending a
                 <xref target="PUSH_PROMISE" format="none">PUSH_PROMISE</xref> frame.  A <xref target="PUSH_PROMISE" format="none">PUSH_PROMISE</xref> frame reserves an
                 idle stream by associating the stream with an open stream that was initiated by the
-                remote peer (see <xref target="PushResources"/>).
-            </t>
-            <t>
-                In this state, only the following transitions are possible:
-            </t>
+                remote peer (see <xref target="PushResources"/>).</t>
+            <t>In this state, only the following transitions are possible:</t>
             <ul spacing="normal">
-              <li>
-                    The endpoint can send a <xref target="HEADERS" format="none">HEADERS</xref> frame.  This causes the stream to
-                    open in a "half-closed (remote)" state.
-                  </li>
-              <li>
-                    Either endpoint can send a <xref target="RST_STREAM" format="none">RST_STREAM</xref> frame to cause the stream
-                    to become "closed".  This releases the stream reservation.
-                  </li>
+              <li>The endpoint can send a <xref target="HEADERS" format="none">HEADERS</xref> frame.  This causes the stream to
+                    open in a "half-closed (remote)" state.</li>
+              <li>Either endpoint can send a <xref target="RST_STREAM" format="none">RST_STREAM</xref> frame to cause the stream
+                    to become "closed".  This releases the stream reservation.</li>
             </ul>
-            <t>
-                An endpoint MUST NOT send any type of frame other than <xref target="HEADERS" format="none">HEADERS</xref>,
-                <xref target="RST_STREAM" format="none">RST_STREAM</xref>, or <xref target="PRIORITY" format="none">PRIORITY</xref> in this state.
-            </t>
-            <t>
-                A <xref target="PRIORITY" format="none">PRIORITY</xref> or <xref target="WINDOW_UPDATE" format="none">WINDOW_UPDATE</xref> frame MAY be received in
+            <t>An endpoint <bcp14>MUST NOT</bcp14> send any type of frame other than <xref target="HEADERS" format="none">HEADERS</xref>,
+                <xref target="RST_STREAM" format="none">RST_STREAM</xref>, or <xref target="PRIORITY" format="none">PRIORITY</xref> in this state.</t>
+            <t>A <xref target="PRIORITY" format="none">PRIORITY</xref> or <xref target="WINDOW_UPDATE" format="none">WINDOW_UPDATE</xref> frame <bcp14>MAY</bcp14> be received in
                 this state.  Receiving any type of frame other than <xref target="RST_STREAM" format="none">RST_STREAM</xref>,
                 <xref target="PRIORITY" format="none">PRIORITY</xref>, or <xref target="WINDOW_UPDATE" format="none">WINDOW_UPDATE</xref> on a stream in this state
-                MUST be treated as a <xref target="ConnectionErrorHandler">connection error</xref>
-                of type <xref target="PROTOCOL_ERROR" format="none">PROTOCOL_ERROR</xref>.
-            </t>
+                <bcp14>MUST</bcp14> be treated as a <xref target="ConnectionErrorHandler">connection error</xref>
+                of type <xref target="PROTOCOL_ERROR" format="none">PROTOCOL_ERROR</xref>.</t>
           </dd>
           <dt>reserved (remote):</dt>
           <dd>
-            <t>
-
-                A stream in the "reserved (remote)" state has been reserved by a remote peer.
-            </t>
-            <t>
-                In this state, only the following transitions are possible:
-            </t>
+            <t>A stream in the "reserved (remote)" state has been reserved by a remote peer.</t>
+            <t>In this state, only the following transitions are possible:</t>
             <ul spacing="normal">
-              <li>
-                    Receiving a <xref target="HEADERS" format="none">HEADERS</xref> frame causes the stream to transition to
-                    "half-closed (local)".
-                  </li>
-              <li>
-                    Either endpoint can send a <xref target="RST_STREAM" format="none">RST_STREAM</xref> frame to cause the stream
-                    to become "closed".  This releases the stream reservation.
-                  </li>
+              <li>Receiving a <xref target="HEADERS" format="none">HEADERS</xref> frame causes the stream to transition to
+                    "half-closed (local)".</li>
+              <li>Either endpoint can send a <xref target="RST_STREAM" format="none">RST_STREAM</xref> frame to cause the stream
+                    to become "closed".  This releases the stream reservation.</li>
             </ul>
-            <t>
-                An endpoint MUST NOT send any type of frame other than <xref target="RST_STREAM" format="none">RST_STREAM</xref>, <xref target="WINDOW_UPDATE" format="none">WINDOW_UPDATE</xref>, or <xref target="PRIORITY" format="none">PRIORITY</xref> in this state.
-            </t>
-            <t>
-                Receiving any type of frame other than <xref target="HEADERS" format="none">HEADERS</xref>,
-                <xref target="RST_STREAM" format="none">RST_STREAM</xref>, or <xref target="PRIORITY" format="none">PRIORITY</xref> on a stream in this state MUST
+            <t>An endpoint <bcp14>MUST NOT</bcp14> send any type of frame other than <xref target="RST_STREAM" format="none">RST_STREAM</xref>, <xref target="WINDOW_UPDATE" format="none">WINDOW_UPDATE</xref>, or <xref target="PRIORITY" format="none">PRIORITY</xref> in this state.</t>
+            <t>Receiving any type of frame other than <xref target="HEADERS" format="none">HEADERS</xref>,
+                <xref target="RST_STREAM" format="none">RST_STREAM</xref>, or <xref target="PRIORITY" format="none">PRIORITY</xref> on a stream in this state <bcp14>MUST</bcp14>
                 be treated as a <xref target="ConnectionErrorHandler">connection error</xref> of
-                type <xref target="PROTOCOL_ERROR" format="none">PROTOCOL_ERROR</xref>.
-            </t>
+                type <xref target="PROTOCOL_ERROR" format="none">PROTOCOL_ERROR</xref>.</t>
           </dd>
           <dt>open:</dt>
           <dd>
-            <t>
-
-                A stream in the "open" state may be used by both peers to send frames of any type.
+            <t>A stream in the "open" state may be used by both peers to send frames of any type.
                 In this state, sending peers observe advertised <xref target="FlowControl">stream-level
-                flow-control limits</xref>.
-            </t>
-            <t>
-                From this state, either endpoint can send a frame with an END_STREAM flag set, which
+                flow-control limits</xref>.</t>
+            <t>From this state, either endpoint can send a frame with an END_STREAM flag set, which
                 causes the stream to transition into one of the "half-closed" states. An endpoint
                 sending an END_STREAM flag causes the stream state to become "half-closed (local)";
                 an endpoint receiving an END_STREAM flag causes the stream state to become "half-closed
-                (remote)".
-            </t>
-            <t>
-                Either endpoint can send a <xref target="RST_STREAM" format="none">RST_STREAM</xref> frame from this state, causing
-                it to transition immediately to "closed".
-            </t>
+                (remote)".</t>
+            <t>Either endpoint can send a <xref target="RST_STREAM" format="none">RST_STREAM</xref> frame from this state, causing
+                it to transition immediately to "closed".</t>
           </dd>
           <dt>half-closed (local):</dt>
           <dd>
-            <t>
-
-                A stream that is in the "half-closed (local)" state cannot be used for sending
+            <t>A stream that is in the "half-closed (local)" state cannot be used for sending
                 frames other than <xref target="WINDOW_UPDATE" format="none">WINDOW_UPDATE</xref>, <xref target="PRIORITY" format="none">PRIORITY</xref>, and
-                <xref target="RST_STREAM" format="none">RST_STREAM</xref>.
-            </t>
-            <t>
-                A stream transitions from this state to "closed" when a frame is received with the
+                <xref target="RST_STREAM" format="none">RST_STREAM</xref>.</t>
+            <t>A stream transitions from this state to "closed" when a frame is received with the
                 END_STREAM flag set or when either peer sends a <xref target="RST_STREAM" format="none">RST_STREAM</xref>
-                frame.
-            </t>
-            <t>
-                An endpoint can receive any type of frame in this state.  Providing flow-control
+                frame.</t>
+            <t>An endpoint can receive any type of frame in this state.  Providing flow-control
                 credit using <xref target="WINDOW_UPDATE" format="none">WINDOW_UPDATE</xref> frames is necessary to continue receiving
                 flow-controlled frames.  In this state, a receiver can ignore <xref target="WINDOW_UPDATE" format="none">WINDOW_UPDATE</xref> frames,
-                which might arrive for a short period after a frame with the END_STREAM flag set is sent.
-            </t>
-            <t><xref target="PRIORITY" format="none">PRIORITY</xref> frames can be received in this state.
-            </t>
+                which might arrive for a short period after a frame with the END_STREAM flag set is sent.</t>
+            <t><xref target="PRIORITY" format="none">PRIORITY</xref> frames can be received in this state.</t>
           </dd>
           <dt>half-closed (remote):</dt>
           <dd>
-            <t>
-
-                A stream that is "half-closed (remote)" is no longer being used by the peer to send
+            <t>A stream that is "half-closed (remote)" is no longer being used by the peer to send
                 frames.  In this state, an endpoint is no longer obligated to maintain a receiver
-                flow-control window.
-            </t>
-            <t>
-                If an endpoint receives additional frames, other
+                flow-control window.</t>
+            <t>If an endpoint receives additional frames, other
                 than <xref target="WINDOW_UPDATE" format="none">WINDOW_UPDATE</xref>, <xref target="PRIORITY" format="none">PRIORITY</xref>, or
-                <xref target="RST_STREAM" format="none">RST_STREAM</xref>,  for a stream that is in this state, it MUST respond with a <xref target="StreamErrorHandler">stream error</xref> of type
-                <xref target="STREAM_CLOSED" format="none">STREAM_CLOSED</xref>.
-            </t>
-            <t>
-                A stream that is "half-closed (remote)" can be used by the endpoint to send frames
-                of any type. In this state, the endpoint continues to observe advertised <xref target="FlowControl">stream-level flow-control limits</xref>.
-            </t>
-            <t>
-                A stream can transition from this state to "closed" by sending a frame with the
-                END_STREAM flag set or when either peer sends a <xref target="RST_STREAM" format="none">RST_STREAM</xref> frame.
-            </t>
+                <xref target="RST_STREAM" format="none">RST_STREAM</xref>,  for a stream that is in this state, it <bcp14>MUST</bcp14> respond with a <xref target="StreamErrorHandler">stream error</xref> of type
+                <xref target="STREAM_CLOSED" format="none">STREAM_CLOSED</xref>.</t>
+            <t>A stream that is "half-closed (remote)" can be used by the endpoint to send frames
+                of any type. In this state, the endpoint continues to observe advertised <xref target="FlowControl">stream-level flow-control limits</xref>.</t>
+            <t>A stream can transition from this state to "closed" by sending a frame with the
+                END_STREAM flag set or when either peer sends a <xref target="RST_STREAM" format="none">RST_STREAM</xref> frame.</t>
           </dd>
           <dt>closed:</dt>
           <dd>
-            <t>
-              The "closed" state is the terminal state.
-            </t>
-            <t>
-              A stream enters the "closed" state after an endpoint both sends and receives a frame
+            <t>The "closed" state is the terminal state.</t>
+            <t>A stream enters the "closed" state after an endpoint both sends and receives a frame
               with an END_STREAM flag set. A stream also enters the "closed" state after an endpoint
               either sends or receives a <xref target="RST_STREAM" format="none">RST_STREAM</xref>
-              frame.
-            </t>
-            <t>
-              An endpoint MUST NOT send frames other than <xref target="PRIORITY" format="none">PRIORITY</xref> on a closed stream.  An endpoint MAY treat receipt of
-              any other type of frame on a closed stream as a <xref target="ConnectionErrorHandler">connection error</xref> of type <xref target="STREAM_CLOSED" format="none">STREAM_CLOSED</xref>, except as noted below.
-            </t>
-            <t>
-              An endpoint that sends a frame with the END_STREAM flag set or a <xref target="RST_STREAM" format="none">RST_STREAM</xref> frame might receive a <xref target="WINDOW_UPDATE" format="none">WINDOW_UPDATE</xref> or <xref target="RST_STREAM" format="none">RST_STREAM</xref> frame from its peer in the time before the peer
-              receives and processes the frame that closes the stream.
-            </t>
-            <t>
-              An endpoint that sends a <xref target="RST_STREAM" format="none">RST_STREAM</xref>
+              frame.</t>
+            <t>An endpoint <bcp14>MUST NOT</bcp14> send frames other than <xref target="PRIORITY" format="none">PRIORITY</xref> on a closed stream.  An endpoint <bcp14>MAY</bcp14> treat receipt of
+              any other type of frame on a closed stream as a <xref target="ConnectionErrorHandler">connection error</xref> of type <xref target="STREAM_CLOSED" format="none">STREAM_CLOSED</xref>, except as noted below.</t>
+            <t>An endpoint that sends a frame with the END_STREAM flag set or a <xref target="RST_STREAM" format="none">RST_STREAM</xref> frame might receive a <xref target="WINDOW_UPDATE" format="none">WINDOW_UPDATE</xref> or <xref target="RST_STREAM" format="none">RST_STREAM</xref> frame from its peer in the time before the peer
+              receives and processes the frame that closes the stream.</t>
+            <t>An endpoint that sends a <xref target="RST_STREAM" format="none">RST_STREAM</xref>
               frame on a stream that is in the "open"  or "half-closed (local)" state could receive any type of frame.  The
-              peer might have sent or enqueued for sending these frames before processing the <xref target="RST_STREAM" format="none">RST_STREAM</xref> frame. An endpoint MUST minimally
+              peer might have sent or enqueued for sending these frames before processing the <xref target="RST_STREAM" format="none">RST_STREAM</xref> frame. An endpoint <bcp14>MUST</bcp14> minimally
               process and then discard any frames it receives in this state.  This means updating
               header compression state for <xref target="HEADERS" format="none">HEADERS</xref> and
               <xref target="PUSH_PROMISE" format="none">PUSH_PROMISE</xref> frames.  Receiving a <xref target="PUSH_PROMISE" format="none">PUSH_PROMISE</xref> frame also causes the promised
               stream to become "reserved (remote)", even when the <xref target="PUSH_PROMISE" format="none">PUSH_PROMISE</xref> frame is received on a closed stream. Additionally, the
               content of <xref target="DATA" format="none">DATA</xref> frames counts toward the
-              connection flow-control window.
-            </t>
-            <t>
-              An endpoint can perform this minimal processing for all streams that are in the
-              "closed" state.  Endpoints MAY use other signals to detect that a peer has received
+              connection flow-control window.</t>
+            <t>An endpoint can perform this minimal processing for all streams that are in the
+              "closed" state.  Endpoints <bcp14>MAY</bcp14> use other signals to detect that a peer has received
               the frames that caused the stream to enter the "closed" state and treat receipt of any frame other
               than <xref target="PRIORITY" format="none">PRIORITY</xref> as a <xref target="ConnectionErrorHandler">connection error</xref> of type <xref target="PROTOCOL_ERROR" format="none">PROTOCOL_ERROR</xref>.  Endpoints can use frames
               that indicate that the peer has received the closing signal to drive this.  Endpoints
-              SHOULD NOT use timers for this purpose.  For example, an endpoint that sends a <xref target="SETTINGS" format="none">SETTINGS</xref> frame after closing a stream can
+              <bcp14>SHOULD NOT</bcp14> use timers for this purpose.  For example, an endpoint that sends a <xref target="SETTINGS" format="none">SETTINGS</xref> frame after closing a stream can
               safely treat receipt of a <xref target="DATA" format="none">DATA</xref> frame on that
               stream as an error after receiving an acknowledgment of the settings.  Other things
               that might be used are <xref target="PING" format="none">PING</xref> frames, receiving
               data on streams that were created after closing the stream, or responses to requests
-              created after closing the stream.
-            </t>
+              created after closing the stream.</t>
           </dd>
         </dl>
-        <t>
-          In the absence of more specific rules, implementations SHOULD treat the receipt of a frame
-          that is not expressly permitted in the description of a state as a <xref
-          target="ConnectionErrorHandler">connection error</xref> of type <xref
-          target="PROTOCOL_ERROR" format="none">PROTOCOL_ERROR</xref>.  Note that <xref
-          target="PRIORITY" format="none">PRIORITY</xref> can be sent and received in any stream
-          state.
-        </t>
-        <t>
-          The rules in this section only apply to frames defined in this document.  Receipt of
+        <t>In the absence of more specific rules, implementations <bcp14>SHOULD</bcp14> treat the receipt of a frame
+          that is not expressly permitted in the description of a state as a <xref target="ConnectionErrorHandler">connection error</xref> of type <xref target="PROTOCOL_ERROR" format="none">PROTOCOL_ERROR</xref>.  Note that <xref target="PRIORITY" format="none">PRIORITY</xref> can be sent and received in any stream
+          state.</t>
+        <t>The rules in this section only apply to frames defined in this document.  Receipt of
           frames for which the semantics are unknown cannot be treated as an error, as the conditions
-          for sending and receiving those frames are also unknown; see <xref
-          target="extensibility"/>.
-        </t>
-        <t>
-          An example of the state transitions for an HTTP request/response exchange can be found in
+          for sending and receiving those frames are also unknown; see <xref target="extensibility"/>.</t>
+        <t>An example of the state transitions for an HTTP request/response exchange can be found in
           <xref target="HttpExamples"/>.  An example of the state transitions for server push can be
-          found in Sections <xref target="PushRequests" format="counter"/> and <xref target="PushResponses" format="counter"/>.
-        </t>
+          found in Sections <xref target="PushRequests" format="counter"/> and <xref target="PushResponses" format="counter"/>.</t>
         <section anchor="StreamIdentifiers">
           <name>Stream Identifiers</name>
-          <t>
-            Streams are identified by an unsigned 31-bit integer.  Streams initiated by a client
-            MUST use odd-numbered stream identifiers; those initiated by the server MUST use
+          <t>Streams are identified by an unsigned 31-bit integer.  Streams initiated by a client
+            <bcp14>MUST</bcp14> use odd-numbered stream identifiers; those initiated by the server <bcp14>MUST</bcp14> use
             even-numbered stream identifiers.  A stream identifier of zero (0x00) is used for
             connection control messages; the stream identifier of zero cannot be used to establish a
-            new stream.
-          </t>
-          <t>
-            The identifier of a newly established stream MUST be numerically greater than all
+            new stream.</t>
+          <t>The identifier of a newly established stream <bcp14>MUST</bcp14> be numerically greater than all
             streams that the initiating endpoint has opened or reserved.  This governs streams that
             are opened using a <xref target="HEADERS" format="none">HEADERS</xref> frame and streams that are reserved using
             <xref target="PUSH_PROMISE" format="none">PUSH_PROMISE</xref>.  An endpoint that receives an unexpected stream identifier
-            MUST respond with a <xref target="ConnectionErrorHandler">connection error</xref> of
-            type <xref target="PROTOCOL_ERROR" format="none">PROTOCOL_ERROR</xref>.
-          </t>
-          <t>
-            A <xref target="HEADERS" format="none">HEADERS</xref> frame will transition the client-initiated stream identified
+            <bcp14>MUST</bcp14> respond with a <xref target="ConnectionErrorHandler">connection error</xref> of
+            type <xref target="PROTOCOL_ERROR" format="none">PROTOCOL_ERROR</xref>.</t>
+          <t>A <xref target="HEADERS" format="none">HEADERS</xref> frame will transition the client-initiated stream identified
             by the stream identifier in the frame header from "idle" to "open". A <xref target="PUSH_PROMISE" format="none">PUSH_PROMISE</xref>
             frame will transition the server-initiated stream identified by the Promised Stream ID field in the frame payload from "idle" to "reserved (local)" or "reserved (remote)". When
             a stream transitions out of the "idle" state, all streams in the "idle" state that might have been opened by the peer with a lower-valued
             stream identifier immediately transition to "closed". That is, an endpoint may skip a stream identifier, with the
-            effect being that the skipped stream is immediately closed.
-          </t>
-          <t>
-            Stream identifiers cannot be reused.  Long-lived connections can result in an endpoint
+            effect being that the skipped stream is immediately closed.</t>
+          <t>Stream identifiers cannot be reused.  Long-lived connections can result in an endpoint
             exhausting the available range of stream identifiers.  A client that is unable to
             establish a new stream identifier can establish a new connection for new streams.  A
             server that is unable to establish a new stream identifier can send a
             <xref target="GOAWAY" format="none">GOAWAY</xref> frame so that the client is forced to open a new connection for
-            new streams.
-          </t>
+            new streams.</t>
         </section>
         <section>
           <name>Stream Concurrency</name>
-          <t>
-            A peer can limit the number of concurrently active streams using the
+          <t>A peer can limit the number of concurrently active streams using the
             <xref target="SETTINGS_MAX_CONCURRENT_STREAMS" format="none">SETTINGS_MAX_CONCURRENT_STREAMS</xref> parameter (see <xref target="SettingValues"/>) within a <xref target="SETTINGS" format="none">SETTINGS</xref> frame. The maximum concurrent
             streams setting is specific to each endpoint and applies only to the peer that receives
             the setting. That is, clients specify the maximum number of concurrent streams the
             server can initiate, and servers specify the maximum number of concurrent streams the
-            client can initiate.
-          </t>
-          <t>
-            Streams that are in the "open" state or in either of the "half-closed" states count toward
+            client can initiate.</t>
+          <t>Streams that are in the "open" state or in either of the "half-closed" states count toward
             the maximum number of streams that an endpoint is permitted to open.  Streams in any of
             these three states count toward the limit advertised in the
             <xref target="SETTINGS_MAX_CONCURRENT_STREAMS" format="none">SETTINGS_MAX_CONCURRENT_STREAMS</xref> setting.  Streams in either of the
-            "reserved" states do not count toward the stream limit.
-          </t>
-          <t>
-            Endpoints MUST NOT exceed the limit set by their peer.  An endpoint that receives a
+            "reserved" states do not count toward the stream limit.</t>
+          <t>Endpoints <bcp14>MUST NOT</bcp14> exceed the limit set by their peer.  An endpoint that receives a
             <xref target="HEADERS" format="none">HEADERS</xref> frame that causes its advertised concurrent stream limit to be
-            exceeded MUST treat this as a <xref target="StreamErrorHandler">stream error</xref> of
+            exceeded <bcp14>MUST</bcp14> treat this as a <xref target="StreamErrorHandler">stream error</xref> of
             type <xref target="PROTOCOL_ERROR" format="none">PROTOCOL_ERROR</xref> or <xref target="REFUSED_STREAM" format="none">REFUSED_STREAM</xref>.  The choice of
-            error code determines whether the endpoint wishes to enable automatic retry (see <xref target="Reliability"/> for details).
-          </t>
-          <t>
-            An endpoint that wishes to reduce the value of
+            error code determines whether the endpoint wishes to enable automatic retry (see <xref target="Reliability"/> for details).</t>
+          <t>An endpoint that wishes to reduce the value of
             <xref target="SETTINGS_MAX_CONCURRENT_STREAMS" format="none">SETTINGS_MAX_CONCURRENT_STREAMS</xref> to a value that is below the current
             number of open streams can either close streams that exceed the new value or allow
-            streams to complete.
-          </t>
+            streams to complete.</t>
         </section>
       </section>
       <section anchor="FlowControl">
         <name>Flow Control</name>
-        <t>
-          Using streams for multiplexing introduces contention over use of the TCP connection,
+        <t>Using streams for multiplexing introduces contention over use of the TCP connection,
           resulting in blocked streams.  A flow-control scheme ensures that streams on the same
           connection do not destructively interfere with each other.  Flow control is used for both
-          individual streams and the connection as a whole.
-        </t>
-        <t>
-          HTTP/2 provides for flow control through use of the <xref target="WINDOW_UPDATE">WINDOW_UPDATE frame</xref>.
-        </t>
+          individual streams and the connection as a whole.</t>
+        <t>HTTP/2 provides for flow control through use of the <xref target="WINDOW_UPDATE">WINDOW_UPDATE frame</xref>.</t>
         <section anchor="fc-principles">
           <name>Flow-Control Principles</name>
-          <t>
-            HTTP/2 stream flow control aims to allow a variety of flow-control algorithms to be
+          <t>HTTP/2 stream flow control aims to allow a variety of flow-control algorithms to be
             used without requiring protocol changes. Flow control in HTTP/2 has the following
-            characteristics:
-          </t>
+            characteristics:</t>
           <ol spacing="normal" type="1">
-            <li>
-                Flow control is specific to a connection.  HTTP/2 flow control operates between
-                the endpoints of a single hop and not over the entire end-to-end path.
-              </li>
-            <li>
-                Flow control is based on <xref target="WINDOW_UPDATE" format="none">WINDOW_UPDATE</xref> frames.  Receivers advertise how many octets
+            <li>Flow control is specific to a connection.  HTTP/2 flow control operates between
+                the endpoints of a single hop and not over the entire end-to-end path.</li>
+            <li>Flow control is based on <xref target="WINDOW_UPDATE" format="none">WINDOW_UPDATE</xref> frames.  Receivers advertise how many octets
                 they are prepared to receive on a stream and for the entire connection.  This is a
-                credit-based scheme.
-              </li>
-            <li>
-                Flow control is directional with overall control provided by the receiver.  A
-                receiver MAY choose to set any window size that it desires for each stream and for
-                the entire connection.  A sender MUST respect flow-control limits imposed by a
+                credit-based scheme.</li>
+            <li>Flow control is directional with overall control provided by the receiver.  A
+                receiver <bcp14>MAY</bcp14> choose to set any window size that it desires for each stream and for
+                the entire connection.  A sender <bcp14>MUST</bcp14> respect flow-control limits imposed by a
                 receiver.  Clients, servers, and intermediaries all independently advertise their
                 flow-control window as a receiver and abide by the flow-control limits set by
-                their peer when sending.
-              </li>
-            <li>
-                The initial value for the flow-control window is 65,535 octets for both new streams
-                and the overall connection.
-              </li>
-            <li>
-                The frame type determines whether flow control applies to a frame.  Of the frames
+                their peer when sending.</li>
+            <li>The initial value for the flow-control window is 65,535 octets for both new streams
+                and the overall connection.</li>
+            <li>The frame type determines whether flow control applies to a frame.  Of the frames
                 specified in this document, only <xref target="DATA" format="none">DATA</xref> frames are subject to flow
                 control; all other frame types do not consume space in the advertised flow-control
-                window.  This ensures that important control frames are not blocked by flow control.
-              </li>
-            <li>
-              An endpoint can choose to disable its own flow control, but an endpoint cannot ignore
-              flow-control signals from its peer.
-            </li>
-            <li>
-                HTTP/2 defines only the format and semantics of the <xref target="WINDOW_UPDATE" format="none">WINDOW_UPDATE</xref>
+                window.  This ensures that important control frames are not blocked by flow control.</li>
+            <li>An endpoint can choose to disable its own flow control, but an endpoint cannot ignore
+              flow-control signals from its peer.</li>
+            <li>HTTP/2 defines only the format and semantics of the <xref target="WINDOW_UPDATE" format="none">WINDOW_UPDATE</xref>
                 frame (<xref target="WINDOW_UPDATE"/>).  This document does not stipulate how a
                 receiver decides when to send this frame or the value that it sends, nor does it
                 specify how a sender chooses to send packets.  Implementations are able to select
-                any algorithm that suits their needs.
-              </li>
+                any algorithm that suits their needs.</li>
           </ol>
-          <t>
-            Implementations are also responsible for prioritizing the sending of requests and
+          <t>Implementations are also responsible for prioritizing the sending of requests and
             responses, choosing how to avoid head-of-line blocking for requests, and managing the
             creation of new streams.  Algorithm choices for these could interact with any
-            flow-control algorithm.
-          </t>
+            flow-control algorithm.</t>
         </section>
         <section anchor="DisableFlowControl">
           <name>Appropriate Use of Flow Control</name>
-          <t>
-            Flow control is defined to protect endpoints that are operating under resource
+          <t>Flow control is defined to protect endpoints that are operating under resource
             constraints.  For example, a proxy needs to share memory between many connections and
             also might have a slow upstream connection and a fast downstream one.  Flow control
             addresses cases where the receiver is unable to process data on one stream yet wants to
-            continue to process other streams in the same connection.
-          </t>
-          <t>
-            Deployments that do not require this capability can advertise a flow-control window of
+            continue to process other streams in the same connection.</t>
+          <t>Deployments that do not require this capability can advertise a flow-control window of
             the maximum size (2<sup>31</sup>-1) and can maintain this window by sending a
             <xref target="WINDOW_UPDATE" format="none">WINDOW_UPDATE</xref> frame when any data is received.  This effectively disables
             flow control for that receiver.  Conversely, a sender is always subject to the
-            flow-control window advertised by the receiver.
-          </t>
-          <t>
-            Deployments with constrained resources (for example, memory) can employ flow control to
+            flow-control window advertised by the receiver.</t>
+          <t>Deployments with constrained resources (for example, memory) can employ flow control to
             limit the amount of memory a peer can consume.  Note, however, that this can lead to
             suboptimal use of available network resources if flow control is enabled without
-            knowledge of the bandwidth * delay product (see <xref target="RFC7323"/>).
-          </t>
-          <t>
-            Even with full awareness of the current bandwidth * delay product, implementation of
-            flow control can be difficult.  Endpoints MUST read and process HTTP/2 frames from the
+            knowledge of the bandwidth * delay product (see <xref target="RFC7323"/>).</t>
+          <t>Even with full awareness of the current bandwidth * delay product, implementation of
+            flow control can be difficult.  Endpoints <bcp14>MUST</bcp14> read and process HTTP/2 frames from the
             TCP receive buffer as soon as data is available.  Failure to read promptly could lead to
-            a deadlock when critical frames, such as <xref target="WINDOW_UPDATE"
-            format="none">WINDOW_UPDATE</xref>, are not read and acted upon. Reading frames promptly
+            a deadlock when critical frames, such as <xref target="WINDOW_UPDATE" format="none">WINDOW_UPDATE</xref>, are not read and acted upon. Reading frames promptly
             does not expose endpoints to resource exhaustion attacks, as HTTP/2 flow control limits
-            resource commitments.
-          </t>
+            resource commitments.</t>
         </section>
         <section anchor="FlowControlPerformance">
           <name>Flow-Control Performance</name>
-          <t>
-            If an endpoint cannot ensure that its peer always has available flow-control window
+          <t>If an endpoint cannot ensure that its peer always has available flow-control window
             space that is greater than the peer's bandwidth * delay product on this connection, its
             receive throughput will be limited by HTTP/2 flow control. This will result in degraded
-            performance.
-          </t>
-          <t>
-            Sending timely <xref target="WINDOW_UPDATE" format="none">WINDOW_UPDATE</xref> frames
+            performance.</t>
+          <t>Sending timely <xref target="WINDOW_UPDATE" format="none">WINDOW_UPDATE</xref> frames
             can improve performance. Endpoints will want to balance the need to improve receive
             throughput with the need to manage resource exhaustion risks and should take careful
-            note of <xref target="dos"/> in defining their strategy to manage window sizes.
-          </t>
+            note of <xref target="dos"/> in defining their strategy to manage window sizes.</t>
         </section>
       </section>
       <section anchor="StreamPriority">
         <name>Prioritization</name>
-        <t>
-          In a multiplexed protocol like HTTP/2, prioritizing allocation of bandwidth and
+        <t>In a multiplexed protocol like HTTP/2, prioritizing allocation of bandwidth and
           computation resources to streams can be critical to attaining good performance.  A poor
           prioritization scheme can result in HTTP/2 providing poor performance.  With no parallelism
-          at the TCP layer, performance could be significantly worse than HTTP/1.1.
-        </t>
-        <t>
-          A good prioritization scheme benefits from the application of contextual knowledge such as
+          at the TCP layer, performance could be significantly worse than HTTP/1.1.</t>
+        <t>A good prioritization scheme benefits from the application of contextual knowledge such as
           the content of resources, how resources are interrelated, and how those resources will be
           used by a peer.  In particular, clients can possess knowledge about the priority of
           requests that is relevant to server prioritization.  In those cases, having clients
-          provide priority information can improve performance.
-        </t>
+          provide priority information can improve performance.</t>
         <section anchor="PriorityHistory">
           <name>Background on Priority in RFC 7540</name>
-          <t>
-            RFC 7540 defined a rich system for signaling priority of requests.  However, this system
-            proved to be complex, and it was not uniformly implemented.
-          </t>
-          <t>
-            The flexible scheme meant that it was possible for clients to express priorities in very
+          <t>RFC 7540 defined a rich system for signaling priority of requests.  However, this system
+            proved to be complex, and it was not uniformly implemented.</t>
+          <t>The flexible scheme meant that it was possible for clients to express priorities in very
             different ways, with little consistency in the approaches that were adopted.  For
             servers, implementing generic support for the scheme was complex.  Implementation of
             priorities was uneven in both clients and servers.  Many server deployments ignored
-            client signals when prioritizing their handling of requests.
-          </t>
-          <t>
-            In short, the prioritization signaling in <xref target="RFC7540">RFC 7540</xref> was not
-            successful.
-          </t>
+            client signals when prioritizing their handling of requests.</t>
+          <t>In short, the prioritization signaling in <xref target="RFC7540">RFC 7540</xref> was not
+            successful.</t>
         </section>
         <section anchor="PriorityHere">
           <name>Priority Signaling in This Document</name>
-          <t>
-            This update to HTTP/2 deprecates the priority signaling defined in <xref target="RFC7540">RFC 7540</xref>.  The bulk of the text related to priority signals is
+          <t>This update to HTTP/2 deprecates the priority signaling defined in <xref target="RFC7540">RFC 7540</xref>.  The bulk of the text related to priority signals is
             not included in this document.  The description of frame fields and some of the
             mandatory handling is retained to ensure that implementations of this document remain
             interoperable with implementations that use the priority signaling described in RFC
-            7540.
-          </t>
-          <t>
-            A thorough description of the RFC 7540 priority scheme remains in <xref target="RFC7540" section="5.3"/>.
-          </t>
-          <t>
-            Signaling priority information is necessary to attain good performance in many cases.
+            7540.</t>
+          <t>A thorough description of the RFC 7540 priority scheme remains in <xref target="RFC7540" section="5.3"/>.</t>
+          <t>Signaling priority information is necessary to attain good performance in many cases.
             Where signaling priority information is important, endpoints are encouraged to use an
-            alternative scheme, such as the scheme described in <xref target="I-D.ietf-httpbis-priority"/>.
-          </t>
-          <t>
-            Though the priority signaling from RFC 7540 was not widely adopted, the information it
+            alternative scheme, such as the scheme described in <xref target="I-D.ietf-httpbis-priority"/>.</t>
+          <t>Though the priority signaling from RFC 7540 was not widely adopted, the information it
             provides can still be useful in the absence of better information.  Endpoints that
             receive priority signals in <xref target="HEADERS" format="none">HEADERS</xref> or <xref target="PRIORITY" format="none">PRIORITY</xref> frames can benefit from applying that
             information.  In particular, implementations that consume these signals would not
-            benefit from discarding these priority signals in the absence of alternatives.
-          </t>
-          <t>
-            Servers SHOULD use other contextual information in determining priority of requests in
-            the absence of any priority signals.  Servers MAY interpret the complete absence of
+            benefit from discarding these priority signals in the absence of alternatives.</t>
+          <t>Servers <bcp14>SHOULD</bcp14> use other contextual information in determining priority of requests in
+            the absence of any priority signals.  Servers <bcp14>MAY</bcp14> interpret the complete absence of
             signals as an indication that the client has not implemented the feature.  The defaults
             described in <xref target="RFC7540" section="5.3.5"/> are known to have poor performance
-            under most conditions, and their use is unlikely to be deliberate.
-          </t>
+            under most conditions, and their use is unlikely to be deliberate.</t>
         </section>
       </section>
       <section anchor="ErrorHandler">
         <name>Error Handling</name>
-        <t>
-          HTTP/2 framing permits two classes of errors:
-        </t>
+        <t>HTTP/2 framing permits two classes of errors:</t>
         <ul spacing="normal">
-          <li>
-              An error condition that renders the entire connection unusable is a connection error.
-            </li>
-          <li>
-              An error in an individual stream is a stream error.
-            </li>
+          <li>An error condition that renders the entire connection unusable is a connection error.</li>
+          <li>An error in an individual stream is a stream error.</li>
         </ul>
-        <t>
-          A list of error codes is included in <xref target="ErrorCodes"/>.
-        </t>
-        <t>
-          It is possible that an endpoint will encounter frames that would cause multiple errors. Implementations MAY discover
-          multiple errors during processing, but they SHOULD report at most one stream and one connection error as a result.
-        </t>
-        <t>
-          The first stream error reported for a given stream prevents any other errors on that stream from being reported.
+        <t>A list of error codes is included in <xref target="ErrorCodes"/>.</t>
+        <t>It is possible that an endpoint will encounter frames that would cause multiple errors. Implementations <bcp14>MAY</bcp14> discover
+          multiple errors during processing, but they <bcp14>SHOULD</bcp14> report at most one stream and one connection error as a result.</t>
+        <t>The first stream error reported for a given stream prevents any other errors on that stream from being reported.
           In comparison, the protocol permits multiple <xref target="GOAWAY" format="none">GOAWAY</xref> frames, though an
-          endpoint SHOULD report just one type of connection error unless an error is encountered during graceful shutdown.
-          If this occurs, an endpoint MAY send an additional GOAWAY frame with the new error code, in addition to any prior
-          GOAWAY that contained <xref target="NO_ERROR" format="none">NO_ERROR</xref>.
-        </t>
-        <t>
-          If an endpoint detects multiple different errors, it MAY choose to report any one of those
-          errors. If a frame causes a connection error, that error MUST be reported.  Additionally,
-          an endpoint MAY use any applicable error code when it detects an error condition; a
+          endpoint <bcp14>SHOULD</bcp14> report just one type of connection error unless an error is encountered during graceful shutdown.
+          If this occurs, an endpoint <bcp14>MAY</bcp14> send an additional GOAWAY frame with the new error code, in addition to any prior
+          GOAWAY that contained <xref target="NO_ERROR" format="none">NO_ERROR</xref>.</t>
+        <t>If an endpoint detects multiple different errors, it <bcp14>MAY</bcp14> choose to report any one of those
+          errors. If a frame causes a connection error, that error <bcp14>MUST</bcp14> be reported.  Additionally,
+          an endpoint <bcp14>MAY</bcp14> use any applicable error code when it detects an error condition; a
           generic error code (such as <xref target="PROTOCOL_ERROR" format="none">PROTOCOL_ERROR</xref> or <xref target="INTERNAL_ERROR" format="none">INTERNAL_ERROR</xref>) can always be used in place of more specific error
-          codes.
-        </t>
+          codes.</t>
         <section anchor="ConnectionErrorHandler">
           <name>Connection Error Handling</name>
-          <t>
-            A connection error is any error that prevents further processing of the frame
-            layer or corrupts any connection state.
-          </t>
-          <t>
-            An endpoint that encounters a connection error SHOULD first send a <xref target="GOAWAY" format="none">GOAWAY</xref>
+          <t>A connection error is any error that prevents further processing of the frame
+            layer or corrupts any connection state.</t>
+          <t>An endpoint that encounters a connection error <bcp14>SHOULD</bcp14> first send a <xref target="GOAWAY" format="none">GOAWAY</xref>
             frame (<xref target="GOAWAY"/>) with the stream identifier of the last stream that it
             successfully received from its peer.  The <xref target="GOAWAY" format="none">GOAWAY</xref> frame includes an <xref target="ErrorCodes">error
             code</xref> that indicates why the connection is terminating.  After sending the
-            <xref target="GOAWAY" format="none">GOAWAY</xref> frame for an error condition, the endpoint MUST close the TCP
-            connection.
-          </t>
-          <t>
-            It is possible that the <xref target="GOAWAY" format="none">GOAWAY</xref> will not be reliably received by the
+            <xref target="GOAWAY" format="none">GOAWAY</xref> frame for an error condition, the endpoint <bcp14>MUST</bcp14> close the TCP
+            connection.</t>
+          <t>It is possible that the <xref target="GOAWAY" format="none">GOAWAY</xref> will not be reliably received by the
             receiving endpoint.  In the event of a connection error,
             <xref target="GOAWAY" format="none">GOAWAY</xref> only provides a best-effort attempt to communicate with the peer
-            about why the connection is being terminated.
-          </t>
-          <t>
-            An endpoint can end a connection at any time.  In particular, an endpoint MAY choose to
-            treat a stream error as a connection error.  Endpoints SHOULD send a
+            about why the connection is being terminated.</t>
+          <t>An endpoint can end a connection at any time.  In particular, an endpoint <bcp14>MAY</bcp14> choose to
+            treat a stream error as a connection error.  Endpoints <bcp14>SHOULD</bcp14> send a
             <xref target="GOAWAY" format="none">GOAWAY</xref> frame when ending a connection, providing that circumstances
-            permit it.
-          </t>
+            permit it.</t>
         </section>
         <section anchor="StreamErrorHandler">
           <name>Stream Error Handling</name>
-          <t>
-            A stream error is an error related to a specific stream that does not affect processing
-            of other streams.
-          </t>
-          <t>
-            An endpoint that detects a stream error sends a <xref target="RST_STREAM" format="none">RST_STREAM</xref> frame (<xref target="RST_STREAM"/>) that contains the stream identifier of the stream where the error
+          <t>A stream error is an error related to a specific stream that does not affect processing
+            of other streams.</t>
+          <t>An endpoint that detects a stream error sends a <xref target="RST_STREAM" format="none">RST_STREAM</xref> frame (<xref target="RST_STREAM"/>) that contains the stream identifier of the stream where the error
             occurred.  The <xref target="RST_STREAM" format="none">RST_STREAM</xref> frame includes an error code that indicates the
-            type of error.
-          </t>
-          <t>
-            A <xref target="RST_STREAM" format="none">RST_STREAM</xref> is the last frame that an endpoint can send on a stream.
-            The peer that sends the <xref target="RST_STREAM" format="none">RST_STREAM</xref> frame MUST be prepared to receive any
+            type of error.</t>
+          <t>A <xref target="RST_STREAM" format="none">RST_STREAM</xref> is the last frame that an endpoint can send on a stream.
+            The peer that sends the <xref target="RST_STREAM" format="none">RST_STREAM</xref> frame <bcp14>MUST</bcp14> be prepared to receive any
             frames that were sent or enqueued for sending by the remote peer.  These frames can be
             ignored, except where they modify connection state (such as the state maintained for
-            <xref target="FieldBlock">field section compression</xref> or flow control).
-          </t>
-          <t>
-            Normally, an endpoint SHOULD NOT send more than one <xref target="RST_STREAM" format="none">RST_STREAM</xref> frame for
-            any stream. However, an endpoint MAY send additional <xref target="RST_STREAM" format="none">RST_STREAM</xref> frames if
+            <xref target="FieldBlock">field section compression</xref> or flow control).</t>
+          <t>Normally, an endpoint <bcp14>SHOULD NOT</bcp14> send more than one <xref target="RST_STREAM" format="none">RST_STREAM</xref> frame for
+            any stream. However, an endpoint <bcp14>MAY</bcp14> send additional <xref target="RST_STREAM" format="none">RST_STREAM</xref> frames if
             it receives frames on a closed stream after more than a round-trip time.  This behavior
-            is permitted to deal with misbehaving implementations.
-          </t>
-          <t>
-            To avoid looping, an endpoint MUST NOT send a <xref target="RST_STREAM" format="none">RST_STREAM</xref> in response to a
-            <xref target="RST_STREAM" format="none">RST_STREAM</xref> frame.
-          </t>
+            is permitted to deal with misbehaving implementations.</t>
+          <t>To avoid looping, an endpoint <bcp14>MUST NOT</bcp14> send a <xref target="RST_STREAM" format="none">RST_STREAM</xref> in response to a
+            <xref target="RST_STREAM" format="none">RST_STREAM</xref> frame.</t>
         </section>
         <section>
           <name>Connection Termination</name>
-          <t>
-            If the TCP connection is closed or reset while streams remain in the "open" or "half-closed"
-            states, then the affected streams cannot be automatically retried (see <xref target="Reliability"/> for details).
-          </t>
+          <t>If the TCP connection is closed or reset while streams remain in the "open" or "half-closed"
+            states, then the affected streams cannot be automatically retried (see <xref target="Reliability"/> for details).</t>
         </section>
       </section>
       <section anchor="extensibility">
         <name>Extending HTTP/2</name>
-        <t>
-          HTTP/2 permits extension of the protocol.  Within the limitations described in this
+        <t>HTTP/2 permits extension of the protocol.  Within the limitations described in this
           section, protocol extensions can be used to provide additional services or alter
           any aspect of the protocol. Extensions are effective only within the scope of a single HTTP/2
-          connection.
-        </t>
-        <t>
-          This applies to the protocol elements defined in this document.  This does not affect the
+          connection.</t>
+        <t>This applies to the protocol elements defined in this document.  This does not affect the
           existing options for extending HTTP, such as defining new methods, status codes, or fields
-          (see <xref target="HTTP" section="16"/>).
-        </t>
-        <t>
-          Extensions are permitted to use new <xref target="FrameHeader">frame types</xref>, new
+          (see <xref target="HTTP" section="16"/>).</t>
+        <t>Extensions are permitted to use new <xref target="FrameHeader">frame types</xref>, new
           <xref target="SETTINGS">settings</xref>, or new <xref target="ErrorCodes">error
-          codes</xref>.  Registries for managing these extension points are defined in <xref
-          section="11" target="RFC7540"/>.
-        </t>
-        <t>
-          Implementations MUST ignore unknown or unsupported values in all extensible protocol
-          elements.  Implementations MUST discard frames that have unknown or unsupported types.
+          codes</xref>.  Registries for managing these extension points are defined in <xref section="11" target="RFC7540"/>.</t>
+        <t>Implementations <bcp14>MUST</bcp14> ignore unknown or unsupported values in all extensible protocol
+          elements.  Implementations <bcp14>MUST</bcp14> discard frames that have unknown or unsupported types.
           This means that any of these extension points can be safely used by extensions without
           prior arrangement or negotiation.  However, extension frames that appear in the middle of
-          a <xref target="FieldBlock">field block</xref> are not permitted; these MUST be treated
+          a <xref target="FieldBlock">field block</xref> are not permitted; these <bcp14>MUST</bcp14> be treated
           as a <xref target="ConnectionErrorHandler">connection error</xref> of type
-          <xref target="PROTOCOL_ERROR" format="none">PROTOCOL_ERROR</xref>.
-        </t>
-        <t>
-          Extensions SHOULD avoid changing protocol elements defined in this document or
+          <xref target="PROTOCOL_ERROR" format="none">PROTOCOL_ERROR</xref>.</t>
+        <t>Extensions <bcp14>SHOULD</bcp14> avoid changing protocol elements defined in this document or
           elements for which no extension mechanism is defined.  This includes changes to the
           layout of frames, additions or changes to the way that frames are composed into <xref target="HttpFraming">HTTP messages</xref>, the definition of pseudo-header fields, or
-          changes to any protocol element that a compliant endpoint might treat as a <xref target="ConnectionErrorHandler">connection error</xref>.
-        </t>
-        <t>
-          An extension that changes existing protocol elements or state MUST be negotiated before
-          being used.  For example, an extension that changes the layout of the <xref
-          target="HEADERS" format="none">HEADERS</xref> frame cannot be used until the peer has
+          changes to any protocol element that a compliant endpoint might treat as a <xref target="ConnectionErrorHandler">connection error</xref>.</t>
+        <t>An extension that changes existing protocol elements or state <bcp14>MUST</bcp14> be negotiated before
+          being used.  For example, an extension that changes the layout of the <xref target="HEADERS" format="none">HEADERS</xref> frame cannot be used until the peer has
           given a positive signal that this is acceptable.  In this case, it could also be necessary
           to coordinate when the revised layout comes into effect.  For example, treating frames
           other than <xref target="DATA" format="none">DATA</xref> frames as flow controlled
           requires a change in semantics that both endpoints need to understand, so this can only be
-          done through negotiation.
-        </t>
-        <t>
-          This document doesn't mandate a specific method for negotiating the use of an extension
+          done through negotiation.</t>
+        <t>This document doesn't mandate a specific method for negotiating the use of an extension
           but notes that a <xref target="SettingValues">setting</xref> could be used for that
           purpose.  If both peers set a value that indicates willingness to use the extension, then
           the extension can be used.  If a setting is used for extension negotiation, the initial
-          value MUST be defined in such a fashion that the extension is initially disabled.
-        </t>
+          value <bcp14>MUST</bcp14> be defined in such a fashion that the extension is initially disabled.</t>
       </section>
     </section>
     <section anchor="FrameTypes">
       <name>Frame Definitions</name>
-      <t>
-        This specification defines a number of frame types, each identified by a unique 8-bit type
+      <t>This specification defines a number of frame types, each identified by a unique 8-bit type
         code. Each frame type serves a distinct purpose in the establishment and management of either
-        the connection as a whole or individual streams.
-      </t>
-      <t>
-        The transmission of specific frame types can alter the state of a connection. If endpoints
+        the connection as a whole or individual streams.</t>
+      <t>The transmission of specific frame types can alter the state of a connection. If endpoints
         fail to maintain a synchronized view of the connection state, successful communication
         within the connection will no longer be possible. Therefore, it is important that endpoints
-        have a shared comprehension of how the state is affected by the use of any given frame.
-      </t>
+        have a shared comprehension of how the state is affected by the use of any given frame.</t>
       <section anchor="DATA">
         <name>DATA</name>
-        <t>
-          DATA frames (type=0x00) convey arbitrary, variable-length sequences of octets associated
+        <t>DATA frames (type=0x00) convey arbitrary, variable-length sequences of octets associated
           with a stream. One or more DATA frames are used, for instance, to carry HTTP request or
-          response message contents.
-        </t>
-        <t>
-          DATA frames MAY also contain padding.  Padding can be added to DATA frames to obscure the
-          size of messages.  Padding is a security feature; see <xref target="padding"/>.
-        </t>
+          response message contents.</t>
+        <t>DATA frames <bcp14>MAY</bcp14> also contain padding.  Padding can be added to DATA frames to obscure the
+          size of messages.  Padding is a security feature; see <xref target="padding"/>.</t>
         <figure anchor="DATAFrameFormat">
           <name>DATA Frame Format</name>
           <artwork type="inline"><![CDATA[
@@ -1513,87 +1067,61 @@ DATA Frame {
 }
 ]]></artwork>
         </figure>
-        <t>
-          The Length, Type, Unused Flag(s), Reserved, and Stream Identifier fields are described in <xref target="FramingLayer"/>.
-          The DATA frame contains the following additional fields:
-        </t>
+        <t>The Length, Type, Unused Flag(s), Reserved, and Stream Identifier fields are described in <xref target="FramingLayer"/>.
+          The DATA frame contains the following additional fields:</t>
         <dl newline="false" spacing="normal">
           <dt>Pad Length:</dt>
-          <dd>
-              An 8-bit field containing the length of the frame padding in units of octets.  This
-              field is conditional and is only present if the PADDED flag is set.
-
-            </dd>
+          <dd>An 8-bit field containing the length of the frame padding in units of octets.  This
+              field is conditional and is only present if the PADDED flag is set.</dd>
           <dt>Data:</dt>
-          <dd>
-              Application data.  The amount of data is the remainder of the frame payload after
-              subtracting the length of the other fields that are present.
-            </dd>
+          <dd>Application data.  The amount of data is the remainder of the frame payload after
+              subtracting the length of the other fields that are present.</dd>
           <dt>Padding:</dt>
-          <dd>
-              Padding octets that contain no application semantic value.  Padding octets MUST be set
-              to zero when sending.  A receiver is not obligated to verify padding but MAY treat
+          <dd>Padding octets that contain no application semantic value.  Padding octets <bcp14>MUST</bcp14> be set
+              to zero when sending.  A receiver is not obligated to verify padding but <bcp14>MAY</bcp14> treat
               non-zero padding as a <xref target="ConnectionErrorHandler">connection error</xref> of
-              type <xref target="PROTOCOL_ERROR" format="none">PROTOCOL_ERROR</xref>.
-            </dd>
+              type <xref target="PROTOCOL_ERROR" format="none">PROTOCOL_ERROR</xref>.</dd>
         </dl>
-        <t>
-          The DATA frame defines the following flags:
-        </t>
+        <t>The DATA frame defines the following flags:</t>
         <dl newline="false" spacing="normal">
           <dt>PADDED (0x08):</dt>
-          <dd>
-              When set, the PADDED flag indicates that the Pad Length field and any padding that it describes
-              are present.
-            </dd>
+          <dd>When set, the PADDED flag indicates that the Pad Length field and any padding that it describes
+              are present.</dd>
           <dt>END_STREAM (0x01):</dt>
-          <dd>
-              When set, the END_STREAM flag indicates that this frame is the last that the endpoint will send for
-              the identified stream.  Setting this flag causes the stream to enter one of <xref target="StreamStates">the "half-closed" states or the "closed" state</xref>.
-            </dd>
+          <dd>When set, the END_STREAM flag indicates that this frame is the last that the endpoint will send for
+              the identified stream.  Setting this flag causes the stream to enter one of <xref target="StreamStates">the "half-closed" states or the "closed" state</xref>.</dd>
         </dl>
         <aside>
-          <t>
-            Note: An endpoint that learns of stream closure after sending all data can close a
+          <t>Note: An endpoint that learns of stream closure after sending all data can close a
             stream by sending a STREAM frame with a zero-length Data field and the END_STREAM flag
             set. This is only possible if the endpoint does not send trailers, as the END_STREAM
-            flag appears on a HEADERS frame in that case; see <xref target="HttpFraming"/>.
-          </t>
+            flag appears on a HEADERS frame in that case; see <xref target="HttpFraming"/>.</t>
         </aside>
-        <t>
-          DATA frames MUST be associated with a stream. If a DATA frame is received whose Stream
-          Identifier field is 0x00, the recipient MUST respond with a <xref target="ConnectionErrorHandler">connection error</xref> of type
-          <xref target="PROTOCOL_ERROR" format="none">PROTOCOL_ERROR</xref>.
-        </t>
-        <t>
-          DATA frames are subject to flow control and can only be sent when a stream is in the
+        <t>DATA frames <bcp14>MUST</bcp14> be associated with a stream. If a DATA frame is received whose Stream
+          Identifier field is 0x00, the recipient <bcp14>MUST</bcp14> respond with a <xref target="ConnectionErrorHandler">connection error</xref> of type
+          <xref target="PROTOCOL_ERROR" format="none">PROTOCOL_ERROR</xref>.</t>
+        <t>DATA frames are subject to flow control and can only be sent when a stream is in the
           "open" or "half-closed (remote)" state. The entire DATA frame payload is included in flow
           control, including the Pad Length and Padding fields if present.  If a DATA frame is received
-          whose stream is not in the "open" or "half-closed (local)" state, the recipient MUST respond
+          whose stream is not in the "open" or "half-closed (local)" state, the recipient <bcp14>MUST</bcp14> respond
           with a <xref target="StreamErrorHandler">stream error</xref> of type
-          <xref target="STREAM_CLOSED" format="none">STREAM_CLOSED</xref>.
-        </t>
-        <t>
-          The total number of padding octets is determined by the value of the Pad Length field. If
+          <xref target="STREAM_CLOSED" format="none">STREAM_CLOSED</xref>.</t>
+        <t>The total number of padding octets is determined by the value of the Pad Length field. If
           the length of the padding is the length of the frame payload or greater, the recipient
-          MUST treat this as a <xref target="ConnectionErrorHandler">connection error</xref> of
-          type <xref target="PROTOCOL_ERROR" format="none">PROTOCOL_ERROR</xref>.
-        </t>
+          <bcp14>MUST</bcp14> treat this as a <xref target="ConnectionErrorHandler">connection error</xref> of
+          type <xref target="PROTOCOL_ERROR" format="none">PROTOCOL_ERROR</xref>.</t>
         <aside>
           <t>Note:
             A frame can be increased in size by one octet by including a Pad Length field with a
-            value of zero.
-          </t>
+            value of zero.</t>
         </aside>
       </section>
       <section anchor="HEADERS">
         <name>HEADERS</name>
-        <t>
-          The HEADERS frame (type=0x01) is used to <xref target="StreamStates">open a stream</xref>,
+        <t>The HEADERS frame (type=0x01) is used to <xref target="StreamStates">open a stream</xref>,
           and additionally carries a field block fragment. Despite the name, a HEADERS frame can carry
           a header section or a trailer section. HEADERS frames can be sent on a stream
-          in the "idle", "reserved (local)", "open", or "half-closed (remote)" state.
-        </t>
+          in the "idle", "reserved (local)", "open", or "half-closed (remote)" state.</t>
         <figure anchor="HEADERSFrameFormat">
           <name>HEADERS Frame Format</name>
           <artwork type="inline"><![CDATA[
@@ -1621,118 +1149,79 @@ HEADERS Frame {
 }
 ]]></artwork>
         </figure>
-        <t>
-          The Length, Type, Unused Flag(s), Reserved, and Stream Identifier fields are described in <xref target="FramingLayer"/>.
-          The HEADERS frame payload has the following additional fields:
-        </t>
+        <t>The Length, Type, Unused Flag(s), Reserved, and Stream Identifier fields are described in <xref target="FramingLayer"/>.
+          The HEADERS frame payload has the following additional fields:</t>
         <dl newline="false" spacing="normal">
           <dt>Pad Length:</dt>
-          <dd>
-            An 8-bit field containing the length of the frame padding in units of octets.  This
-            field is only present if the PADDED flag is set.
-          </dd>
+          <dd>An 8-bit field containing the length of the frame padding in units of octets.  This
+            field is only present if the PADDED flag is set.</dd>
           <dt>Exclusive:</dt>
-          <dd>
-            A single-bit flag.  This field is only present if the PRIORITY flag is set.  Priority
-            signals in HEADERS frames are deprecated; see <xref target="PriorityHere"/>.
-          </dd>
+          <dd>A single-bit flag.  This field is only present if the PRIORITY flag is set.  Priority
+            signals in HEADERS frames are deprecated; see <xref target="PriorityHere"/>.</dd>
           <dt>Stream Dependency:</dt>
-          <dd>
-            A 31-bit stream identifier.  This field is only present if the PRIORITY flag is set.
-          </dd>
+          <dd>A 31-bit stream identifier.  This field is only present if the PRIORITY flag is set.</dd>
           <dt>Weight:</dt>
-          <dd>
-            An unsigned 8-bit integer.  This field is only present if the PRIORITY flag is set.
-          </dd>
+          <dd>An unsigned 8-bit integer.  This field is only present if the PRIORITY flag is set.</dd>
           <dt>Field Block Fragment:</dt>
-          <dd>
-              A <xref target="FieldBlock">field block fragment</xref>.
-            </dd>
+          <dd>A <xref target="FieldBlock">field block fragment</xref>.</dd>
           <dt>Padding:</dt>
-          <dd>
-              Padding octets that contain no application semantic value.  Padding octets MUST be set
-              to zero when sending.  A receiver is not obligated to verify padding but MAY treat
+          <dd>Padding octets that contain no application semantic value.  Padding octets <bcp14>MUST</bcp14> be set
+              to zero when sending.  A receiver is not obligated to verify padding but <bcp14>MAY</bcp14> treat
               non-zero padding as a <xref target="ConnectionErrorHandler">connection error</xref> of
-              type <xref target="PROTOCOL_ERROR" format="none">PROTOCOL_ERROR</xref>.
-            </dd>
+              type <xref target="PROTOCOL_ERROR" format="none">PROTOCOL_ERROR</xref>.</dd>
         </dl>
-        <t>
-          The HEADERS frame defines the following flags:
-        </t>
+        <t>The HEADERS frame defines the following flags:</t>
         <dl newline="false" spacing="normal">
           <dt>PRIORITY (0x20):</dt>
           <dd>
-            <t>
-              When set, the PRIORITY flag indicates that the Exclusive, Stream Dependency, and Weight
-              fields are present.
-            </t>
+            <t>When set, the PRIORITY flag indicates that the Exclusive, Stream Dependency, and Weight
+              fields are present.</t>
           </dd>
           <dt>PADDED (0x08):</dt>
           <dd>
-            <t>
-                When set, the PADDED flag indicates that the Pad Length field and any padding that it
-                describes are present.
-            </t>
+            <t>When set, the PADDED flag indicates that the Pad Length field and any padding that it
+                describes are present.</t>
           </dd>
           <dt>END_HEADERS (0x04):</dt>
           <dd>
-            <t>
-                When set, the END_HEADERS flag indicates that this frame contains an entire <xref target="FieldBlock">field block</xref> and is not followed by any
-                <xref target="CONTINUATION" format="none">CONTINUATION</xref> frames.
-            </t>
-            <t>
-                A HEADERS frame without the END_HEADERS flag set MUST be followed by a
-                <xref target="CONTINUATION" format="none">CONTINUATION</xref> frame for the same stream.  A receiver MUST treat the
+            <t>When set, the END_HEADERS flag indicates that this frame contains an entire <xref target="FieldBlock">field block</xref> and is not followed by any
+                <xref target="CONTINUATION" format="none">CONTINUATION</xref> frames.</t>
+            <t>A HEADERS frame without the END_HEADERS flag set <bcp14>MUST</bcp14> be followed by a
+                <xref target="CONTINUATION" format="none">CONTINUATION</xref> frame for the same stream.  A receiver <bcp14>MUST</bcp14> treat the
                 receipt of any other type of frame or a frame on a different stream as a <xref target="ConnectionErrorHandler">connection error</xref> of type
-                <xref target="PROTOCOL_ERROR" format="none">PROTOCOL_ERROR</xref>.
-            </t>
+                <xref target="PROTOCOL_ERROR" format="none">PROTOCOL_ERROR</xref>.</t>
           </dd>
           <dt>END_STREAM (0x01):</dt>
           <dd>
-            <t>
-                When set, the END_STREAM flag indicates that the <xref target="FieldBlock">field block</xref> is
-                the last that the endpoint will send for the identified stream.
-            </t>
-            <t>
-                A HEADERS frame with the END_STREAM flag set signals the end of a stream.
+            <t>When set, the END_STREAM flag indicates that the <xref target="FieldBlock">field block</xref> is
+                the last that the endpoint will send for the identified stream.</t>
+            <t>A HEADERS frame with the END_STREAM flag set signals the end of a stream.
                 However, a HEADERS frame with the END_STREAM flag set can be followed by
                 <xref target="CONTINUATION" format="none">CONTINUATION</xref> frames on the same stream.  Logically, the
-                <xref target="CONTINUATION" format="none">CONTINUATION</xref> frames are part of the HEADERS frame.
-            </t>
+                <xref target="CONTINUATION" format="none">CONTINUATION</xref> frames are part of the HEADERS frame.</t>
           </dd>
         </dl>
-        <t>
-          The frame payload of a HEADERS frame contains a <xref target="FieldBlock">field block
+        <t>The frame payload of a HEADERS frame contains a <xref target="FieldBlock">field block
           fragment</xref>.  A field block that does not fit within a HEADERS frame is continued in
-          a <xref target="CONTINUATION">CONTINUATION frame</xref>.
-        </t>
-        <t>
-          HEADERS frames MUST be associated with a stream. If a HEADERS frame is received whose
-          Stream Identifier field is 0x00, the recipient MUST respond with a <xref target="ConnectionErrorHandler">connection error</xref> of type
-          <xref target="PROTOCOL_ERROR" format="none">PROTOCOL_ERROR</xref>.
-        </t>
-        <t>
-          The HEADERS frame changes the connection state as described in <xref target="FieldBlock"/>.
-        </t>
-        <t>
-          The total number of padding octets is determined by the value of the Pad Length field.  If
+          a <xref target="CONTINUATION">CONTINUATION frame</xref>.</t>
+        <t>HEADERS frames <bcp14>MUST</bcp14> be associated with a stream. If a HEADERS frame is received whose
+          Stream Identifier field is 0x00, the recipient <bcp14>MUST</bcp14> respond with a <xref target="ConnectionErrorHandler">connection error</xref> of type
+          <xref target="PROTOCOL_ERROR" format="none">PROTOCOL_ERROR</xref>.</t>
+        <t>The HEADERS frame changes the connection state as described in <xref target="FieldBlock"/>.</t>
+        <t>The total number of padding octets is determined by the value of the Pad Length field.  If
           the length of the padding is the length of the frame payload or greater, the recipient
-          MUST treat this as a <xref target="ConnectionErrorHandler">connection error</xref> of
-          type <xref target="PROTOCOL_ERROR" format="none">PROTOCOL_ERROR</xref>.
-        </t>
+          <bcp14>MUST</bcp14> treat this as a <xref target="ConnectionErrorHandler">connection error</xref> of
+          type <xref target="PROTOCOL_ERROR" format="none">PROTOCOL_ERROR</xref>.</t>
         <aside>
           <t>Note:
             A frame can be increased in size by one octet by including a Pad Length field with a
-            value of zero.
-          </t>
+            value of zero.</t>
         </aside>
       </section>
       <section anchor="PRIORITY">
         <name>PRIORITY</name>
-        <t>
-          The PRIORITY frame (type=0x02) is deprecated; see <xref target="PriorityHere"/>.  A
-          PRIORITY frame can be sent in any stream state, including idle or closed streams.
-        </t>
+        <t>The PRIORITY frame (type=0x02) is deprecated; see <xref target="PriorityHere"/>.  A
+          PRIORITY frame can be sent in any stream state, including idle or closed streams.</t>
         <figure anchor="PRIORITYFrameFormat">
           <name>PRIORITY Frame Format</name>
           <artwork type="inline"><![CDATA[
@@ -1751,47 +1240,29 @@ PRIORITY Frame {
 }
 ]]></artwork>
         </figure>
-        <t>
-          The Length, Type, Unused Flag(s), Reserved, and Stream Identifier fields are described in <xref target="FramingLayer"/>.
-          The frame payload of a PRIORITY frame contains the following additional fields:
-        </t>
+        <t>The Length, Type, Unused Flag(s), Reserved, and Stream Identifier fields are described in <xref target="FramingLayer"/>.
+          The frame payload of a PRIORITY frame contains the following additional fields:</t>
         <dl newline="false" spacing="normal">
           <dt>Exclusive:</dt>
-          <dd>
-            A single-bit flag.
-          </dd>
+          <dd>A single-bit flag.</dd>
           <dt>Stream Dependency:</dt>
-          <dd>
-            A 31-bit stream identifier.
-          </dd>
+          <dd>A 31-bit stream identifier.</dd>
           <dt>Weight:</dt>
-          <dd>
-            An unsigned 8-bit integer.
-          </dd>
+          <dd>An unsigned 8-bit integer.</dd>
         </dl>
-        <t>
-          The PRIORITY frame does not define any flags.
-        </t>
-        <t>
-          The PRIORITY frame always identifies a stream.  If a PRIORITY frame is received with a
-          stream identifier of 0x00, the recipient MUST respond with a <xref target="ConnectionErrorHandler">connection error</xref> of type <xref target="PROTOCOL_ERROR" format="none">PROTOCOL_ERROR</xref>.
-        </t>
-        <t>
-          Sending or receiving a PRIORITY frame does not affect the state of any stream (<xref target="StreamStates"/>).  The PRIORITY frame can be sent on a stream in any state,
+        <t>The PRIORITY frame does not define any flags.</t>
+        <t>The PRIORITY frame always identifies a stream.  If a PRIORITY frame is received with a
+          stream identifier of 0x00, the recipient <bcp14>MUST</bcp14> respond with a <xref target="ConnectionErrorHandler">connection error</xref> of type <xref target="PROTOCOL_ERROR" format="none">PROTOCOL_ERROR</xref>.</t>
+        <t>Sending or receiving a PRIORITY frame does not affect the state of any stream (<xref target="StreamStates"/>).  The PRIORITY frame can be sent on a stream in any state,
           including "idle" or "closed".  A PRIORITY frame cannot be sent between consecutive frames
-          that comprise a single <xref target="FieldBlock">field block</xref>.
-        </t>
-        <t>
-          A PRIORITY frame with a length other than 5 octets MUST be treated as a <xref target="StreamErrorHandler">stream error</xref> of type <xref target="FRAME_SIZE_ERROR" format="none">FRAME_SIZE_ERROR</xref>.
-        </t>
+          that comprise a single <xref target="FieldBlock">field block</xref>.</t>
+        <t>A PRIORITY frame with a length other than 5 octets <bcp14>MUST</bcp14> be treated as a <xref target="StreamErrorHandler">stream error</xref> of type <xref target="FRAME_SIZE_ERROR" format="none">FRAME_SIZE_ERROR</xref>.</t>
       </section>
       <section anchor="RST_STREAM">
         <name>RST_STREAM</name>
-        <t>
-          The RST_STREAM frame (type=0x03) allows for immediate termination of a stream.  RST_STREAM
+        <t>The RST_STREAM frame (type=0x03) allows for immediate termination of a stream.  RST_STREAM
           is sent to request cancellation of a stream or to indicate that an error condition has
-          occurred.
-        </t>
+          occurred.</t>
         <figure anchor="RST_STREAMFrameFormat">
           <name>RST_STREAM Frame Format</name>
           <artwork type="inline"><![CDATA[
@@ -1808,99 +1279,67 @@ RST_STREAM Frame {
 }
 ]]></artwork>
         </figure>
-        <t>
-          The Length, Type, Unused Flag(s), Reserved, and Stream Identifier fields are described in <xref target="FramingLayer"/>.
+        <t>The Length, Type, Unused Flag(s), Reserved, and Stream Identifier fields are described in <xref target="FramingLayer"/>.
           Additionally, the RST_STREAM frame contains a single unsigned, 32-bit integer identifying the <xref target="ErrorCodes">error code</xref>.  The error code indicates why the stream is being
-          terminated.
-        </t>
-        <t>
-          The RST_STREAM frame does not define any flags.
-        </t>
-        <t>
-          The RST_STREAM frame fully terminates the referenced stream and causes it to enter the
-          "closed" state. After receiving a RST_STREAM on a stream, the receiver MUST NOT send
+          terminated.</t>
+        <t>The RST_STREAM frame does not define any flags.</t>
+        <t>The RST_STREAM frame fully terminates the referenced stream and causes it to enter the
+          "closed" state. After receiving a RST_STREAM on a stream, the receiver <bcp14>MUST NOT</bcp14> send
           additional frames for that stream, except for <xref target="PRIORITY" format="none">PRIORITY</xref>. However,
-          after sending the RST_STREAM, the sending endpoint MUST be prepared to receive and process
+          after sending the RST_STREAM, the sending endpoint <bcp14>MUST</bcp14> be prepared to receive and process
           additional frames sent on the stream that might have been sent by the peer prior to the
-          arrival of the RST_STREAM.
-        </t>
-        <t>
-          RST_STREAM frames MUST be associated with a stream.  If a RST_STREAM frame is received
-          with a stream identifier of 0x00, the recipient MUST treat this as a <xref target="ConnectionErrorHandler">connection error</xref> of type
-          <xref target="PROTOCOL_ERROR" format="none">PROTOCOL_ERROR</xref>.
-        </t>
-        <t>
-          RST_STREAM frames MUST NOT be sent for a stream in the "idle" state.  If a RST_STREAM
-          frame identifying an idle stream is received, the recipient MUST treat this as a <xref target="ConnectionErrorHandler">connection error</xref> of type
-          <xref target="PROTOCOL_ERROR" format="none">PROTOCOL_ERROR</xref>.
-        </t>
-        <t>
-          A RST_STREAM frame with a length other than 4 octets MUST be treated as a <xref target="ConnectionErrorHandler">connection error</xref> of type
-          <xref target="FRAME_SIZE_ERROR" format="none">FRAME_SIZE_ERROR</xref>.
-        </t>
+          arrival of the RST_STREAM.</t>
+        <t>RST_STREAM frames <bcp14>MUST</bcp14> be associated with a stream.  If a RST_STREAM frame is received
+          with a stream identifier of 0x00, the recipient <bcp14>MUST</bcp14> treat this as a <xref target="ConnectionErrorHandler">connection error</xref> of type
+          <xref target="PROTOCOL_ERROR" format="none">PROTOCOL_ERROR</xref>.</t>
+        <t>RST_STREAM frames <bcp14>MUST NOT</bcp14> be sent for a stream in the "idle" state.  If a RST_STREAM
+          frame identifying an idle stream is received, the recipient <bcp14>MUST</bcp14> treat this as a <xref target="ConnectionErrorHandler">connection error</xref> of type
+          <xref target="PROTOCOL_ERROR" format="none">PROTOCOL_ERROR</xref>.</t>
+        <t>A RST_STREAM frame with a length other than 4 octets <bcp14>MUST</bcp14> be treated as a <xref target="ConnectionErrorHandler">connection error</xref> of type
+          <xref target="FRAME_SIZE_ERROR" format="none">FRAME_SIZE_ERROR</xref>.</t>
       </section>
       <section anchor="SETTINGS">
         <name>SETTINGS</name>
-        <t>
-          The SETTINGS frame (type=0x04) conveys configuration parameters that affect how endpoints
+        <t>The SETTINGS frame (type=0x04) conveys configuration parameters that affect how endpoints
           communicate, such as preferences and constraints on peer behavior.  The SETTINGS frame is
           also used to acknowledge the receipt of those settings.  Individually, a configuration
-          parameter from a SETTINGS frame is referred to as a "setting".
-        </t>
-        <t>
-          Settings are not negotiated; they describe characteristics of the sending peer,
+          parameter from a SETTINGS frame is referred to as a "setting".</t>
+        <t>Settings are not negotiated; they describe characteristics of the sending peer,
           which are used by the receiving peer. Different values for the same setting can be
           advertised by each peer. For example, a client might set a high initial flow-control
-          window, whereas a server might set a lower value to conserve resources.
-        </t>
-        <t>
-          A SETTINGS frame MUST be sent by both endpoints at the start of a connection and MAY be
+          window, whereas a server might set a lower value to conserve resources.</t>
+        <t>A SETTINGS frame <bcp14>MUST</bcp14> be sent by both endpoints at the start of a connection and <bcp14>MAY</bcp14> be
           sent at any other time by either endpoint over the lifetime of the connection.
-          Implementations MUST support all of the settings defined by this specification.
-        </t>
-        <t>
-          Each parameter in a SETTINGS frame replaces any existing value for that parameter.
+          Implementations <bcp14>MUST</bcp14> support all of the settings defined by this specification.</t>
+        <t>Each parameter in a SETTINGS frame replaces any existing value for that parameter.
           Settings are processed in the order in which they appear, and a receiver of a SETTINGS
           frame does not need to maintain any state other than the current value of each setting.
           Therefore, the value of a SETTINGS parameter is the last value that is seen by
-          a receiver.
-        </t>
-        <t>
-          SETTINGS frames are acknowledged by the receiving peer. To enable this, the SETTINGS
-          frame defines the ACK flag:
-        </t>
+          a receiver.</t>
+        <t>SETTINGS frames are acknowledged by the receiving peer. To enable this, the SETTINGS
+          frame defines the ACK flag:</t>
         <dl newline="false" spacing="normal">
           <dt>ACK (0x01):</dt>
-          <dd>
-              When set, the ACK flag indicates that this frame acknowledges receipt and application of the
-              peer's SETTINGS frame.  When this bit is set, the frame payload of the SETTINGS frame MUST
+          <dd>When set, the ACK flag indicates that this frame acknowledges receipt and application of the
+              peer's SETTINGS frame.  When this bit is set, the frame payload of the SETTINGS frame <bcp14>MUST</bcp14>
               be empty.  Receipt of a SETTINGS frame with the ACK flag set and a length field value
-              other than 0 MUST be treated as a <xref target="ConnectionErrorHandler">connection
-              error</xref> of type <xref target="FRAME_SIZE_ERROR" format="none">FRAME_SIZE_ERROR</xref>.  For more information, see <xref target="SettingsSync"/> ("<xref target="SettingsSync" format="title"/>").
-            </dd>
+              other than 0 <bcp14>MUST</bcp14> be treated as a <xref target="ConnectionErrorHandler">connection
+              error</xref> of type <xref target="FRAME_SIZE_ERROR" format="none">FRAME_SIZE_ERROR</xref>.  For more information, see <xref target="SettingsSync"/> ("<xref target="SettingsSync" format="title"/>").</dd>
         </dl>
-        <t>
-          SETTINGS frames always apply to a connection, never a single stream.  The stream
-          identifier for a SETTINGS frame MUST be zero (0x00). If an endpoint receives a SETTINGS
-          frame whose Stream Identifier field is anything other than 0x00, the endpoint MUST respond
+        <t>SETTINGS frames always apply to a connection, never a single stream.  The stream
+          identifier for a SETTINGS frame <bcp14>MUST</bcp14> be zero (0x00). If an endpoint receives a SETTINGS
+          frame whose Stream Identifier field is anything other than 0x00, the endpoint <bcp14>MUST</bcp14> respond
           with a <xref target="ConnectionErrorHandler">connection error</xref> of type
-          <xref target="PROTOCOL_ERROR" format="none">PROTOCOL_ERROR</xref>.
-        </t>
-        <t>
-          The SETTINGS frame affects connection state.  A badly formed or incomplete SETTINGS frame
-          MUST be treated as a <xref target="ConnectionErrorHandler">connection error</xref> of type
-          <xref target="PROTOCOL_ERROR" format="none">PROTOCOL_ERROR</xref>.
-        </t>
-        <t>
-          A SETTINGS frame with a length other than a multiple of 6 octets MUST be treated as a <xref target="ConnectionErrorHandler">connection error</xref> of type
-          <xref target="FRAME_SIZE_ERROR" format="none">FRAME_SIZE_ERROR</xref>.
-        </t>
+          <xref target="PROTOCOL_ERROR" format="none">PROTOCOL_ERROR</xref>.</t>
+        <t>The SETTINGS frame affects connection state.  A badly formed or incomplete SETTINGS frame
+          <bcp14>MUST</bcp14> be treated as a <xref target="ConnectionErrorHandler">connection error</xref> of type
+          <xref target="PROTOCOL_ERROR" format="none">PROTOCOL_ERROR</xref>.</t>
+        <t>A SETTINGS frame with a length other than a multiple of 6 octets <bcp14>MUST</bcp14> be treated as a <xref target="ConnectionErrorHandler">connection error</xref> of type
+          <xref target="FRAME_SIZE_ERROR" format="none">FRAME_SIZE_ERROR</xref>.</t>
         <section anchor="SettingFormat">
           <name>SETTINGS Format</name>
-          <t>
-            The frame payload of a SETTINGS frame consists of zero or more settings, each consisting of
-            an unsigned 16-bit setting identifier and an unsigned 32-bit value.
-          </t>
+          <t>The frame payload of a SETTINGS frame consists of zero or more settings, each consisting of
+            an unsigned 16-bit setting identifier and an unsigned 32-bit value.</t>
           <figure anchor="SettingFrameFormat">
             <name>SETTINGS Frame Format</name>
             <artwork type="inline"><![CDATA[
@@ -1923,164 +1362,116 @@ Setting {
 }
 ]]></artwork>
           </figure>
-          <t>
-            The Length, Type, Unused Flag(s), Reserved, and Stream Identifier fields are described
+          <t>The Length, Type, Unused Flag(s), Reserved, and Stream Identifier fields are described
             in <xref target="FramingLayer"/>.  The frame payload of a SETTINGS frame contains any
-            number of Setting fields, each of which consists of:
-          </t>
+            number of Setting fields, each of which consists of:</t>
           <dl newline="false" spacing="normal">
             <dt>Identifier:</dt>
-            <dd>
-              A 16-bit setting identifier; see <xref target="SettingValues"/>.
-            </dd>
+            <dd>A 16-bit setting identifier; see <xref target="SettingValues"/>.</dd>
             <dt>Value:</dt>
-            <dd>
-              A 32-bit value for the setting.
-            </dd>
+            <dd>A 32-bit value for the setting.</dd>
           </dl>
         </section>
         <section anchor="SettingValues">
           <name>Defined Settings</name>
-          <t>
-            The following settings are defined:
-          </t>
+          <t>The following settings are defined:</t>
           <dl newline="false" spacing="normal">
             <dt anchor="SETTINGS_HEADER_TABLE_SIZE">SETTINGS_HEADER_TABLE_SIZE (0x01):</dt>
             <dd>
-              <t>
-                  This setting allows the sender to inform the remote endpoint of the maximum size of the
+              <t>This setting allows the sender to inform the remote endpoint of the maximum size of the
                   compression table used to decode field blocks, in units of octets. The encoder can select
                   any size equal to or less than this value by using signaling specific to the
-                  compression format inside a field block (see <xref target="COMPRESSION"/>). The initial value is 4,096 octets.
-              </t>
+                  compression format inside a field block (see <xref target="COMPRESSION"/>). The initial value is 4,096 octets.</t>
             </dd>
             <dt anchor="SETTINGS_ENABLE_PUSH">SETTINGS_ENABLE_PUSH (0x02):</dt>
             <dd>
-              <t>
-                This setting can be used to enable or disable server push.  A server MUST NOT send a
+              <t>This setting can be used to enable or disable server push.  A server <bcp14>MUST NOT</bcp14> send a
                 <xref target="PUSH_PROMISE" format="none">PUSH_PROMISE</xref> frame if it receives
                 this parameter set to a value of 0; see <xref target="PushResources"/>. A client
-                that has both set this parameter to 0 and had it acknowledged MUST treat the receipt
-                of a <xref target="PUSH_PROMISE" format="none">PUSH_PROMISE</xref> frame as a <xref
-                target="ConnectionErrorHandler">connection error</xref> of type <xref
-                target="PROTOCOL_ERROR" format="none">PROTOCOL_ERROR</xref>.
-              </t>
-              <t>
-                The initial value of SETTINGS_ENABLE_PUSH is 1.  For a client, this value indicates that it
+                that has both set this parameter to 0 and had it acknowledged <bcp14>MUST</bcp14> treat the receipt
+                of a <xref target="PUSH_PROMISE" format="none">PUSH_PROMISE</xref> frame as a <xref target="ConnectionErrorHandler">connection error</xref> of type <xref target="PROTOCOL_ERROR" format="none">PROTOCOL_ERROR</xref>.</t>
+              <t>The initial value of SETTINGS_ENABLE_PUSH is 1.  For a client, this value indicates that it
                 is willing to receive PUSH_PROMISE frames.  For a server, this initial value has no effect, and
-                is equivalent to the value 0.  Any value other than 0 or 1 MUST be treated as a
+                is equivalent to the value 0.  Any value other than 0 or 1 <bcp14>MUST</bcp14> be treated as a
                 <xref target="ConnectionErrorHandler">connection error</xref> of type
-                <xref target="PROTOCOL_ERROR" format="none">PROTOCOL_ERROR</xref>.
-              </t>
-              <t>
-                A server MUST NOT explicitly set this value to 1.  A server MAY choose to omit this
-                setting when it sends a SETTINGS frame, but if a server does include a value, it MUST
-                be 0.  A client MUST treat receipt of a SETTINGS frame with SETTINGS_ENABLE_PUSH set
+                <xref target="PROTOCOL_ERROR" format="none">PROTOCOL_ERROR</xref>.</t>
+              <t>A server <bcp14>MUST NOT</bcp14> explicitly set this value to 1.  A server <bcp14>MAY</bcp14> choose to omit this
+                setting when it sends a SETTINGS frame, but if a server does include a value, it <bcp14>MUST</bcp14>
+                be 0.  A client <bcp14>MUST</bcp14> treat receipt of a SETTINGS frame with SETTINGS_ENABLE_PUSH set
                 to 1 as a <xref target="ConnectionErrorHandler">connection error</xref> of type
-                <xref target="PROTOCOL_ERROR" format="none">PROTOCOL_ERROR</xref>.
-              </t>
+                <xref target="PROTOCOL_ERROR" format="none">PROTOCOL_ERROR</xref>.</t>
             </dd>
             <dt anchor="SETTINGS_MAX_CONCURRENT_STREAMS">SETTINGS_MAX_CONCURRENT_STREAMS (0x03):</dt>
             <dd>
-              <t>
-                  This setting indicates the maximum number of concurrent streams that the sender will allow.
+              <t>This setting indicates the maximum number of concurrent streams that the sender will allow.
                   This limit is directional: it applies to the number of streams that the sender
                   permits the receiver to create. Initially, there is no limit to this value.  It is
                   recommended that this value be no smaller than 100, so as to not unnecessarily
-                  limit parallelism.
-              </t>
-              <t>
-                  A value of 0 for SETTINGS_MAX_CONCURRENT_STREAMS SHOULD NOT be treated as special
+                  limit parallelism.</t>
+              <t>A value of 0 for SETTINGS_MAX_CONCURRENT_STREAMS <bcp14>SHOULD NOT</bcp14> be treated as special
                   by endpoints.  A zero value does prevent the creation of new streams; however, this
                   can also happen for any limit that is exhausted with active streams.  Servers
-                  SHOULD only set a zero value for short durations; if a server does not wish to
-                  accept requests, closing the connection is more appropriate.
-              </t>
+                  <bcp14>SHOULD</bcp14> only set a zero value for short durations; if a server does not wish to
+                  accept requests, closing the connection is more appropriate.</t>
             </dd>
             <dt anchor="SETTINGS_INITIAL_WINDOW_SIZE">SETTINGS_INITIAL_WINDOW_SIZE (0x04):</dt>
             <dd>
-              <t>
-                  This setting indicates the sender's initial window size (in units of octets) for stream-level flow
-                  control.  The initial value is 2<sup>16</sup>-1 (65,535) octets.
-              </t>
-              <t>
-                  This setting affects the window size of all streams (see <xref target="InitialWindowSize"/>).
-              </t>
-              <t>
-                  Values above the maximum flow-control window size of 2<sup>31</sup>-1 MUST
+              <t>This setting indicates the sender's initial window size (in units of octets) for stream-level flow
+                  control.  The initial value is 2<sup>16</sup>-1 (65,535) octets.</t>
+              <t>This setting affects the window size of all streams (see <xref target="InitialWindowSize"/>).</t>
+              <t>Values above the maximum flow-control window size of 2<sup>31</sup>-1 <bcp14>MUST</bcp14>
                   be treated as a <xref target="ConnectionErrorHandler">connection error</xref> of
-                  type <xref target="FLOW_CONTROL_ERROR" format="none">FLOW_CONTROL_ERROR</xref>.
-              </t>
+                  type <xref target="FLOW_CONTROL_ERROR" format="none">FLOW_CONTROL_ERROR</xref>.</t>
             </dd>
             <dt anchor="SETTINGS_MAX_FRAME_SIZE">SETTINGS_MAX_FRAME_SIZE (0x05):</dt>
             <dd>
-              <t>
-                  This setting indicates the size of the largest frame payload that the sender is willing to
-                  receive, in units of octets.
-              </t>
-              <t>
-                  The initial value is 2<sup>14</sup> (16,384) octets.  The value advertised by
-                  an endpoint MUST be between this initial value and the maximum allowed frame size
+              <t>This setting indicates the size of the largest frame payload that the sender is willing to
+                  receive, in units of octets.</t>
+              <t>The initial value is 2<sup>14</sup> (16,384) octets.  The value advertised by
+                  an endpoint <bcp14>MUST</bcp14> be between this initial value and the maximum allowed frame size
                   (2<sup>24</sup>-1 or 16,777,215 octets), inclusive.  Values outside this range
-                  MUST be treated as a <xref target="ConnectionErrorHandler">connection error</xref>
-                  of type <xref target="PROTOCOL_ERROR" format="none">PROTOCOL_ERROR</xref>.
-              </t>
+                  <bcp14>MUST</bcp14> be treated as a <xref target="ConnectionErrorHandler">connection error</xref>
+                  of type <xref target="PROTOCOL_ERROR" format="none">PROTOCOL_ERROR</xref>.</t>
             </dd>
             <dt anchor="SETTINGS_MAX_HEADER_LIST_SIZE">SETTINGS_MAX_HEADER_LIST_SIZE (0x06):</dt>
             <dd>
-              <t>
-                  This advisory setting informs a peer of the maximum field section size that the
+              <t>This advisory setting informs a peer of the maximum field section size that the
                   sender is prepared to accept, in units of octets. The value is based on the uncompressed
                   size of field lines, including the length of the name and value in units of octets plus
-                  an overhead of 32 octets for each field line.
-              </t>
-              <t>
-                  For any given request, a lower limit than what is advertised MAY be enforced.  The
-                  initial value of this setting is unlimited.
-              </t>
+                  an overhead of 32 octets for each field line.</t>
+              <t>For any given request, a lower limit than what is advertised <bcp14>MAY</bcp14> be enforced.  The
+                  initial value of this setting is unlimited.</t>
             </dd>
           </dl>
-          <t>
-            An endpoint that receives a SETTINGS frame with any unknown or unsupported identifier
-            MUST ignore that setting.
-          </t>
+          <t>An endpoint that receives a SETTINGS frame with any unknown or unsupported identifier
+            <bcp14>MUST</bcp14> ignore that setting.</t>
         </section>
         <section anchor="SettingsSync">
           <name>Settings Synchronization</name>
-          <t>
-            Most values in SETTINGS benefit from or require an understanding of when the peer has
+          <t>Most values in SETTINGS benefit from or require an understanding of when the peer has
             received and applied the changed parameter values. In order to provide such
             synchronization timepoints, the recipient of a SETTINGS frame in which the ACK flag is
-            not set MUST apply the updated settings as soon as possible upon receipt.  SETTINGS
-            frames are acknowledged in the order in which they are received.
-          </t>
-          <t>
-            The values in the SETTINGS frame MUST be processed in the order they appear, with no
-            other frame processing between values.  Unsupported settings MUST be ignored.  Once
-            all values have been processed, the recipient MUST immediately emit a SETTINGS frame
+            not set <bcp14>MUST</bcp14> apply the updated settings as soon as possible upon receipt.  SETTINGS
+            frames are acknowledged in the order in which they are received.</t>
+          <t>The values in the SETTINGS frame <bcp14>MUST</bcp14> be processed in the order they appear, with no
+            other frame processing between values.  Unsupported settings <bcp14>MUST</bcp14> be ignored.  Once
+            all values have been processed, the recipient <bcp14>MUST</bcp14> immediately emit a SETTINGS frame
             with the ACK flag set. Upon receiving a SETTINGS frame with the ACK flag set, the sender
             of the altered settings can rely on the values from the oldest unacknowledged SETTINGS frame
-            having been applied.
-          </t>
-          <t>
-            If the sender of a SETTINGS frame does not receive an acknowledgment within a
-            reasonable amount of time, it MAY issue a <xref
-            target="ConnectionErrorHandler">connection error</xref> of type <xref
-            target="SETTINGS_TIMEOUT" format="none">SETTINGS_TIMEOUT</xref>. In setting a timeout,
+            having been applied.</t>
+          <t>If the sender of a SETTINGS frame does not receive an acknowledgment within a
+            reasonable amount of time, it <bcp14>MAY</bcp14> issue a <xref target="ConnectionErrorHandler">connection error</xref> of type <xref target="SETTINGS_TIMEOUT" format="none">SETTINGS_TIMEOUT</xref>. In setting a timeout,
             some allowance needs to be made for processing delays at the peer; a timeout that is
-            solely based on the round-trip time between endpoints might result in spurious errors.
-          </t>
+            solely based on the round-trip time between endpoints might result in spurious errors.</t>
         </section>
       </section>
       <section anchor="PUSH_PROMISE">
         <name>PUSH_PROMISE</name>
-        <t>
-          The PUSH_PROMISE frame (type=0x05) is used to notify the peer endpoint in advance of
+        <t>The PUSH_PROMISE frame (type=0x05) is used to notify the peer endpoint in advance of
           streams the sender intends to initiate.  The PUSH_PROMISE frame includes the unsigned
           31-bit identifier of the stream the endpoint plans to create along with a field section
           that provides additional context for the stream.  <xref target="PushResources"/> contains a
-          thorough description of the use of PUSH_PROMISE frames.
-        </t>
+          thorough description of the use of PUSH_PROMISE frames.</t>
         <figure anchor="PUSH_PROMISEFrameFormat">
           <name>PUSH_PROMISE Frame Format</name>
           <artwork type="inline"><![CDATA[
@@ -2104,123 +1495,87 @@ PUSH_PROMISE Frame {
 }
 ]]></artwork>
         </figure>
-        <t>
-          The Length, Type, Unused Flag(s), Reserved, and Stream Identifier fields are described in <xref target="FramingLayer"/>.
-          The PUSH_PROMISE frame payload has the following additional fields:
-        </t>
+        <t>The Length, Type, Unused Flag(s), Reserved, and Stream Identifier fields are described in <xref target="FramingLayer"/>.
+          The PUSH_PROMISE frame payload has the following additional fields:</t>
         <dl newline="false" spacing="normal">
           <dt>Pad Length:</dt>
-          <dd>
-              An 8-bit field containing the length of the frame padding in units of octets.  This
-              field is only present if the PADDED flag is set.
-            </dd>
+          <dd>An 8-bit field containing the length of the frame padding in units of octets.  This
+              field is only present if the PADDED flag is set.</dd>
           <dt>Promised Stream ID:</dt>
-          <dd>
-              An unsigned 31-bit integer that identifies the stream that is reserved by the
-              PUSH_PROMISE.  The promised stream identifier MUST be a valid choice for the next
-              stream sent by the sender (see "new stream identifier" in <xref target="StreamIdentifiers"/>).
-            </dd>
+          <dd>An unsigned 31-bit integer that identifies the stream that is reserved by the
+              PUSH_PROMISE.  The promised stream identifier <bcp14>MUST</bcp14> be a valid choice for the next
+              stream sent by the sender (see "new stream identifier" in <xref target="StreamIdentifiers"/>).</dd>
           <dt>Field Block Fragment:</dt>
-          <dd>
-            A <xref target="FieldBlock">field block fragment</xref> containing the request control
-            data and a header section.
-          </dd>
+          <dd>A <xref target="FieldBlock">field block fragment</xref> containing the request control
+            data and a header section.</dd>
           <dt>Padding:</dt>
-          <dd>
-              Padding octets that contain no application semantic value.  Padding octets MUST be set
-              to zero when sending.  A receiver is not obligated to verify padding but MAY treat
+          <dd>Padding octets that contain no application semantic value.  Padding octets <bcp14>MUST</bcp14> be set
+              to zero when sending.  A receiver is not obligated to verify padding but <bcp14>MAY</bcp14> treat
               non-zero padding as a <xref target="ConnectionErrorHandler">connection error</xref> of
-              type <xref target="PROTOCOL_ERROR" format="none">PROTOCOL_ERROR</xref>.
-            </dd>
+              type <xref target="PROTOCOL_ERROR" format="none">PROTOCOL_ERROR</xref>.</dd>
         </dl>
-        <t>
-          The PUSH_PROMISE frame defines the following flags:
-        </t>
+        <t>The PUSH_PROMISE frame defines the following flags:</t>
         <dl newline="false" spacing="normal">
           <dt>PADDED (0x08):</dt>
           <dd>
-            <t>
-                When set, the PADDED flag indicates that the Pad Length field and any padding that it
-                describes are present.
-            </t>
+            <t>When set, the PADDED flag indicates that the Pad Length field and any padding that it
+                describes are present.</t>
           </dd>
           <dt>END_HEADERS (0x04):</dt>
           <dd>
-            <t>
-                When set, the END_HEADERS flag indicates that this frame contains an entire <xref target="FieldBlock">field block</xref> and is not followed by any
-                <xref target="CONTINUATION" format="none">CONTINUATION</xref> frames.
-            </t>
-            <t>
-                A PUSH_PROMISE frame without the END_HEADERS flag set MUST be followed by a
-                CONTINUATION frame for the same stream.  A receiver MUST treat the receipt of any
+            <t>When set, the END_HEADERS flag indicates that this frame contains an entire <xref target="FieldBlock">field block</xref> and is not followed by any
+                <xref target="CONTINUATION" format="none">CONTINUATION</xref> frames.</t>
+            <t>A PUSH_PROMISE frame without the END_HEADERS flag set <bcp14>MUST</bcp14> be followed by a
+                CONTINUATION frame for the same stream.  A receiver <bcp14>MUST</bcp14> treat the receipt of any
                 other type of frame or a frame on a different stream as a <xref target="ConnectionErrorHandler">connection error</xref> of type
-                <xref target="PROTOCOL_ERROR" format="none">PROTOCOL_ERROR</xref>.
-            </t>
+                <xref target="PROTOCOL_ERROR" format="none">PROTOCOL_ERROR</xref>.</t>
           </dd>
         </dl>
-        <t>
-          PUSH_PROMISE frames MUST only be sent on a peer-initiated stream that is in either the
+        <t>PUSH_PROMISE frames <bcp14>MUST</bcp14> only be sent on a peer-initiated stream that is in either the
           "open" or "half-closed (remote)" state. The stream identifier of a PUSH_PROMISE frame
           indicates the stream it is associated with.  If the Stream Identifier field specifies the
-          value 0x00, a recipient MUST respond with a <xref target="ConnectionErrorHandler">connection error</xref> of type
-          <xref target="PROTOCOL_ERROR" format="none">PROTOCOL_ERROR</xref>.
-        </t>
-        <t>
-          Promised streams are not required to be used in the order they are promised.  The
-          PUSH_PROMISE only reserves stream identifiers for later use.
-        </t>
-        <t>
-          PUSH_PROMISE MUST NOT be sent if the <xref target="SETTINGS_ENABLE_PUSH" format="none">SETTINGS_ENABLE_PUSH</xref> setting of the
+          value 0x00, a recipient <bcp14>MUST</bcp14> respond with a <xref target="ConnectionErrorHandler">connection error</xref> of type
+          <xref target="PROTOCOL_ERROR" format="none">PROTOCOL_ERROR</xref>.</t>
+        <t>Promised streams are not required to be used in the order they are promised.  The
+          PUSH_PROMISE only reserves stream identifiers for later use.</t>
+        <t>PUSH_PROMISE <bcp14>MUST NOT</bcp14> be sent if the <xref target="SETTINGS_ENABLE_PUSH" format="none">SETTINGS_ENABLE_PUSH</xref> setting of the
           peer endpoint is set to 0.  An endpoint that has set this setting and has received
-          acknowledgment MUST treat the receipt of a PUSH_PROMISE frame as a <xref target="ConnectionErrorHandler">connection error</xref> of type
-          <xref target="PROTOCOL_ERROR" format="none">PROTOCOL_ERROR</xref>.
-        </t>
-        <t>
-          Recipients of PUSH_PROMISE frames can choose to reject promised streams by returning a
+          acknowledgment <bcp14>MUST</bcp14> treat the receipt of a PUSH_PROMISE frame as a <xref target="ConnectionErrorHandler">connection error</xref> of type
+          <xref target="PROTOCOL_ERROR" format="none">PROTOCOL_ERROR</xref>.</t>
+        <t>Recipients of PUSH_PROMISE frames can choose to reject promised streams by returning a
           <xref target="RST_STREAM" format="none">RST_STREAM</xref> referencing the promised stream identifier back to the sender of
-          the PUSH_PROMISE.
-        </t>
-        <t>
-          A PUSH_PROMISE frame modifies the connection state in two ways.  First, the inclusion of a <xref target="FieldBlock">field block</xref> potentially modifies the state maintained for
+          the PUSH_PROMISE.</t>
+        <t>A PUSH_PROMISE frame modifies the connection state in two ways.  First, the inclusion of a <xref target="FieldBlock">field block</xref> potentially modifies the state maintained for
           field section compression.  Second, PUSH_PROMISE also reserves a stream for later use, causing the
-          promised stream to enter the "reserved (local)" or "reserved (remote)" state.  A sender MUST NOT send a PUSH_PROMISE on a
-          stream unless that stream is either "open" or "half-closed (remote)"; the sender MUST
-          ensure that the promised stream is a valid choice for a <xref target="StreamIdentifiers">new stream identifier</xref> (that is, the promised stream MUST
-          be in the "idle" state).
-        </t>
-        <t>
-          Since PUSH_PROMISE reserves a stream, ignoring a PUSH_PROMISE frame causes the stream
-          state to become indeterminate.  A receiver MUST treat the receipt of a PUSH_PROMISE on a
+          promised stream to enter the "reserved (local)" or "reserved (remote)" state.  A sender <bcp14>MUST NOT</bcp14> send a PUSH_PROMISE on a
+          stream unless that stream is either "open" or "half-closed (remote)"; the sender <bcp14>MUST</bcp14>
+          ensure that the promised stream is a valid choice for a <xref target="StreamIdentifiers">new stream identifier</xref> (that is, the promised stream <bcp14>MUST</bcp14>
+          be in the "idle" state).</t>
+        <t>Since PUSH_PROMISE reserves a stream, ignoring a PUSH_PROMISE frame causes the stream
+          state to become indeterminate.  A receiver <bcp14>MUST</bcp14> treat the receipt of a PUSH_PROMISE on a
           stream that is neither "open" nor "half-closed (local)" as a <xref target="ConnectionErrorHandler">connection error</xref> of type
           <xref target="PROTOCOL_ERROR" format="none">PROTOCOL_ERROR</xref>.  However, an endpoint that has sent
-          <xref target="RST_STREAM" format="none">RST_STREAM</xref> on the associated stream MUST handle PUSH_PROMISE frames that
+          <xref target="RST_STREAM" format="none">RST_STREAM</xref> on the associated stream <bcp14>MUST</bcp14> handle PUSH_PROMISE frames that
           might have been created before the <xref target="RST_STREAM" format="none">RST_STREAM</xref> frame is received and
-          processed.
-        </t>
-        <t>
-          A receiver MUST treat the receipt of a PUSH_PROMISE that promises an <xref target="StreamIdentifiers">illegal stream identifier</xref> as a <xref target="ConnectionErrorHandler">connection error</xref> of type
+          processed.</t>
+        <t>A receiver <bcp14>MUST</bcp14> treat the receipt of a PUSH_PROMISE that promises an <xref target="StreamIdentifiers">illegal stream identifier</xref> as a <xref target="ConnectionErrorHandler">connection error</xref> of type
           <xref target="PROTOCOL_ERROR" format="none">PROTOCOL_ERROR</xref>. Note that an illegal stream identifier
-          is an identifier for a stream that is not currently in the "idle" state.
-        </t>
-        <t>
-          The total number of padding octets is determined by the value of the Pad Length field.  If
+          is an identifier for a stream that is not currently in the "idle" state.</t>
+        <t>The total number of padding octets is determined by the value of the Pad Length field.  If
           the length of the padding is the length of the frame payload or greater, the recipient
-          MUST treat this as a <xref target="ConnectionErrorHandler">connection error</xref> of
-          type <xref target="PROTOCOL_ERROR" format="none">PROTOCOL_ERROR</xref>.
-        </t>
+          <bcp14>MUST</bcp14> treat this as a <xref target="ConnectionErrorHandler">connection error</xref> of
+          type <xref target="PROTOCOL_ERROR" format="none">PROTOCOL_ERROR</xref>.</t>
         <aside>
           <t>Note:
             A frame can be increased in size by one octet by including a Pad Length field with a
-            value of zero.
-          </t>
-        </aside>      </section>
+            value of zero.</t>
+        </aside>
+      </section>
       <section anchor="PING">
         <name>PING</name>
-        <t>
-          The PING frame (type=0x06) is a mechanism for measuring a minimal round-trip time from the
+        <t>The PING frame (type=0x06) is a mechanism for measuring a minimal round-trip time from the
           sender, as well as determining whether an idle connection is still functional.  PING
-          frames can be sent from any endpoint.
-        </t>
+          frames can be sent from any endpoint.</t>
         <figure anchor="PINGFrameFormat">
           <name>PING Frame Format</name>
           <artwork type="inline"><![CDATA[
@@ -2238,84 +1593,56 @@ PING Frame {
 }
 ]]></artwork>
         </figure>
-        <t>
-          The Length, Type, Unused Flag(s), Reserved, and Stream Identifier fields are described in <xref target="FramingLayer"/>.
-        </t>
-        <t>
-          In addition to the frame header, PING frames MUST contain 8 octets of opaque data in the frame payload.
-          A sender can include any value it chooses and use those octets in any fashion.
-        </t>
-        <t>
-          Receivers of a PING frame that does not include an ACK flag MUST send a PING frame with
-          the ACK flag set in response, with an identical frame payload.  PING responses SHOULD be given
-          higher priority than any other frame.
-        </t>
-        <t>
-          The PING frame defines the following flags:
-        </t>
+        <t>The Length, Type, Unused Flag(s), Reserved, and Stream Identifier fields are described in <xref target="FramingLayer"/>.</t>
+        <t>In addition to the frame header, PING frames <bcp14>MUST</bcp14> contain 8 octets of opaque data in the frame payload.
+          A sender can include any value it chooses and use those octets in any fashion.</t>
+        <t>Receivers of a PING frame that does not include an ACK flag <bcp14>MUST</bcp14> send a PING frame with
+          the ACK flag set in response, with an identical frame payload.  PING responses <bcp14>SHOULD</bcp14> be given
+          higher priority than any other frame.</t>
+        <t>The PING frame defines the following flags:</t>
         <dl newline="false" spacing="normal">
           <dt>ACK (0x01):</dt>
-          <dd>
-              When set, the ACK flag indicates that this PING frame is a PING response.  An endpoint MUST
-              set this flag in PING responses.  An endpoint MUST NOT respond to PING frames
-              containing this flag.
-            </dd>
+          <dd>When set, the ACK flag indicates that this PING frame is a PING response.  An endpoint <bcp14>MUST</bcp14>
+              set this flag in PING responses.  An endpoint <bcp14>MUST NOT</bcp14> respond to PING frames
+              containing this flag.</dd>
         </dl>
-        <t>
-          PING frames are not associated with any individual stream. If a PING frame is received
-          with a Stream Identifier field value other than 0x00, the recipient MUST respond with a
+        <t>PING frames are not associated with any individual stream. If a PING frame is received
+          with a Stream Identifier field value other than 0x00, the recipient <bcp14>MUST</bcp14> respond with a
           <xref target="ConnectionErrorHandler">connection error</xref> of type
-          <xref target="PROTOCOL_ERROR" format="none">PROTOCOL_ERROR</xref>.
-        </t>
-        <t>
-          Receipt of a PING frame with a length field value other than 8 MUST be treated as a <xref target="ConnectionErrorHandler">connection error</xref> of type
-          <xref target="FRAME_SIZE_ERROR" format="none">FRAME_SIZE_ERROR</xref>.
-        </t>
+          <xref target="PROTOCOL_ERROR" format="none">PROTOCOL_ERROR</xref>.</t>
+        <t>Receipt of a PING frame with a length field value other than 8 <bcp14>MUST</bcp14> be treated as a <xref target="ConnectionErrorHandler">connection error</xref> of type
+          <xref target="FRAME_SIZE_ERROR" format="none">FRAME_SIZE_ERROR</xref>.</t>
       </section>
       <section anchor="GOAWAY">
         <name>GOAWAY</name>
-        <t>
-          The GOAWAY frame (type=0x07) is used to initiate shutdown of a connection or to signal
+        <t>The GOAWAY frame (type=0x07) is used to initiate shutdown of a connection or to signal
           serious error conditions.  GOAWAY allows an endpoint to gracefully stop accepting new
           streams while still finishing processing of previously established streams.  This enables
-          administrative actions, like server maintenance.
-        </t>
-        <t>
-          There is an inherent race condition between an endpoint starting new streams and the
+          administrative actions, like server maintenance.</t>
+        <t>There is an inherent race condition between an endpoint starting new streams and the
           remote peer sending a GOAWAY frame.  To deal with this case, the GOAWAY contains the stream
           identifier of the last peer-initiated stream that was or might be processed on the
           sending endpoint in this connection.  For instance, if the server sends a GOAWAY frame,
-          the identified stream is the highest-numbered stream initiated by the client.
-        </t>
-        <t>
-          Once the GOAWAY is sent, the sender will ignore frames sent on streams initiated by the
+          the identified stream is the highest-numbered stream initiated by the client.</t>
+        <t>Once the GOAWAY is sent, the sender will ignore frames sent on streams initiated by the
           receiver if the stream has an identifier higher than the included last stream identifier.
-          Receivers of a GOAWAY frame MUST NOT open additional streams on the connection, although a
-          new connection can be established for new streams.
-        </t>
-        <t>
-          If the receiver of the GOAWAY has sent data on streams with a higher stream identifier
+          Receivers of a GOAWAY frame <bcp14>MUST NOT</bcp14> open additional streams on the connection, although a
+          new connection can be established for new streams.</t>
+        <t>If the receiver of the GOAWAY has sent data on streams with a higher stream identifier
           than what is indicated in the GOAWAY frame, those streams are not or will not be
           processed.  The receiver of the GOAWAY frame can treat the streams as though they had
           never been created at all, thereby allowing those streams to be retried later on a new
-          connection.
-        </t>
-        <t>
-          Endpoints SHOULD always send a GOAWAY frame before closing a connection so that the remote
+          connection.</t>
+        <t>Endpoints <bcp14>SHOULD</bcp14> always send a GOAWAY frame before closing a connection so that the remote
           peer can know whether a stream has been partially processed or not.  For example, if an
           HTTP client sends a POST at the same time that a server closes a connection, the client
           cannot know if the server started to process that POST request if the server does not send
-          a GOAWAY frame to indicate what streams it might have acted on.
-        </t>
-        <t>
-          An endpoint might choose to close a connection without sending a GOAWAY for misbehaving
-          peers.
-        </t>
-        <t>
-          A GOAWAY frame might not immediately precede closing of the connection; a receiver of a
-          GOAWAY that has no more use for the connection SHOULD still send a GOAWAY frame before
-          terminating the connection.
-        </t>
+          a GOAWAY frame to indicate what streams it might have acted on.</t>
+        <t>An endpoint might choose to close a connection without sending a GOAWAY for misbehaving
+          peers.</t>
+        <t>A GOAWAY frame might not immediately precede closing of the connection; a receiver of a
+          GOAWAY that has no more use for the connection <bcp14>SHOULD</bcp14> still send a GOAWAY frame before
+          terminating the connection.</t>
         <figure anchor="GOAWAYFrameFormat">
           <name>GOAWAY Frame Format</name>
           <artwork type="inline"><![CDATA[
@@ -2335,112 +1662,79 @@ GOAWAY Frame {
 }
 ]]></artwork>
         </figure>
-        <t>
-          The Length, Type, Unused Flag(s), Reserved, and Stream Identifier fields are described in <xref target="FramingLayer"/>.
-        </t>
-        <t>
-          The GOAWAY frame does not define any flags.
-        </t>
-        <t>
-          The GOAWAY frame applies to the connection, not a specific stream.  An endpoint MUST treat
+        <t>The Length, Type, Unused Flag(s), Reserved, and Stream Identifier fields are described in <xref target="FramingLayer"/>.</t>
+        <t>The GOAWAY frame does not define any flags.</t>
+        <t>The GOAWAY frame applies to the connection, not a specific stream.  An endpoint <bcp14>MUST</bcp14> treat
           a <xref target="GOAWAY" format="none">GOAWAY</xref> frame with a stream identifier other than 0x00 as a <xref target="ConnectionErrorHandler">connection error</xref> of type
-          <xref target="PROTOCOL_ERROR" format="none">PROTOCOL_ERROR</xref>.
-        </t>
-        <t>
-          The last stream identifier in the GOAWAY frame contains the highest-numbered stream
+          <xref target="PROTOCOL_ERROR" format="none">PROTOCOL_ERROR</xref>.</t>
+        <t>The last stream identifier in the GOAWAY frame contains the highest-numbered stream
           identifier for which the sender of the GOAWAY frame might have taken some action on or
           might yet take action on.  All streams up to and including the identified stream might
           have been processed in some way.  The last stream identifier can be set to 0 if no streams
-          were processed.
-        </t>
+          were processed.</t>
         <aside>
           <t>Note:
             In this context, "processed" means that some data from the stream was passed to some
-            higher layer of software that might have taken some action as a result.
-          </t>
+            higher layer of software that might have taken some action as a result.</t>
         </aside>
-        <t>
-          If a connection terminates without a GOAWAY frame, the last stream identifier is
-          effectively the highest possible stream identifier.
-        </t>
-        <t>
-          On streams with lower- or equal-numbered identifiers that were not closed completely prior
+        <t>If a connection terminates without a GOAWAY frame, the last stream identifier is
+          effectively the highest possible stream identifier.</t>
+        <t>On streams with lower- or equal-numbered identifiers that were not closed completely prior
           to the connection being closed, reattempting requests, transactions, or any protocol
           activity is not possible, except for idempotent actions like HTTP GET, PUT, or
           DELETE.  Any protocol activity that uses higher-numbered streams can be safely retried
-          using a new connection.
-        </t>
-        <t>
-          Activity on streams numbered lower than or equal to the last stream identifier might still
+          using a new connection.</t>
+        <t>Activity on streams numbered lower than or equal to the last stream identifier might still
           complete successfully.  The sender of a GOAWAY frame might gracefully shut down a
           connection by sending a GOAWAY frame, maintaining the connection in an "open" state until
-          all in-progress streams complete.
-        </t>
-        <t>
-          An endpoint MAY send multiple GOAWAY frames if circumstances change.  For instance, an
+          all in-progress streams complete.</t>
+        <t>An endpoint <bcp14>MAY</bcp14> send multiple GOAWAY frames if circumstances change.  For instance, an
           endpoint that sends GOAWAY with <xref target="NO_ERROR" format="none">NO_ERROR</xref> during graceful shutdown could
           subsequently encounter a condition that requires immediate termination of the connection.
           The last stream identifier from the last GOAWAY frame received indicates which streams
-          could have been acted upon.  Endpoints MUST NOT increase the value they send in the last
+          could have been acted upon.  Endpoints <bcp14>MUST NOT</bcp14> increase the value they send in the last
           stream identifier, since the peers might already have retried unprocessed requests on
-          another connection.
-        </t>
-        <t>
-          A client that is unable to retry requests loses all requests that are in flight when the
+          another connection.</t>
+        <t>A client that is unable to retry requests loses all requests that are in flight when the
           server closes the connection.  This is especially true for intermediaries that might not
           be serving clients using HTTP/2.  A server that is attempting to gracefully shut down a
-          connection SHOULD send an initial GOAWAY frame with the last stream identifier set to
+          connection <bcp14>SHOULD</bcp14> send an initial GOAWAY frame with the last stream identifier set to
           2<sup>31</sup>-1 and a <xref target="NO_ERROR" format="none">NO_ERROR</xref> code.  This signals to the client that
           a shutdown is imminent and that initiating further requests is prohibited.  After allowing
-          time for any in-flight stream creation (at least one round-trip time),  the server MAY
+          time for any in-flight stream creation (at least one round-trip time),  the server <bcp14>MAY</bcp14>
           send another GOAWAY frame with an updated last stream identifier.  This ensures that a
-          connection can be cleanly shut down without losing requests.
-        </t>
-        <t>
-          After sending a GOAWAY frame, the sender can discard frames for streams initiated by the
+          connection can be cleanly shut down without losing requests.</t>
+        <t>After sending a GOAWAY frame, the sender can discard frames for streams initiated by the
           receiver with identifiers higher than the identified last stream.  However, any frames
           that alter connection state cannot be completely ignored.  For instance,
           <xref target="HEADERS" format="none">HEADERS</xref>, <xref target="PUSH_PROMISE" format="none">PUSH_PROMISE</xref>, and <xref target="CONTINUATION" format="none">CONTINUATION</xref> frames
-          MUST be minimally processed to ensure that the state maintained for field section compression is
-          consistent (see <xref target="FieldBlock"/>); similarly, DATA frames MUST be counted
+          <bcp14>MUST</bcp14> be minimally processed to ensure that the state maintained for field section compression is
+          consistent (see <xref target="FieldBlock"/>); similarly, DATA frames <bcp14>MUST</bcp14> be counted
           toward the connection flow-control window.  Failure to process these frames can cause flow
-          control or field section compression state to become unsynchronized.
-        </t>
-        <t>
-          The GOAWAY frame also contains a 32-bit <xref target="ErrorCodes">error code</xref> that
-          contains the reason for closing the connection.
-        </t>
-        <t>
-          Endpoints MAY append opaque data to the frame payload of any GOAWAY frame.  Additional debug
+          control or field section compression state to become unsynchronized.</t>
+        <t>The GOAWAY frame also contains a 32-bit <xref target="ErrorCodes">error code</xref> that
+          contains the reason for closing the connection.</t>
+        <t>Endpoints <bcp14>MAY</bcp14> append opaque data to the frame payload of any GOAWAY frame.  Additional debug
           data is intended for diagnostic purposes only and carries no semantic value.  Debug
           information could contain security- or privacy-sensitive data.  Logged or otherwise
-          persistently stored debug data MUST have adequate safeguards to prevent unauthorized
-          access.
-        </t>
+          persistently stored debug data <bcp14>MUST</bcp14> have adequate safeguards to prevent unauthorized
+          access.</t>
       </section>
       <section anchor="WINDOW_UPDATE">
         <name>WINDOW_UPDATE</name>
-        <t>
-          The WINDOW_UPDATE frame (type=0x08) is used to implement flow control; see <xref target="FlowControl"/> for an overview.
-        </t>
-        <t>
-          Flow control operates at two levels: on each individual stream and on the entire
-          connection.
-        </t>
-        <t>
-          Both types of flow control are hop by hop, that is, only between the two endpoints.
+        <t>The WINDOW_UPDATE frame (type=0x08) is used to implement flow control; see <xref target="FlowControl"/> for an overview.</t>
+        <t>Flow control operates at two levels: on each individual stream and on the entire
+          connection.</t>
+        <t>Both types of flow control are hop by hop, that is, only between the two endpoints.
           Intermediaries do not forward WINDOW_UPDATE frames between dependent connections.
           However, throttling of data transfer by any receiver can indirectly cause the propagation
-          of flow-control information toward the original sender.
-        </t>
-        <t>
-          Flow control only applies to frames that are identified as being subject to flow control.
+          of flow-control information toward the original sender.</t>
+        <t>Flow control only applies to frames that are identified as being subject to flow control.
           Of the frame types defined in this document, this includes only <xref target="DATA" format="none">DATA</xref> frames.
-          Frames that are exempt from flow control MUST be accepted and processed, unless the
-          receiver is unable to assign resources to handling the frame.  A receiver MAY respond with
+          Frames that are exempt from flow control <bcp14>MUST</bcp14> be accepted and processed, unless the
+          receiver is unable to assign resources to handling the frame.  A receiver <bcp14>MAY</bcp14> respond with
           a <xref target="StreamErrorHandler">stream error</xref> or <xref target="ConnectionErrorHandler">connection error</xref> of type
-          <xref target="FLOW_CONTROL_ERROR" format="none">FLOW_CONTROL_ERROR</xref> if it is unable to accept a frame.
-        </t>
+          <xref target="FLOW_CONTROL_ERROR" format="none">FLOW_CONTROL_ERROR</xref> if it is unable to accept a frame.</t>
         <figure anchor="WINDOW_UPDATEFrameFormat">
           <name>WINDOW_UPDATE Frame Format</name>
           <artwork type="inline"><![CDATA[
@@ -2458,165 +1752,114 @@ WINDOW_UPDATE Frame {
 }
 ]]></artwork>
         </figure>
-        <t>
-          The Length, Type, Unused Flag(s), Reserved, and Stream Identifier fields are described in <xref target="FramingLayer"/>.
+        <t>The Length, Type, Unused Flag(s), Reserved, and Stream Identifier fields are described in <xref target="FramingLayer"/>.
           The frame payload of a WINDOW_UPDATE frame is one reserved bit plus an unsigned 31-bit integer
           indicating the number of octets that the sender can transmit in addition to the existing
           flow-control window.  The legal range for the increment to the flow-control window is 1 to
-          2<sup>31</sup>-1 (2,147,483,647) octets.
-        </t>
-        <t>
-          The WINDOW_UPDATE frame does not define any flags.
-        </t>
-        <t>
-          The WINDOW_UPDATE frame can be specific to a stream or to the entire connection.  In the
+          2<sup>31</sup>-1 (2,147,483,647) octets.</t>
+        <t>The WINDOW_UPDATE frame does not define any flags.</t>
+        <t>The WINDOW_UPDATE frame can be specific to a stream or to the entire connection.  In the
           former case, the frame's stream identifier indicates the affected stream; in the latter,
-          the value "0" indicates that the entire connection is the subject of the frame.
-        </t>
-        <t>
-          A receiver MUST treat the receipt of a WINDOW_UPDATE frame with a flow-control window
+          the value "0" indicates that the entire connection is the subject of the frame.</t>
+        <t>A receiver <bcp14>MUST</bcp14> treat the receipt of a WINDOW_UPDATE frame with a flow-control window
           increment of 0 as a <xref target="StreamErrorHandler">stream error</xref> of type
-          <xref target="PROTOCOL_ERROR" format="none">PROTOCOL_ERROR</xref>; errors on the connection flow-control window MUST be
-          treated as a <xref target="ConnectionErrorHandler">connection error</xref>.
-        </t>
-        <t>
-          WINDOW_UPDATE can be sent by a peer that has sent a frame with the END_STREAM flag set.
+          <xref target="PROTOCOL_ERROR" format="none">PROTOCOL_ERROR</xref>; errors on the connection flow-control window <bcp14>MUST</bcp14> be
+          treated as a <xref target="ConnectionErrorHandler">connection error</xref>.</t>
+        <t>WINDOW_UPDATE can be sent by a peer that has sent a frame with the END_STREAM flag set.
           This means that a receiver could receive a WINDOW_UPDATE frame on a stream in a "half-closed (remote)"
-          or "closed" state.  A receiver MUST NOT treat this as an error (see <xref target="StreamStates"/>).
-        </t>
-        <t>
-          A receiver that receives a flow-controlled frame MUST always account for its contribution
+          or "closed" state.  A receiver <bcp14>MUST NOT</bcp14> treat this as an error (see <xref target="StreamStates"/>).</t>
+        <t>A receiver that receives a flow-controlled frame <bcp14>MUST</bcp14> always account for its contribution
           against the connection flow-control window, unless the receiver treats this as a <xref target="ConnectionErrorHandler">connection error</xref>.  This is necessary even if the
           frame is in error.  The sender counts the frame toward the flow-control window, but if
           the receiver does not, the flow-control window at the sender and receiver can become
-          different.
-        </t>
-        <t>
-          A WINDOW_UPDATE frame with a length other than 4 octets MUST be treated as a <xref target="ConnectionErrorHandler">connection error</xref> of type
-          <xref target="FRAME_SIZE_ERROR" format="none">FRAME_SIZE_ERROR</xref>.
-        </t>
+          different.</t>
+        <t>A WINDOW_UPDATE frame with a length other than 4 octets <bcp14>MUST</bcp14> be treated as a <xref target="ConnectionErrorHandler">connection error</xref> of type
+          <xref target="FRAME_SIZE_ERROR" format="none">FRAME_SIZE_ERROR</xref>.</t>
         <section>
           <name>The Flow-Control Window</name>
-          <t>
-            Flow control in HTTP/2 is implemented using a window kept by each sender on every
+          <t>Flow control in HTTP/2 is implemented using a window kept by each sender on every
             stream. The flow-control window is a simple integer value that indicates how many octets
             of data the sender is permitted to transmit; as such, its size is a measure of the
-            buffering capacity of the receiver.
-          </t>
-          <t>
-            Two flow-control windows are applicable: the stream flow-control window and the
-            connection flow-control window.  The sender MUST NOT send a flow-controlled frame with a
+            buffering capacity of the receiver.</t>
+          <t>Two flow-control windows are applicable: the stream flow-control window and the
+            connection flow-control window.  The sender <bcp14>MUST NOT</bcp14> send a flow-controlled frame with a
             length that exceeds the space available in either of the flow-control windows advertised
             by the receiver.  Frames with zero length with the END_STREAM flag set (that is, an
-            empty <xref target="DATA" format="none">DATA</xref> frame) MAY be sent if there is no available space in either
-            flow-control window.
-          </t>
-          <t>
-            For flow-control calculations, the 9-octet frame header is not counted.
-          </t>
-          <t>
-            After sending a flow-controlled frame, the sender reduces the space available in both
-            windows by the length of the transmitted frame.
-          </t>
-          <t>
-            The receiver of a frame sends a WINDOW_UPDATE frame as it consumes data and frees up
+            empty <xref target="DATA" format="none">DATA</xref> frame) <bcp14>MAY</bcp14> be sent if there is no available space in either
+            flow-control window.</t>
+          <t>For flow-control calculations, the 9-octet frame header is not counted.</t>
+          <t>After sending a flow-controlled frame, the sender reduces the space available in both
+            windows by the length of the transmitted frame.</t>
+          <t>The receiver of a frame sends a WINDOW_UPDATE frame as it consumes data and frees up
             space in flow-control windows.  Separate WINDOW_UPDATE frames are sent for the stream-
             and connection-level flow-control windows.  Receivers are advised to have mechanisms in
-            place to avoid sending WINDOW_UPDATE frames with very small increments; see <xref
-            target="RFC1122" section="4.2.3.3"/>.
-          </t>
-          <t>
-            A sender that receives a WINDOW_UPDATE frame updates the corresponding window by the
-            amount specified in the frame.
-          </t>
-          <t>
-            A sender MUST NOT allow a flow-control window to exceed 2<sup>31</sup>-1 octets.
+            place to avoid sending WINDOW_UPDATE frames with very small increments; see <xref target="RFC1122" section="4.2.3.3"/>.</t>
+          <t>A sender that receives a WINDOW_UPDATE frame updates the corresponding window by the
+            amount specified in the frame.</t>
+          <t>A sender <bcp14>MUST NOT</bcp14> allow a flow-control window to exceed 2<sup>31</sup>-1 octets.
             If a sender receives a WINDOW_UPDATE that causes a flow-control window to exceed this
-            maximum, it MUST terminate either the stream or the connection, as appropriate.  For
+            maximum, it <bcp14>MUST</bcp14> terminate either the stream or the connection, as appropriate.  For
             streams, the sender sends a <xref target="RST_STREAM" format="none">RST_STREAM</xref> with an error code of
             <xref target="FLOW_CONTROL_ERROR" format="none">FLOW_CONTROL_ERROR</xref>; for the connection, a <xref target="GOAWAY" format="none">GOAWAY</xref>
-            frame with an error code of <xref target="FLOW_CONTROL_ERROR" format="none">FLOW_CONTROL_ERROR</xref> is sent.
-          </t>
-          <t>
-            Flow-controlled frames from the sender and WINDOW_UPDATE frames from the receiver are
+            frame with an error code of <xref target="FLOW_CONTROL_ERROR" format="none">FLOW_CONTROL_ERROR</xref> is sent.</t>
+          <t>Flow-controlled frames from the sender and WINDOW_UPDATE frames from the receiver are
             completely asynchronous with respect to each other. This property allows a receiver to
-            aggressively update the window size kept by the sender to prevent streams from stalling.
-          </t>
+            aggressively update the window size kept by the sender to prevent streams from stalling.</t>
         </section>
         <section anchor="InitialWindowSize">
           <name>Initial Flow-Control Window Size</name>
-          <t>
-            When an HTTP/2 connection is first established, new streams are created with an initial
+          <t>When an HTTP/2 connection is first established, new streams are created with an initial
             flow-control window size of 65,535 octets. The connection flow-control window is also 65,535
             octets. Both endpoints can adjust the initial window size for new streams by including
             a value for <xref target="SETTINGS_INITIAL_WINDOW_SIZE" format="none">SETTINGS_INITIAL_WINDOW_SIZE</xref> in the <xref target="SETTINGS" format="none">SETTINGS</xref>
             frame. The connection flow-control window can
-            only be changed using WINDOW_UPDATE frames.
-          </t>
-          <t>
-            Prior to receiving a <xref target="SETTINGS" format="none">SETTINGS</xref> frame that sets a value for
+            only be changed using WINDOW_UPDATE frames.</t>
+          <t>Prior to receiving a <xref target="SETTINGS" format="none">SETTINGS</xref> frame that sets a value for
             <xref target="SETTINGS_INITIAL_WINDOW_SIZE" format="none">SETTINGS_INITIAL_WINDOW_SIZE</xref>, an endpoint can only use the default
             initial window size when sending flow-controlled frames.  Similarly, the connection flow-control
             window is set based on the default initial window size until a WINDOW_UPDATE frame is
-            received.
-          </t>
-          <t>
-            In addition to changing the flow-control window for streams that are not yet active, a
+            received.</t>
+          <t>In addition to changing the flow-control window for streams that are not yet active, a
             <xref target="SETTINGS" format="none">SETTINGS</xref> frame can alter the initial flow-control window size for streams
             with active flow-control windows (that is, streams in the "open" or "half-closed
             (remote)" state).  When the value of <xref target="SETTINGS_INITIAL_WINDOW_SIZE" format="none">SETTINGS_INITIAL_WINDOW_SIZE</xref>
-            changes, a receiver MUST adjust the size of all stream flow-control windows that it
-            maintains by the difference between the new value and the old value.
-          </t>
-          <t>
-            A change to <xref target="SETTINGS_INITIAL_WINDOW_SIZE" format="none">SETTINGS_INITIAL_WINDOW_SIZE</xref> can cause the available space in
-            a flow-control window to become negative.  A sender MUST track the negative flow-control
-            window and MUST NOT send new flow-controlled frames until it receives WINDOW_UPDATE
-            frames that cause the flow-control window to become positive.
-          </t>
-          <t>
-            For example, if the client sends 60 KB immediately on connection establishment and the
+            changes, a receiver <bcp14>MUST</bcp14> adjust the size of all stream flow-control windows that it
+            maintains by the difference between the new value and the old value.</t>
+          <t>A change to <xref target="SETTINGS_INITIAL_WINDOW_SIZE" format="none">SETTINGS_INITIAL_WINDOW_SIZE</xref> can cause the available space in
+            a flow-control window to become negative.  A sender <bcp14>MUST</bcp14> track the negative flow-control
+            window and <bcp14>MUST NOT</bcp14> send new flow-controlled frames until it receives WINDOW_UPDATE
+            frames that cause the flow-control window to become positive.</t>
+          <t>For example, if the client sends 60 KB immediately on connection establishment and the
             server sets the initial window size to be 16 KB, the client will recalculate the
             available flow-control window to be -44 KB on receipt of the <xref target="SETTINGS" format="none">SETTINGS</xref>
             frame.  The client retains a negative flow-control window until WINDOW_UPDATE frames
-            restore the window to being positive, after which the client can resume sending.
-          </t>
-          <t>
-            A <xref target="SETTINGS" format="none">SETTINGS</xref> frame cannot alter the connection flow-control window.
-          </t>
-          <t>
-            An endpoint MUST treat a change to <xref target="SETTINGS_INITIAL_WINDOW_SIZE" format="none">SETTINGS_INITIAL_WINDOW_SIZE</xref> that
+            restore the window to being positive, after which the client can resume sending.</t>
+          <t>A <xref target="SETTINGS" format="none">SETTINGS</xref> frame cannot alter the connection flow-control window.</t>
+          <t>An endpoint <bcp14>MUST</bcp14> treat a change to <xref target="SETTINGS_INITIAL_WINDOW_SIZE" format="none">SETTINGS_INITIAL_WINDOW_SIZE</xref> that
             causes any flow-control window to exceed the maximum size as a <xref target="ConnectionErrorHandler">connection error</xref> of type
-            <xref target="FLOW_CONTROL_ERROR" format="none">FLOW_CONTROL_ERROR</xref>.
-          </t>
+            <xref target="FLOW_CONTROL_ERROR" format="none">FLOW_CONTROL_ERROR</xref>.</t>
         </section>
         <section>
           <name>Reducing the Stream Window Size</name>
-          <t>
-            A receiver that wishes to use a smaller flow-control window than the current size can
-            send a new <xref target="SETTINGS" format="none">SETTINGS</xref> frame.  However, the receiver MUST be prepared to
+          <t>A receiver that wishes to use a smaller flow-control window than the current size can
+            send a new <xref target="SETTINGS" format="none">SETTINGS</xref> frame.  However, the receiver <bcp14>MUST</bcp14> be prepared to
             receive data that exceeds this window size, since the sender might send data that
-            exceeds the lower limit prior to processing the <xref target="SETTINGS" format="none">SETTINGS</xref> frame.
-          </t>
-          <t>
-            After sending a SETTINGS frame that reduces the initial flow-control window size, a
-            receiver MAY continue to process streams that exceed flow-control limits.  Allowing
+            exceeds the lower limit prior to processing the <xref target="SETTINGS" format="none">SETTINGS</xref> frame.</t>
+          <t>After sending a SETTINGS frame that reduces the initial flow-control window size, a
+            receiver <bcp14>MAY</bcp14> continue to process streams that exceed flow-control limits.  Allowing
             streams to continue does not allow the receiver to immediately reduce the space it
             reserves for flow-control windows.  Progress on these streams can also stall, since
             <xref target="WINDOW_UPDATE" format="none">WINDOW_UPDATE</xref> frames are needed to allow the sender to resume sending.
-            The receiver MAY instead send a <xref target="RST_STREAM" format="none">RST_STREAM</xref> with an error code of
-            <xref target="FLOW_CONTROL_ERROR" format="none">FLOW_CONTROL_ERROR</xref> for the affected streams.
-          </t>
+            The receiver <bcp14>MAY</bcp14> instead send a <xref target="RST_STREAM" format="none">RST_STREAM</xref> with an error code of
+            <xref target="FLOW_CONTROL_ERROR" format="none">FLOW_CONTROL_ERROR</xref> for the affected streams.</t>
         </section>
       </section>
       <section anchor="CONTINUATION">
         <name>CONTINUATION</name>
-        <t>
-          The CONTINUATION frame (type=0x09) is used to continue a sequence of <xref target="FieldBlock">field block fragments</xref>.  Any number of CONTINUATION frames can
+        <t>The CONTINUATION frame (type=0x09) is used to continue a sequence of <xref target="FieldBlock">field block fragments</xref>.  Any number of CONTINUATION frames can
           be sent, as long as the preceding frame is on the same stream and is a
           <xref target="HEADERS" format="none">HEADERS</xref>, <xref target="PUSH_PROMISE" format="none">PUSH_PROMISE</xref>, or CONTINUATION frame without the
-          END_HEADERS flag set.
-        </t>
+          END_HEADERS flag set.</t>
         <figure anchor="CONTINUATIONFrameFormat">
           <name>CONTINUATION Frame Format</name>
           <artwork type="inline"><![CDATA[
@@ -2635,401 +1878,248 @@ CONTINUATION Frame {
 }
 ]]></artwork>
         </figure>
-        <t>
-          The Length, Type, Unused Flag(s), Reserved, and Stream Identifier fields are described in <xref target="FramingLayer"/>.
+        <t>The Length, Type, Unused Flag(s), Reserved, and Stream Identifier fields are described in <xref target="FramingLayer"/>.
           The CONTINUATION frame payload contains a <xref target="FieldBlock">field block
-          fragment</xref>.
-        </t>
-        <t>
-          The CONTINUATION frame defines the following flag:
-        </t>
+          fragment</xref>.</t>
+        <t>The CONTINUATION frame defines the following flag:</t>
         <dl newline="false" spacing="normal">
           <dt>END_HEADERS (0x04):</dt>
           <dd>
-            <t>
-                When set, the END_HEADERS flag indicates that this frame ends a <xref target="FieldBlock">field
-                block</xref>.
-            </t>
-            <t>
-                If the END_HEADERS flag is not set, this frame MUST be followed by another
-                CONTINUATION frame.  A receiver MUST treat the receipt of any other type of frame or
+            <t>When set, the END_HEADERS flag indicates that this frame ends a <xref target="FieldBlock">field
+                block</xref>.</t>
+            <t>If the END_HEADERS flag is not set, this frame <bcp14>MUST</bcp14> be followed by another
+                CONTINUATION frame.  A receiver <bcp14>MUST</bcp14> treat the receipt of any other type of frame or
                 a frame on a different stream as a <xref target="ConnectionErrorHandler">connection
-                error</xref> of type <xref target="PROTOCOL_ERROR" format="none">PROTOCOL_ERROR</xref>.
-            </t>
+                error</xref> of type <xref target="PROTOCOL_ERROR" format="none">PROTOCOL_ERROR</xref>.</t>
           </dd>
         </dl>
-        <t>
-          The CONTINUATION frame changes the connection state as defined in <xref target="FieldBlock"/>.
-        </t>
-        <t>
-          CONTINUATION frames MUST be associated with a stream. If a CONTINUATION frame is received
-          with a Stream Identifier field of 0x00, the recipient MUST respond with a <xref target="ConnectionErrorHandler">connection error</xref> of type PROTOCOL_ERROR.
-        </t>
-        <t>
-          A CONTINUATION frame MUST be preceded by a <xref target="HEADERS" format="none">HEADERS</xref>,
+        <t>The CONTINUATION frame changes the connection state as defined in <xref target="FieldBlock"/>.</t>
+        <t>CONTINUATION frames <bcp14>MUST</bcp14> be associated with a stream. If a CONTINUATION frame is received
+          with a Stream Identifier field of 0x00, the recipient <bcp14>MUST</bcp14> respond with a <xref target="ConnectionErrorHandler">connection error</xref> of type PROTOCOL_ERROR.</t>
+        <t>A CONTINUATION frame <bcp14>MUST</bcp14> be preceded by a <xref target="HEADERS" format="none">HEADERS</xref>,
           <xref target="PUSH_PROMISE" format="none">PUSH_PROMISE</xref> or CONTINUATION frame without the END_HEADERS flag set.  A
-          recipient that observes violation of this rule MUST respond with a <xref target="ConnectionErrorHandler"> connection error</xref> of type
-          <xref target="PROTOCOL_ERROR" format="none">PROTOCOL_ERROR</xref>.
-        </t>
+          recipient that observes violation of this rule <bcp14>MUST</bcp14> respond with a <xref target="ConnectionErrorHandler">connection error</xref> of type
+          <xref target="PROTOCOL_ERROR" format="none">PROTOCOL_ERROR</xref>.</t>
       </section>
     </section>
     <section anchor="ErrorCodes">
       <name>Error Codes</name>
-      <t>
-        Error codes are 32-bit fields that are used in <xref target="RST_STREAM" format="none">RST_STREAM</xref> and
-        <xref target="GOAWAY" format="none">GOAWAY</xref> frames to convey the reasons for the stream or connection error.
-      </t>
-      <t>
-        Error codes share a common code space.  Some error codes apply only to either streams or the
-        entire connection and have no defined semantics in the other context.
-      </t>
-      <t>
-        The following error codes are defined:
-      </t>
+      <t>Error codes are 32-bit fields that are used in <xref target="RST_STREAM" format="none">RST_STREAM</xref> and
+        <xref target="GOAWAY" format="none">GOAWAY</xref> frames to convey the reasons for the stream or connection error.</t>
+      <t>Error codes share a common code space.  Some error codes apply only to either streams or the
+        entire connection and have no defined semantics in the other context.</t>
+      <t>The following error codes are defined:</t>
       <dl newline="false" spacing="normal">
         <dt>NO_ERROR (0x00):</dt>
-        <dd anchor="NO_ERROR">
-            The associated condition is not a result of an error.  For example, a
+        <dd anchor="NO_ERROR">The associated condition is not a result of an error.  For example, a
             <xref target="GOAWAY" format="none">GOAWAY</xref> might include this code to indicate graceful shutdown of a
-            connection.
-          </dd>
+            connection.</dd>
         <dt>PROTOCOL_ERROR (0x01):</dt>
-        <dd anchor="PROTOCOL_ERROR">
-            The endpoint detected an unspecific protocol error.  This error is for use when a more
-            specific error code is not available.
-          </dd>
+        <dd anchor="PROTOCOL_ERROR">The endpoint detected an unspecific protocol error.  This error is for use when a more
+            specific error code is not available.</dd>
         <dt>INTERNAL_ERROR (0x02):</dt>
-        <dd anchor="INTERNAL_ERROR">
-            The endpoint encountered an unexpected internal error.
-          </dd>
+        <dd anchor="INTERNAL_ERROR">The endpoint encountered an unexpected internal error.</dd>
         <dt>FLOW_CONTROL_ERROR (0x03):</dt>
-        <dd anchor="FLOW_CONTROL_ERROR">
-            The endpoint detected that its peer violated the flow-control protocol.
-          </dd>
+        <dd anchor="FLOW_CONTROL_ERROR">The endpoint detected that its peer violated the flow-control protocol.</dd>
         <dt>SETTINGS_TIMEOUT (0x04):</dt>
-        <dd anchor="SETTINGS_TIMEOUT">
-            The endpoint sent a <xref target="SETTINGS" format="none">SETTINGS</xref> frame but did not receive a response in a
-            timely manner.  See <xref target="SettingsSync"/> ("Settings Synchronization").
-          </dd>
+        <dd anchor="SETTINGS_TIMEOUT">The endpoint sent a <xref target="SETTINGS" format="none">SETTINGS</xref> frame but did not receive a response in a
+            timely manner.  See <xref target="SettingsSync"/> ("Settings Synchronization").</dd>
         <dt>STREAM_CLOSED (0x05):</dt>
-        <dd anchor="STREAM_CLOSED">
-            The endpoint received a frame after a stream was half-closed.
-          </dd>
+        <dd anchor="STREAM_CLOSED">The endpoint received a frame after a stream was half-closed.</dd>
         <dt>FRAME_SIZE_ERROR (0x06):</dt>
-        <dd anchor="FRAME_SIZE_ERROR">
-            The endpoint received a frame with an invalid size.
-          </dd>
+        <dd anchor="FRAME_SIZE_ERROR">The endpoint received a frame with an invalid size.</dd>
         <dt>REFUSED_STREAM (0x07):</dt>
-        <dd anchor="REFUSED_STREAM">
-            The endpoint refused the stream prior to performing any application processing (see
-            <xref target="Reliability"/> for details).
-          </dd>
+        <dd anchor="REFUSED_STREAM">The endpoint refused the stream prior to performing any application processing (see
+            <xref target="Reliability"/> for details).</dd>
         <dt>CANCEL (0x08):</dt>
-        <dd anchor="CANCEL">
-            The endpoint uses this error code to indicate that the stream is no longer needed.
-          </dd>
+        <dd anchor="CANCEL">The endpoint uses this error code to indicate that the stream is no longer needed.</dd>
         <dt>COMPRESSION_ERROR (0x09):</dt>
-        <dd anchor="COMPRESSION_ERROR">
-            The endpoint is unable to maintain the field section compression context for the
-            connection.
-          </dd>
+        <dd anchor="COMPRESSION_ERROR">The endpoint is unable to maintain the field section compression context for the
+            connection.</dd>
         <dt>CONNECT_ERROR (0x0a):</dt>
-        <dd anchor="CONNECT_ERROR">
-            The connection established in response to a <xref target="CONNECT">CONNECT
-            request</xref> was reset or abnormally closed.
-          </dd>
+        <dd anchor="CONNECT_ERROR">The connection established in response to a <xref target="CONNECT">CONNECT
+            request</xref> was reset or abnormally closed.</dd>
         <dt>ENHANCE_YOUR_CALM (0x0b):</dt>
-        <dd anchor="ENHANCE_YOUR_CALM">
-            The endpoint detected that its peer is exhibiting a behavior that might be generating
-            excessive load.
-          </dd>
+        <dd anchor="ENHANCE_YOUR_CALM">The endpoint detected that its peer is exhibiting a behavior that might be generating
+            excessive load.</dd>
         <dt>INADEQUATE_SECURITY (0x0c):</dt>
-        <dd anchor="INADEQUATE_SECURITY">
-            The underlying transport has properties that do not meet minimum security
-            requirements (see <xref target="TLSUsage"/>).
-          </dd>
+        <dd anchor="INADEQUATE_SECURITY">The underlying transport has properties that do not meet minimum security
+            requirements (see <xref target="TLSUsage"/>).</dd>
         <dt>HTTP_1_1_REQUIRED (0x0d):</dt>
-        <dd anchor="HTTP_1_1_REQUIRED">
-            The endpoint requires that HTTP/1.1 be used instead of HTTP/2.
-          </dd>
+        <dd anchor="HTTP_1_1_REQUIRED">The endpoint requires that HTTP/1.1 be used instead of HTTP/2.</dd>
       </dl>
-      <t>
-        Unknown or unsupported error codes MUST NOT trigger any special behavior.  These MAY be
-        treated by an implementation as being equivalent to <xref target="INTERNAL_ERROR" format="none">INTERNAL_ERROR</xref>.
-      </t>
+      <t>Unknown or unsupported error codes <bcp14>MUST NOT</bcp14> trigger any special behavior.  These <bcp14>MAY</bcp14> be
+        treated by an implementation as being equivalent to <xref target="INTERNAL_ERROR" format="none">INTERNAL_ERROR</xref>.</t>
     </section>
     <section anchor="HttpLayer">
       <name>Expressing HTTP Semantics in HTTP/2</name>
-      <t>
-        HTTP/2 is an instantiation of the HTTP message abstraction (<xref target="HTTP"
-        section="6"/>).
-      </t>
+      <t>HTTP/2 is an instantiation of the HTTP message abstraction (<xref target="HTTP" section="6"/>).</t>
       <section anchor="HttpFraming">
         <name>HTTP Message Framing</name>
-        <t>
-          A client sends an HTTP request on a new stream, using a previously unused <xref
-          target="StreamIdentifiers">stream identifier</xref>. A server sends an HTTP response on
-          the same stream as the request.
-        </t>
-        <t>
-          An HTTP message (request or response) consists of:
-        </t>
+        <t>A client sends an HTTP request on a new stream, using a previously unused <xref target="StreamIdentifiers">stream identifier</xref>. A server sends an HTTP response on
+          the same stream as the request.</t>
+        <t>An HTTP message (request or response) consists of:</t>
         <ol spacing="normal" type="1">
-          <li>
-            one <xref target="HEADERS" format="none">HEADERS</xref> frame (followed by zero or
+          <li>one <xref target="HEADERS" format="none">HEADERS</xref> frame (followed by zero or
             more <xref target="CONTINUATION" format="none">CONTINUATION</xref> frames) containing
-            the header section (see <xref target="HTTP" section="6.3"/>),
-          </li>
-          <li>
-            zero or more <xref target="DATA" format="none">DATA</xref> frames containing the
-            message content (see <xref target="HTTP" section="6.4"/>), and
-          </li>
-          <li>
-            optionally, one <xref target="HEADERS" format="none">HEADERS</xref> frame (followed by
+            the header section (see <xref target="HTTP" section="6.3"/>),</li>
+          <li>zero or more <xref target="DATA" format="none">DATA</xref> frames containing the
+            message content (see <xref target="HTTP" section="6.4"/>), and</li>
+          <li>optionally, one <xref target="HEADERS" format="none">HEADERS</xref> frame (followed by
             zero or more <xref target="CONTINUATION" format="none">CONTINUATION</xref> frames)
-            containing the trailer section, if present (see <xref target="HTTP" section="6.5"/>).
-          </li>
+            containing the trailer section, if present (see <xref target="HTTP" section="6.5"/>).</li>
         </ol>
-        <t>
-          For a response only, a server MAY send any number of interim responses before the <xref
-          target="HEADERS" format="none">HEADERS</xref> frame containing a final response. An
+        <t>For a response only, a server <bcp14>MAY</bcp14> send any number of interim responses before the <xref target="HEADERS" format="none">HEADERS</xref> frame containing a final response. An
           interim response consists of a <xref target="HEADERS" format="none">HEADERS</xref> frame
-          (which might be followed by zero or more <xref target="CONTINUATION"
-          format="none">CONTINUATION</xref> frames) containing the control data and header section
-          of an interim (1xx) HTTP response (see <xref target="HTTP" section="15"/>). A <xref
-          target="HEADERS" format="none">HEADERS</xref> frame with the END_STREAM flag set that carries
-          an informational status code is <xref target="malformed">malformed</xref>.
-        </t>
-        <t>
-          The last frame in the sequence bears an END_STREAM flag, noting that a <xref
-          target="HEADERS" format="none">HEADERS</xref> frame with the END_STREAM flag set can be
+          (which might be followed by zero or more <xref target="CONTINUATION" format="none">CONTINUATION</xref> frames) containing the control data and header section
+          of an interim (1xx) HTTP response (see <xref target="HTTP" section="15"/>). A <xref target="HEADERS" format="none">HEADERS</xref> frame with the END_STREAM flag set that carries
+          an informational status code is <xref target="malformed">malformed</xref>.</t>
+        <t>The last frame in the sequence bears an END_STREAM flag, noting that a <xref target="HEADERS" format="none">HEADERS</xref> frame with the END_STREAM flag set can be
           followed by <xref target="CONTINUATION" format="none">CONTINUATION</xref> frames that
-          carry any remaining fragments of the field block.
-        </t>
-        <t>
-          Other frames (from any stream) MUST NOT occur between the <xref target="HEADERS" format="none">HEADERS</xref> frame
-          and any <xref target="CONTINUATION" format="none">CONTINUATION</xref> frames that might follow.
-        </t>
-        <t>
-          HTTP/2 uses DATA frames to carry message content.  The <tt>chunked</tt> transfer encoding
-          defined in <xref target="HTTP11" section="7.1"/> cannot be used in HTTP/2; see <xref
-          target="ConnectionSpecific"/>.
-        </t>
-        <t>
-          Trailer fields are carried in a field block that also terminates the stream. That is,
-          trailer fields comprise a sequence starting with a <xref target="HEADERS"
-          format="none">HEADERS</xref> frame, followed by zero or more <xref target="CONTINUATION"
-          format="none">CONTINUATION</xref> frames, where the <xref target="HEADERS"
-          format="none">HEADERS</xref> frame bears an END_STREAM flag. Trailers MUST NOT include
+          carry any remaining fragments of the field block.</t>
+        <t>Other frames (from any stream) <bcp14>MUST NOT</bcp14> occur between the <xref target="HEADERS" format="none">HEADERS</xref> frame
+          and any <xref target="CONTINUATION" format="none">CONTINUATION</xref> frames that might follow.</t>
+        <t>HTTP/2 uses DATA frames to carry message content.  The <tt>chunked</tt> transfer encoding
+          defined in <xref target="HTTP11" section="7.1"/> cannot be used in HTTP/2; see <xref target="ConnectionSpecific"/>.</t>
+        <t>Trailer fields are carried in a field block that also terminates the stream. That is,
+          trailer fields comprise a sequence starting with a <xref target="HEADERS" format="none">HEADERS</xref> frame, followed by zero or more <xref target="CONTINUATION" format="none">CONTINUATION</xref> frames, where the <xref target="HEADERS" format="none">HEADERS</xref> frame bears an END_STREAM flag. Trailers <bcp14>MUST NOT</bcp14> include
           <xref target="PseudoHeaderFields">pseudo-header fields</xref>. An endpoint that receives
-          pseudo-header fields in trailers MUST treat the request or response as <xref
-          target="malformed">malformed</xref>.
-        </t>
-        <t>
-          An endpoint that receives a <xref target="HEADERS" format="none">HEADERS</xref> frame
-          without the END_STREAM flag set after receiving the <xref target="HEADERS"
-          format="none">HEADERS</xref> frame that opens a request or after receiving a final
-          (non-informational) status code MUST treat the corresponding request or response as <xref
-          target="malformed">malformed</xref>.
-        </t>
-        <t>
-          An HTTP request/response exchange fully consumes a single stream. A request starts with
+          pseudo-header fields in trailers <bcp14>MUST</bcp14> treat the request or response as <xref target="malformed">malformed</xref>.</t>
+        <t>An endpoint that receives a <xref target="HEADERS" format="none">HEADERS</xref> frame
+          without the END_STREAM flag set after receiving the <xref target="HEADERS" format="none">HEADERS</xref> frame that opens a request or after receiving a final
+          (non-informational) status code <bcp14>MUST</bcp14> treat the corresponding request or response as <xref target="malformed">malformed</xref>.</t>
+        <t>An HTTP request/response exchange fully consumes a single stream. A request starts with
           the <xref target="HEADERS" format="none">HEADERS</xref> frame that puts the stream into
           the "open" state. The request ends with a frame with the END_STREAM flag set, which causes the
           stream to become "half-closed (local)" for the client and "half-closed (remote)" for the
-          server. A response stream starts with zero or more interim responses in <xref
-          target="HEADERS" format="none">HEADERS</xref> frames, followed by a <xref target="HEADERS"
-          format="none">HEADERS</xref> frame containing a final status code.
-        </t>
-        <t>
-          An HTTP response is complete after the server sends -- or the client receives -- a frame
-          with the END_STREAM flag set (including any <xref target="CONTINUATION"
-          format="none">CONTINUATION</xref> frames needed to complete a field block). A server can
+          server. A response stream starts with zero or more interim responses in <xref target="HEADERS" format="none">HEADERS</xref> frames, followed by a <xref target="HEADERS" format="none">HEADERS</xref> frame containing a final status code.</t>
+        <t>An HTTP response is complete after the server sends -- or the client receives -- a frame
+          with the END_STREAM flag set (including any <xref target="CONTINUATION" format="none">CONTINUATION</xref> frames needed to complete a field block). A server can
           send a complete response prior to the client sending an entire request if the response
           does not depend on any portion of the request that has not been sent and received. When
-          this is true, a server MAY request that the client abort transmission of a request
+          this is true, a server <bcp14>MAY</bcp14> request that the client abort transmission of a request
           without error by sending a <xref target="RST_STREAM" format="none">RST_STREAM</xref> with
           an error code of <xref target="NO_ERROR" format="none">NO_ERROR</xref> after sending a
-          complete response (i.e., a frame with the END_STREAM flag set). Clients MUST NOT discard
-          responses as a result of receiving such a <xref target="RST_STREAM"
-          format="none">RST_STREAM</xref>, though clients can always discard responses at their
-          discretion for other reasons.
-        </t>
+          complete response (i.e., a frame with the END_STREAM flag set). Clients <bcp14>MUST NOT</bcp14> discard
+          responses as a result of receiving such a <xref target="RST_STREAM" format="none">RST_STREAM</xref>, though clients can always discard responses at their
+          discretion for other reasons.</t>
         <section anchor="malformed">
           <name>Malformed Messages</name>
-          <t>
-            A malformed request or response is one that is an otherwise valid sequence of HTTP/2
+          <t>A malformed request or response is one that is an otherwise valid sequence of HTTP/2
             frames but is invalid due to the presence of extraneous frames, prohibited fields or
             pseudo-header fields, the absence of mandatory pseudo-header fields, the inclusion of
             uppercase field names, or invalid field names and/or values (in certain circumstances;
-            see <xref target="HttpHeaders"/>).
-          </t>
-          <t>
-            A request or response that includes message content can include a
+            see <xref target="HttpHeaders"/>).</t>
+          <t>A request or response that includes message content can include a
             <tt>content-length</tt> header field. A request or response is also malformed if the
-            value of a <tt>content-length</tt> header field does not equal the sum of the <xref
-            target="DATA" format="none">DATA</xref> frame payload lengths that form the content,
+            value of a <tt>content-length</tt> header field does not equal the sum of the <xref target="DATA" format="none">DATA</xref> frame payload lengths that form the content,
             unless the message is defined as having no content.  For example, 204 or 304 responses
             contain no content, as does the response to a HEAD request.  A response that is defined
-            to have no content, as described in <xref target="HTTP" section="6.4.1"/>, MAY have a
+            to have no content, as described in <xref target="HTTP" section="6.4.1"/>, <bcp14>MAY</bcp14> have a
             non-zero <tt>content-length</tt> header field, even though no content is included in
-            <xref target="DATA" format="none">DATA</xref> frames.
-          </t>
-          <t>
-            Intermediaries that process HTTP requests or responses (i.e., any intermediary not
-            acting as a tunnel) MUST NOT forward a malformed request or response. Malformed
-            requests or responses that are detected MUST be treated as a <xref
-            target="StreamErrorHandler">stream error</xref> of type <xref target="PROTOCOL_ERROR"
-            format="none">PROTOCOL_ERROR</xref>.
-          </t>
-          <t>
-            For malformed requests, a server MAY send an HTTP response prior to closing or
-            resetting the stream.  Clients MUST NOT accept a malformed response.
-          </t>
-          <t>
-            Endpoints that progressively process messages might have performed some processing
+            <xref target="DATA" format="none">DATA</xref> frames.</t>
+          <t>Intermediaries that process HTTP requests or responses (i.e., any intermediary not
+            acting as a tunnel) <bcp14>MUST NOT</bcp14> forward a malformed request or response. Malformed
+            requests or responses that are detected <bcp14>MUST</bcp14> be treated as a <xref target="StreamErrorHandler">stream error</xref> of type <xref target="PROTOCOL_ERROR" format="none">PROTOCOL_ERROR</xref>.</t>
+          <t>For malformed requests, a server <bcp14>MAY</bcp14> send an HTTP response prior to closing or
+            resetting the stream.  Clients <bcp14>MUST NOT</bcp14> accept a malformed response.</t>
+          <t>Endpoints that progressively process messages might have performed some processing
             before identifying a request or response as malformed. For instance, it might be
             possible to generate an informational or 404 status code without having received a
             complete request. Similarly, intermediaries might forward incomplete messages before
-            detecting errors. A server MAY generate a final response before receiving an entire
+            detecting errors. A server <bcp14>MAY</bcp14> generate a final response before receiving an entire
             request when the response does not depend on the remainder of the request being
-            correct.
-          </t>
-          <t>
-            These requirements are intended to protect against several types of common attacks
+            correct.</t>
+          <t>These requirements are intended to protect against several types of common attacks
             against HTTP; they are deliberately strict because being permissive can expose
-            implementations to these vulnerabilities.
-          </t>
+            implementations to these vulnerabilities.</t>
         </section>
       </section>
       <section anchor="HttpHeaders">
         <name>HTTP Fields</name>
-        <t>
-          HTTP fields (<xref target="HTTP" section="5"/>) are conveyed by HTTP/2 in the HEADERS,
-          CONTINUATION, and PUSH_PROMISE frames, compressed with <xref target="COMPRESSION">HPACK</xref>.
-        </t>
-        <t>
-          Field names MUST be converted to lowercase when constructing an HTTP/2 message.
-        </t>
+        <t>HTTP fields (<xref target="HTTP" section="5"/>) are conveyed by HTTP/2 in the HEADERS,
+          CONTINUATION, and PUSH_PROMISE frames, compressed with <xref target="COMPRESSION">HPACK</xref>.</t>
+        <t>Field names <bcp14>MUST</bcp14> be converted to lowercase when constructing an HTTP/2 message.</t>
         <section>
           <name>Field Validity</name>
-          <t>
-            The definitions of field names and values in HTTP prohibit some characters that HPACK
-            might be able to convey.  HTTP/2 implementations SHOULD validate field names and values
-            according to their definitions in Sections <xref target="HTTP" section="5.1"
-            sectionFormat="bare"/> and <xref target="HTTP" section="5.5" sectionFormat="bare"/> of <xref
-            target="HTTP"/>, respectively, and treat messages that contain prohibited characters as
-            <xref target="malformed">malformed</xref>.
-          </t>
-          <t>
-            Failure to validate fields can be exploited for request smuggling attacks.  In
+          <t>The definitions of field names and values in HTTP prohibit some characters that HPACK
+            might be able to convey.  HTTP/2 implementations <bcp14>SHOULD</bcp14> validate field names and values
+            according to their definitions in Sections <xref target="HTTP" section="5.1" sectionFormat="bare"/> and <xref target="HTTP" section="5.5" sectionFormat="bare"/> of <xref target="HTTP"/>, respectively, and treat messages that contain prohibited characters as
+            <xref target="malformed">malformed</xref>.</t>
+          <t>Failure to validate fields can be exploited for request smuggling attacks.  In
             particular, unvalidated fields might enable attacks when messages are forwarded using
             <xref target="HTTP11">HTTP/1.1</xref>, where characters such as carriage return (CR), line feed (LF), and COLON are
-            used as delimiters.  Implementations MUST perform the following minimal validation of
-            field names and values:
-          </t>
+            used as delimiters.  Implementations <bcp14>MUST</bcp14> perform the following minimal validation of
+            field names and values:</t>
           <ul>
-            <li>
-              A field name MUST NOT contain characters in the ranges 0x00-0x20, 0x41-0x5a, or
+            <li>A field name <bcp14>MUST NOT</bcp14> contain characters in the ranges 0x00-0x20, 0x41-0x5a, or
               0x7f-0xff (all ranges inclusive).  This specifically excludes all non-visible ASCII
               characters, ASCII SP (0x20), and uppercase characters ('A' to 'Z', ASCII 0x41 to
-              0x5a).
-            </li>
-            <li>
-              With the exception of <xref target="PseudoHeaderFields">pseudo-header fields</xref>,
-              which have a name that starts with a single colon, field names MUST NOT include a
-              colon (ASCII COLON, 0x3a).
-            </li>
-            <li>
-              A field value MUST NOT contain the zero value (ASCII NUL, 0x00), line feed (ASCII LF,
-              0x0a), or carriage return (ASCII CR, 0x0d) at any position.
-            </li>
-            <li>
-              A field value MUST NOT start or end with an ASCII whitespace character (ASCII SP or
-              HTAB, 0x20 or 0x09).
-            </li>
+              0x5a).</li>
+            <li>With the exception of <xref target="PseudoHeaderFields">pseudo-header fields</xref>,
+              which have a name that starts with a single colon, field names <bcp14>MUST NOT</bcp14> include a
+              colon (ASCII COLON, 0x3a).</li>
+            <li>A field value <bcp14>MUST NOT</bcp14> contain the zero value (ASCII NUL, 0x00), line feed (ASCII LF,
+              0x0a), or carriage return (ASCII CR, 0x0d) at any position.</li>
+            <li>A field value <bcp14>MUST NOT</bcp14> start or end with an ASCII whitespace character (ASCII SP or
+              HTAB, 0x20 or 0x09).</li>
           </ul>
           <aside>
-          <t>
-            Note: An implementation that validates fields according to the definitions in Sections
-            <xref target="HTTP" section="5.1" sectionFormat="bare"/> and <xref target="HTTP"
-            section="5.5" sectionFormat="bare"/> of <xref target="HTTP"/> only needs an additional check
-            that field names do not include uppercase characters.
-          </t>
-        </aside>
-          <t>
-            A request or response that contains a field that violates any of these conditions MUST
+            <t>Note: An implementation that validates fields according to the definitions in Sections
+            <xref target="HTTP" section="5.1" sectionFormat="bare"/> and <xref target="HTTP" section="5.5" sectionFormat="bare"/> of <xref target="HTTP"/> only needs an additional check
+            that field names do not include uppercase characters.</t>
+          </aside>
+          <t>A request or response that contains a field that violates any of these conditions <bcp14>MUST</bcp14>
             be treated as <xref target="malformed">malformed</xref>.  In particular, an intermediary
-            that does not process fields when forwarding messages MUST NOT forward fields that
-            contain any of the values that are listed as prohibited above.
-          </t>
-          <t>
-            When a request message violates one of these requirements, an implementation SHOULD
+            that does not process fields when forwarding messages <bcp14>MUST NOT</bcp14> forward fields that
+            contain any of the values that are listed as prohibited above.</t>
+          <t>When a request message violates one of these requirements, an implementation <bcp14>SHOULD</bcp14>
             generate a 400 (Bad Request) status code (see <xref target="HTTP" section="15.5.1"/>),
             unless a more suitable status code is defined or the status code cannot be sent (e.g.,
-            because the error occurs in a trailer field).
-          </t>
+            because the error occurs in a trailer field).</t>
           <aside>
-            <t>
-              Note: Field values that are not valid according to the definition of the corresponding
-              field do not cause a request to be <xref target="malformed"
-              format="none">malformed</xref>; the requirements above only apply to the generic
-              syntax for fields as defined in <xref target="HTTP" section="5"/>.
-            </t>
+            <t>Note: Field values that are not valid according to the definition of the corresponding
+              field do not cause a request to be <xref target="malformed" format="none">malformed</xref>; the requirements above only apply to the generic
+              syntax for fields as defined in <xref target="HTTP" section="5"/>.</t>
           </aside>
         </section>
         <section anchor="ConnectionSpecific">
           <name>Connection-Specific Header Fields</name>
-          <t>
-            HTTP/2 does not use the <tt>Connection</tt> header field (<xref target="HTTP"
-            section="7.6.1"/>) to indicate connection-specific header fields; in this protocol,
-            connection-specific metadata is conveyed by other means.  An endpoint MUST NOT generate
+          <t>HTTP/2 does not use the <tt>Connection</tt> header field (<xref target="HTTP" section="7.6.1"/>) to indicate connection-specific header fields; in this protocol,
+            connection-specific metadata is conveyed by other means.  An endpoint <bcp14>MUST NOT</bcp14> generate
             an HTTP/2 message containing connection-specific header fields.  This includes the
             <tt>Connection</tt> header field and those listed as having connection-specific
             semantics in <xref target="HTTP" section="7.6.1"/> (that is, <tt>Proxy-Connection</tt>,
             <tt>Keep-Alive</tt>, <tt>Transfer-Encoding</tt>, and <tt>Upgrade</tt>).  Any message
-            containing connection-specific header fields MUST be treated as <xref
-            target="malformed">malformed</xref>.
-          </t>
-          <t>
-            The only exception to this is the TE header field, which MAY be present in an HTTP/2
-            request; when it is, it MUST NOT contain any value other than "trailers".
-          </t>
-          <t>
-            An intermediary transforming an HTTP/1.x message to HTTP/2 MUST remove connection-specific
+            containing connection-specific header fields <bcp14>MUST</bcp14> be treated as <xref target="malformed">malformed</xref>.</t>
+          <t>The only exception to this is the TE header field, which <bcp14>MAY</bcp14> be present in an HTTP/2
+            request; when it is, it <bcp14>MUST NOT</bcp14> contain any value other than "trailers".</t>
+          <t>An intermediary transforming an HTTP/1.x message to HTTP/2 <bcp14>MUST</bcp14> remove connection-specific
             header fields as discussed in <xref target="HTTP" section="7.6.1"/>,
-            or their messages will be treated by other HTTP/2 endpoints as <xref target="malformed">malformed</xref>.
-          </t>
+            or their messages will be treated by other HTTP/2 endpoints as <xref target="malformed">malformed</xref>.</t>
           <aside>
             <t>Note:
               HTTP/2 purposefully does not support upgrade to another protocol.  The handshake
               methods described in <xref target="starting"/> are believed sufficient to
-              negotiate the use of alternative protocols.
-            </t>
+              negotiate the use of alternative protocols.</t>
           </aside>
         </section>
         <section anchor="CompressCookie">
           <name>Compressing the Cookie Header Field</name>
-          <t>
-            The <xref target="COOKIE">Cookie header field</xref> uses a semicolon (";") to delimit
+          <t>The <xref target="COOKIE">Cookie header field</xref> uses a semicolon (";") to delimit
             cookie-pairs (or "crumbs").  This header field contains multiple values, but does not use
             a COMMA (",") as a separator, thereby preventing cookie-pairs from being sent on
             multiple field lines (see <xref target="HTTP" section="5.2"/>).  This can significantly
             reduce compression efficiency, as updates to individual cookie-pairs would invalidate any
-            field lines that are stored in the HPACK table.
-          </t>
-          <t>
-            To allow for better compression efficiency, the Cookie header field MAY be split into
+            field lines that are stored in the HPACK table.</t>
+          <t>To allow for better compression efficiency, the Cookie header field <bcp14>MAY</bcp14> be split into
             separate header fields, each with one or more cookie-pairs.  If there are multiple
-            Cookie header fields after decompression, these MUST be concatenated into a single
+            Cookie header fields after decompression, these <bcp14>MUST</bcp14> be concatenated into a single
             octet string using the two-octet delimiter of 0x3b, 0x20 (the ASCII string "; ")
             before being passed into a non-HTTP/2 context, such as an HTTP/1.1 connection, or a
-            generic HTTP server application.
-          </t>
-          <t keepWithNext="true">
-              Therefore, the following two lists of Cookie header fields are semantically
-              equivalent.
-          </t>
+            generic HTTP server application.</t>
+          <t keepWithNext="true">Therefore, the following two lists of Cookie header fields are semantically
+              equivalent.</t>
           <artwork type="inline"><![CDATA[
 cookie: a=b; c=d; e=f
 
@@ -3041,493 +2131,321 @@ cookie: e=f
       </section>
       <section anchor="PseudoHeaderFields">
         <name>HTTP Control Data</name>
-        <t>
-          HTTP/2 uses special pseudo-header fields beginning with a ':' character (ASCII 0x3a) to
-          convey message control data (see <xref target="HTTP" section="6.2"/>).
-        </t>
-        <t>
-          Pseudo-header fields are not HTTP header fields.  Endpoints MUST NOT generate
+        <t>HTTP/2 uses special pseudo-header fields beginning with a ':' character (ASCII 0x3a) to
+          convey message control data (see <xref target="HTTP" section="6.2"/>).</t>
+        <t>Pseudo-header fields are not HTTP header fields.  Endpoints <bcp14>MUST NOT</bcp14> generate
           pseudo-header fields other than those defined in this document.  Note that an
           extension could negotiate the use of additional pseudo-header fields; see
-          <xref target="extensibility"/>.
-        </t>
-        <t>
-          Pseudo-header fields are only valid in the context in which they are defined.
-          Pseudo-header fields defined for requests MUST NOT appear in responses; pseudo-header
-          fields defined for responses MUST NOT appear in requests.  Pseudo-header fields MUST
-          NOT appear in a trailer section.  Endpoints MUST treat a request or response that contains
-          undefined or invalid pseudo-header fields as <xref target="malformed">malformed</xref>.
-        </t>
-        <t>
-          All pseudo-header fields MUST appear in a field block before all regular field lines.
+          <xref target="extensibility"/>.</t>
+        <t>Pseudo-header fields are only valid in the context in which they are defined.
+          Pseudo-header fields defined for requests <bcp14>MUST NOT</bcp14> appear in responses; pseudo-header
+          fields defined for responses <bcp14>MUST NOT</bcp14> appear in requests.  Pseudo-header fields <bcp14>MUST
+          NOT</bcp14> appear in a trailer section.  Endpoints <bcp14>MUST</bcp14> treat a request or response that contains
+          undefined or invalid pseudo-header fields as <xref target="malformed">malformed</xref>.</t>
+        <t>All pseudo-header fields <bcp14>MUST</bcp14> appear in a field block before all regular field lines.
           Any request or response that contains a pseudo-header field that appears in a field
-          block after a regular field line MUST be treated as <xref target="malformed">malformed</xref>.
-        </t>
-        <t>
-          The same pseudo-header field name MUST NOT appear more than once in a field block. A
+          block after a regular field line <bcp14>MUST</bcp14> be treated as <xref target="malformed">malformed</xref>.</t>
+        <t>The same pseudo-header field name <bcp14>MUST NOT</bcp14> appear more than once in a field block. A
           field block for an HTTP request or response that contains a repeated pseudo-header field
-          name MUST be treated as <xref target="malformed">malformed</xref>.
-        </t>
+          name <bcp14>MUST</bcp14> be treated as <xref target="malformed">malformed</xref>.</t>
         <section anchor="HttpRequest">
           <name>Request Pseudo-Header Fields</name>
-          <t>
-            The following pseudo-header fields are defined for HTTP/2 requests:
-          </t>
+          <t>The following pseudo-header fields are defined for HTTP/2 requests:</t>
           <ul spacing="normal">
             <li>
-              <t>
-                  The "<tt>:method</tt>" pseudo-header field includes the HTTP
-                  method (<xref target="HTTP" section="9"/>).
-              </t>
+              <t>The "<tt>:method</tt>" pseudo-header field includes the HTTP
+                  method (<xref target="HTTP" section="9"/>).</t>
             </li>
             <li>
-              <t>
-                The "<tt>:scheme</tt>" pseudo-header field includes the scheme portion of the request
-                target. The scheme is taken from the target URI (<xref target="RFC3986"
-                section="3.1"/>) when generating a request directly, or from the scheme of a
+              <t>The "<tt>:scheme</tt>" pseudo-header field includes the scheme portion of the request
+                target. The scheme is taken from the target URI (<xref target="RFC3986" section="3.1"/>) when generating a request directly, or from the scheme of a
                 translated request (for example, see <xref target="HTTP11" section="3.3"/>). Scheme
-                is omitted for <xref target="CONNECT">CONNECT requests</xref>.
-              </t>
+                is omitted for <xref target="CONNECT">CONNECT requests</xref>.</t>
               <t>"<tt>:scheme</tt>" is not restricted to "<tt>http</tt>" and "<tt>https</tt>" schemed
                 URIs.  A proxy or gateway can translate requests for non-HTTP schemes, enabling
-                the use of HTTP to interact with non-HTTP services.
-              </t>
+                the use of HTTP to interact with non-HTTP services.</t>
             </li>
             <li>
-              <t>
-                The "<tt>:authority</tt>" pseudo-header field conveys the authority portion (<xref
-                target="RFC3986" section="3.2"/>) of the target URI (<xref target="HTTP"
-                section="7.1"/>). The recipient of a HTTP/2 request MUST NOT use the <tt>Host</tt>
-                header field to determine the target URI if "<tt>:authority</tt>" is present.
-              </t>
-              <t>
-                Clients that generate HTTP/2 requests directly MUST use the "<tt>:authority</tt>"
+              <t>The "<tt>:authority</tt>" pseudo-header field conveys the authority portion (<xref target="RFC3986" section="3.2"/>) of the target URI (<xref target="HTTP" section="7.1"/>). The recipient of a HTTP/2 request <bcp14>MUST NOT</bcp14> use the <tt>Host</tt>
+                header field to determine the target URI if "<tt>:authority</tt>" is present.</t>
+              <t>Clients that generate HTTP/2 requests directly <bcp14>MUST</bcp14> use the "<tt>:authority</tt>"
                 pseudo-header field to convey authority information, unless there is no authority
-                information to convey (in which case it MUST NOT generate "<tt>:authority</tt>").
-              </t>
-              <t>
-                Clients MUST NOT generate a request with a <tt>Host</tt> header field that differs
+                information to convey (in which case it <bcp14>MUST NOT</bcp14> generate "<tt>:authority</tt>").</t>
+              <t>Clients <bcp14>MUST NOT</bcp14> generate a request with a <tt>Host</tt> header field that differs
                 from the "<tt>:authority</tt>" pseudo-header field.  A
-                server SHOULD treat a request as malformed if it contains a <tt>Host</tt> header
+                server <bcp14>SHOULD</bcp14> treat a request as malformed if it contains a <tt>Host</tt> header
                 field that identifies an entity that differs from the entity in the "<tt>:authority</tt>" pseudo-header
-                field.  The values of fields need to be normalized to compare them (see <xref
-                target="RFC3986" section="6.2"/>).  An origin server can apply any normalization
-                method, whereas other servers MUST perform scheme-based normalization (see <xref
-                target="RFC3986" section="6.2.3"/>) of the two fields.
-              </t>
-              <t>
-                An intermediary that forwards a request over HTTP/2 MUST construct an
+                field.  The values of fields need to be normalized to compare them (see <xref target="RFC3986" section="6.2"/>).  An origin server can apply any normalization
+                method, whereas other servers <bcp14>MUST</bcp14> perform scheme-based normalization (see <xref target="RFC3986" section="6.2.3"/>) of the two fields.</t>
+              <t>An intermediary that forwards a request over HTTP/2 <bcp14>MUST</bcp14> construct an
                 "<tt>:authority</tt>" pseudo-header field using the authority information from the
                 control data of the original request, unless the original request's target URI
-                does not contain authority information (in which case it MUST NOT generate
+                does not contain authority information (in which case it <bcp14>MUST NOT</bcp14> generate
                 "<tt>:authority</tt>"). Note that the <tt>Host</tt> header field is not the sole
-                source of this information; see <xref target="HTTP" section="7.2"/>.
-              </t>
-              <t>
-                An intermediary that needs to generate a <tt>Host</tt> header field (which might be
-                necessary to construct an HTTP/1.1 request) MUST use the value from the "<tt>:authority</tt>"
+                source of this information; see <xref target="HTTP" section="7.2"/>.</t>
+              <t>An intermediary that needs to generate a <tt>Host</tt> header field (which might be
+                necessary to construct an HTTP/1.1 request) <bcp14>MUST</bcp14> use the value from the "<tt>:authority</tt>"
                 pseudo-header field as the value of the <tt>Host</tt> field,
                 unless the intermediary also changes the request target. This replaces any existing
-                <tt>Host</tt> field to avoid potential vulnerabilities in HTTP routing.
-              </t>
-              <t>
-                An intermediary that forwards a request over HTTP/2 MAY retain any <tt>Host</tt>
-                header field.
-              </t>
-              <t>
-                Note that request targets for CONNECT or asterisk-form OPTIONS requests never
-                include authority information; see Sections <xref target="HTTP" section="7.1"
-                sectionFormat="bare"/> and <xref target="HTTP" section="7.2" sectionFormat="bare"/>
-                of <xref target="HTTP"/>.
-              </t>
-              <t>
-                "<tt>:authority</tt>" MUST NOT include the deprecated userinfo subcomponent for
-                "<tt>http</tt>" or "<tt>https</tt>" schemed URIs.
-              </t>
+                <tt>Host</tt> field to avoid potential vulnerabilities in HTTP routing.</t>
+              <t>An intermediary that forwards a request over HTTP/2 <bcp14>MAY</bcp14> retain any <tt>Host</tt>
+                header field.</t>
+              <t>Note that request targets for CONNECT or asterisk-form OPTIONS requests never
+                include authority information; see Sections <xref target="HTTP" section="7.1" sectionFormat="bare"/> and <xref target="HTTP" section="7.2" sectionFormat="bare"/>
+                of <xref target="HTTP"/>.</t>
+              <t>"<tt>:authority</tt>" <bcp14>MUST NOT</bcp14> include the deprecated userinfo subcomponent for
+                "<tt>http</tt>" or "<tt>https</tt>" schemed URIs.</t>
             </li>
             <li>
-              <t>
-                  The "<tt>:path</tt>" pseudo-header field includes the path and
+              <t>The "<tt>:path</tt>" pseudo-header field includes the path and
                   query parts of the target URI (the <tt>absolute-path</tt>
                   production and, optionally, a '?' character followed by the
                   <tt>query</tt> production; see <xref target="HTTP" section="4.1"/>).
                   A request in asterisk form (for OPTIONS) includes the value '*' for the
-                  "<tt>:path</tt>" pseudo-header field.
-              </t>
-              <t>
-                  This pseudo-header field MUST NOT be empty for "<tt>http</tt>" or "<tt>https</tt>"
+                  "<tt>:path</tt>" pseudo-header field.</t>
+              <t>This pseudo-header field <bcp14>MUST NOT</bcp14> be empty for "<tt>http</tt>" or "<tt>https</tt>"
                   URIs; "<tt>http</tt>" or "<tt>https</tt>" URIs that do not contain a path component
-                  MUST include a value of '/'. The exceptions to this rule are:
-              </t>
+                  <bcp14>MUST</bcp14> include a value of '/'. The exceptions to this rule are:</t>
               <ul>
-                <li>
-                  an OPTIONS request for an "<tt>http</tt>" or "<tt>https</tt>" URI that does not include a path
-                  component; these MUST include a "<tt>:path</tt>" pseudo-header field with a value
-                  of '*' (see <xref target="HTTP" section="7.1"/>).
-                </li>
-                <li>
-                  <xref target="CONNECT">CONNECT requests</xref>, where the "<tt>:path</tt>" pseudo-header field is omitted.
-                </li>
+                <li>an OPTIONS request for an "<tt>http</tt>" or "<tt>https</tt>" URI that does not include a path
+                  component; these <bcp14>MUST</bcp14> include a "<tt>:path</tt>" pseudo-header field with a value
+                  of '*' (see <xref target="HTTP" section="7.1"/>).</li>
+                <li><xref target="CONNECT">CONNECT requests</xref>, where the "<tt>:path</tt>" pseudo-header field is omitted.</li>
               </ul>
             </li>
           </ul>
-          <t>
-            All HTTP/2 requests MUST include exactly one valid value for the "<tt>:method</tt>",
-            "<tt>:scheme</tt>", and "<tt>:path</tt>" pseudo-header fields, unless they are <xref
-            target="CONNECT">CONNECT requests</xref>. An HTTP request that omits mandatory
-            pseudo-header fields is <xref target="malformed">malformed</xref>.
-          </t>
-          <t>
-            Individual HTTP/2 requests do not carry an explicit indicator of protocol version.
+          <t>All HTTP/2 requests <bcp14>MUST</bcp14> include exactly one valid value for the "<tt>:method</tt>",
+            "<tt>:scheme</tt>", and "<tt>:path</tt>" pseudo-header fields, unless they are <xref target="CONNECT">CONNECT requests</xref>. An HTTP request that omits mandatory
+            pseudo-header fields is <xref target="malformed">malformed</xref>.</t>
+          <t>Individual HTTP/2 requests do not carry an explicit indicator of protocol version.
             All HTTP/2 requests implicitly have a protocol version of "2.0" (see
-            <xref target="HTTP" section="6.2"/>).
-          </t>
+            <xref target="HTTP" section="6.2"/>).</t>
         </section>
         <section anchor="HttpResponse">
           <name>Response Pseudo-Header Fields</name>
-          <t>
-            For HTTP/2 responses, a single "<tt>:status</tt>" pseudo-header
+          <t>For HTTP/2 responses, a single "<tt>:status</tt>" pseudo-header
             field is defined that carries the HTTP status code field (see
-            <xref target="HTTP" section="15"/>). This pseudo-header field MUST be included in all
+            <xref target="HTTP" section="15"/>). This pseudo-header field <bcp14>MUST</bcp14> be included in all
             responses, including interim responses; otherwise, the response is
-            <xref target="malformed">malformed</xref>.
-          </t>
-          <t>
-            HTTP/2 responses implicitly have a protocol version of "2.0".
-          </t>
+            <xref target="malformed">malformed</xref>.</t>
+          <t>HTTP/2 responses implicitly have a protocol version of "2.0".</t>
         </section>
       </section>
       <section anchor="PushResources">
         <name>Server Push</name>
-        <t>
-          HTTP/2 allows a server to preemptively send (or "push") responses (along with
+        <t>HTTP/2 allows a server to preemptively send (or "push") responses (along with
           corresponding "promised" requests) to a client in association with a previous
-          client-initiated request.
-        </t>
-        <t>
-          Server push was designed to allow a server to improve client-perceived performance by
+          client-initiated request.</t>
+        <t>Server push was designed to allow a server to improve client-perceived performance by
           predicting what requests will follow those that it receives, thereby removing a round
           trip for them. For example, a request for HTML is often followed by requests
           for stylesheets and scripts referenced by that page. When these requests
           are pushed, the client does not need to wait to receive the references to them in the HTML
-          and issue separate requests.
-        </t>
-        <t>
-          In practice, server push is difficult to use effectively, because it requires the
+          and issue separate requests.</t>
+        <t>In practice, server push is difficult to use effectively, because it requires the
           server to correctly anticipate the additional requests the client will make, taking into
           account factors such as caching, content negotiation, and user behavior. Errors in
           prediction can lead to performance degradation, due to the opportunity cost that the
           additional data on the wire represents. In particular, pushing any significant amount of
-          data can cause contention issues with responses that are more important.
-        </t>
-        <t>
-          A client can request that server push be disabled, though this is negotiated for each hop
-          independently. The <xref target="SETTINGS_ENABLE_PUSH"
-          format="none">SETTINGS_ENABLE_PUSH</xref> setting can be set to 0 to indicate that server
-          push is disabled.
-        </t>
-        <t>
-          Promised requests MUST be safe (see <xref target="HTTP" section="9.2.1"/>) and cacheable
+          data can cause contention issues with responses that are more important.</t>
+        <t>A client can request that server push be disabled, though this is negotiated for each hop
+          independently. The <xref target="SETTINGS_ENABLE_PUSH" format="none">SETTINGS_ENABLE_PUSH</xref> setting can be set to 0 to indicate that server
+          push is disabled.</t>
+        <t>Promised requests <bcp14>MUST</bcp14> be safe (see <xref target="HTTP" section="9.2.1"/>) and cacheable
           (see <xref target="HTTP" section="9.2.3"/>). Promised requests cannot include any content
           or a trailer section. Clients that receive a promised request that is not cacheable, that
-          is not known to be safe, or that indicates the presence of request content MUST reset the
+          is not known to be safe, or that indicates the presence of request content <bcp14>MUST</bcp14> reset the
           promised stream with a <xref target="StreamErrorHandler">stream error</xref> of type
           <xref target="PROTOCOL_ERROR" format="none">PROTOCOL_ERROR</xref>. Note that this could result
           in the promised stream being reset if the client does not recognize a newly defined
-          method as being safe.
-        </t>
-        <t>
-          Pushed responses that are cacheable (see <xref target="CACHE" section="3"/>) can be
+          method as being safe.</t>
+        <t>Pushed responses that are cacheable (see <xref target="CACHE" section="3"/>) can be
           stored by the client, if it implements an HTTP cache. Pushed responses are considered
           successfully validated on the origin server (e.g., if the "no-cache" cache response
           directive is present; see <xref target="CACHE" section="5.2.2.4"/>) while the stream
-          identified by the promised stream identifier is still open.
-        </t>
-        <t>
-          Pushed responses that are not cacheable MUST NOT be stored by any HTTP cache. They MAY
-          be made available to the application separately.
-        </t>
-        <t>
-          The server MUST include a value in the "<tt>:authority</tt>" pseudo-header field for which
-          the server is authoritative (see <xref target="authority"/>). A client MUST treat a <xref
-          target="PUSH_PROMISE" format="none">PUSH_PROMISE</xref> for which the server is not
-          authoritative as a <xref target="StreamErrorHandler">stream error</xref> of type <xref
-          target="PROTOCOL_ERROR" format="none">PROTOCOL_ERROR</xref>.
-        </t>
-        <t>
-          An intermediary can receive pushes from the server and choose not to forward them on to
+          identified by the promised stream identifier is still open.</t>
+        <t>Pushed responses that are not cacheable <bcp14>MUST NOT</bcp14> be stored by any HTTP cache. They <bcp14>MAY</bcp14>
+          be made available to the application separately.</t>
+        <t>The server <bcp14>MUST</bcp14> include a value in the "<tt>:authority</tt>" pseudo-header field for which
+          the server is authoritative (see <xref target="authority"/>). A client <bcp14>MUST</bcp14> treat a <xref target="PUSH_PROMISE" format="none">PUSH_PROMISE</xref> for which the server is not
+          authoritative as a <xref target="StreamErrorHandler">stream error</xref> of type <xref target="PROTOCOL_ERROR" format="none">PROTOCOL_ERROR</xref>.</t>
+        <t>An intermediary can receive pushes from the server and choose not to forward them on to
           the client. In other words, how to make use of the pushed information is up to that
           intermediary. Equally, the intermediary might choose to make additional pushes to the
-          client, without any action taken by the server.
-        </t>
-        <t>
-          A client cannot push. Thus, servers MUST treat the receipt of a <xref
-          target="PUSH_PROMISE" format="none">PUSH_PROMISE</xref> frame as a <xref
-          target="ConnectionErrorHandler">connection error</xref> of type <xref
-          target="PROTOCOL_ERROR" format="none">PROTOCOL_ERROR</xref>. A server cannot set the
+          client, without any action taken by the server.</t>
+        <t>A client cannot push. Thus, servers <bcp14>MUST</bcp14> treat the receipt of a <xref target="PUSH_PROMISE" format="none">PUSH_PROMISE</xref> frame as a <xref target="ConnectionErrorHandler">connection error</xref> of type <xref target="PROTOCOL_ERROR" format="none">PROTOCOL_ERROR</xref>. A server cannot set the
           <xref target="SETTINGS_ENABLE_PUSH" format="none">SETTINGS_ENABLE_PUSH</xref> setting to
-          a value other than 0 (see <xref target="SettingValues"/>).
-        </t>
+          a value other than 0 (see <xref target="SettingValues"/>).</t>
         <section anchor="PushRequests">
           <name>Push Requests</name>
-          <t>
-            Server push is semantically equivalent to a server responding to a request; however, in
+          <t>Server push is semantically equivalent to a server responding to a request; however, in
             this case, that request is also sent by the server, as a <xref target="PUSH_PROMISE" format="none">PUSH_PROMISE</xref>
-            frame.
-          </t>
-          <t>
-            The <xref target="PUSH_PROMISE" format="none">PUSH_PROMISE</xref> frame includes a
+            frame.</t>
+          <t>The <xref target="PUSH_PROMISE" format="none">PUSH_PROMISE</xref> frame includes a
             field block that contains control data and a complete
             set of request header fields that the server attributes to the request. It is not
-            possible to push a response to a request that includes message content.
-          </t>
-          <t>
-            Promised requests are always associated with an explicit request from the client. The
+            possible to push a response to a request that includes message content.</t>
+          <t>Promised requests are always associated with an explicit request from the client. The
             <xref target="PUSH_PROMISE" format="none">PUSH_PROMISE</xref> frames sent by the server are sent on that explicit
             request's stream. The <xref target="PUSH_PROMISE" format="none">PUSH_PROMISE</xref> frame also includes a promised stream
-            identifier, chosen from the stream identifiers available to the server (see <xref target="StreamIdentifiers"/>).
-          </t>
-          <t>
-            The header fields in <xref target="PUSH_PROMISE" format="none">PUSH_PROMISE</xref> and
-            any subsequent <xref target="CONTINUATION" format="none">CONTINUATION</xref> frames MUST
+            identifier, chosen from the stream identifiers available to the server (see <xref target="StreamIdentifiers"/>).</t>
+          <t>The header fields in <xref target="PUSH_PROMISE" format="none">PUSH_PROMISE</xref> and
+            any subsequent <xref target="CONTINUATION" format="none">CONTINUATION</xref> frames <bcp14>MUST</bcp14>
             be a valid and complete set of <xref target="HttpRequest">request header
-            fields</xref>. The server MUST include a method in the "<tt>:method</tt>" pseudo-header
-            field that is safe and cacheable. If a client receives a <xref target="PUSH_PROMISE"
-            format="none">PUSH_PROMISE</xref> that does not include a complete and valid set of
+            fields</xref>. The server <bcp14>MUST</bcp14> include a method in the "<tt>:method</tt>" pseudo-header
+            field that is safe and cacheable. If a client receives a <xref target="PUSH_PROMISE" format="none">PUSH_PROMISE</xref> that does not include a complete and valid set of
             header fields or the "<tt>:method</tt>" pseudo-header field identifies a method that is
-            not safe, it MUST respond on the promised stream with a <xref
-            target="StreamErrorHandler">stream error</xref> of type <xref target="PROTOCOL_ERROR"
-            format="none">PROTOCOL_ERROR</xref>.
-          </t>
-          <t>
-            The server SHOULD send <xref target="PUSH_PROMISE" format="none">PUSH_PROMISE</xref>
+            not safe, it <bcp14>MUST</bcp14> respond on the promised stream with a <xref target="StreamErrorHandler">stream error</xref> of type <xref target="PROTOCOL_ERROR" format="none">PROTOCOL_ERROR</xref>.</t>
+          <t>The server <bcp14>SHOULD</bcp14> send <xref target="PUSH_PROMISE" format="none">PUSH_PROMISE</xref>
             (<xref target="PUSH_PROMISE"/>) frames prior to sending any frames that reference the
             promised responses. This avoids a race where clients issue requests prior to receiving
-            any <xref target="PUSH_PROMISE" format="none">PUSH_PROMISE</xref> frames.
-          </t>
-          <t>
-            For example, if the server receives a request for a document containing embedded links
+            any <xref target="PUSH_PROMISE" format="none">PUSH_PROMISE</xref> frames.</t>
+          <t>For example, if the server receives a request for a document containing embedded links
             to multiple image files and the server chooses to push those additional images to the
             client, sending <xref target="PUSH_PROMISE" format="none">PUSH_PROMISE</xref> frames
             before the <xref target="DATA" format="none">DATA</xref> frames that contain the image
             links ensures that the client is able to see that a resource will be pushed before
             discovering embedded links. Similarly, if the server pushes resources referenced by the
-            field block (for instance, in Link header fields), sending a <xref
-            target="PUSH_PROMISE" format="none">PUSH_PROMISE</xref> before sending the header
-            ensures that clients do not request those resources.
-          </t>
-          <t><xref target="PUSH_PROMISE" format="none">PUSH_PROMISE</xref> frames MUST NOT be sent by the client.
-          </t>
+            field block (for instance, in Link header fields), sending a <xref target="PUSH_PROMISE" format="none">PUSH_PROMISE</xref> before sending the header
+            ensures that clients do not request those resources.</t>
+          <t><xref target="PUSH_PROMISE" format="none">PUSH_PROMISE</xref> frames <bcp14>MUST NOT</bcp14> be sent by the client.</t>
           <t><xref target="PUSH_PROMISE" format="none">PUSH_PROMISE</xref> frames can be sent by the server on any
-            client-initiated stream, but the stream MUST be in either the "open" or "half-closed
+            client-initiated stream, but the stream <bcp14>MUST</bcp14> be in either the "open" or "half-closed
             (remote)" state with respect to the server.  <xref target="PUSH_PROMISE" format="none">PUSH_PROMISE</xref> frames are
             interspersed with the frames that comprise a response, though they cannot be
             interspersed with <xref target="HEADERS" format="none">HEADERS</xref> and <xref target="CONTINUATION" format="none">CONTINUATION</xref> frames that
-            comprise a single field block.
-          </t>
-          <t>
-            Sending a <xref target="PUSH_PROMISE" format="none">PUSH_PROMISE</xref> frame creates a new stream and puts the stream
+            comprise a single field block.</t>
+          <t>Sending a <xref target="PUSH_PROMISE" format="none">PUSH_PROMISE</xref> frame creates a new stream and puts the stream
             into the "reserved (local)" state for the server and the "reserved (remote)" state for
-            the client.
-          </t>
+            the client.</t>
         </section>
         <section anchor="PushResponses">
           <name>Push Responses</name>
-          <t>
-            After sending the <xref target="PUSH_PROMISE" format="none">PUSH_PROMISE</xref> frame,
-            the server can begin delivering the pushed response as a <xref
-            target="HttpResponse">response</xref> on a server-initiated stream that uses the
+          <t>After sending the <xref target="PUSH_PROMISE" format="none">PUSH_PROMISE</xref> frame,
+            the server can begin delivering the pushed response as a <xref target="HttpResponse">response</xref> on a server-initiated stream that uses the
             promised stream identifier. The server uses this stream to transmit an HTTP response,
             using the same sequence of frames as that defined in <xref target="HttpFraming"/>. This
             stream becomes <xref target="StreamStates">"half-closed" to the client</xref> after the
-            initial <xref target="HEADERS" format="none">HEADERS</xref> frame is sent.
-          </t>
-          <t>
-            Once a client receives a <xref target="PUSH_PROMISE" format="none">PUSH_PROMISE</xref> frame and chooses to accept the
-            pushed response, the client SHOULD NOT issue any requests for the promised response
-            until after the promised stream has closed.
-          </t>
-          <t>
-            If the client determines, for any reason, that it does not wish to receive the pushed
+            initial <xref target="HEADERS" format="none">HEADERS</xref> frame is sent.</t>
+          <t>Once a client receives a <xref target="PUSH_PROMISE" format="none">PUSH_PROMISE</xref> frame and chooses to accept the
+            pushed response, the client <bcp14>SHOULD NOT</bcp14> issue any requests for the promised response
+            until after the promised stream has closed.</t>
+          <t>If the client determines, for any reason, that it does not wish to receive the pushed
             response from the server or if the server takes too long to begin sending the promised
-            response, the client can send a <xref target="RST_STREAM"
-            format="none">RST_STREAM</xref> frame, using either the <xref target="CANCEL"
-            format="none">CANCEL</xref> or <xref target="REFUSED_STREAM"
-            format="none">REFUSED_STREAM</xref> code and referencing the pushed stream's identifier.
-          </t>
-          <t>
-            A client can use the <xref target="SETTINGS_MAX_CONCURRENT_STREAMS"
-            format="none">SETTINGS_MAX_CONCURRENT_STREAMS</xref> setting to limit the number of
-            responses that can be concurrently pushed by a server. Advertising a <xref
-            target="SETTINGS_MAX_CONCURRENT_STREAMS"
-            format="none">SETTINGS_MAX_CONCURRENT_STREAMS</xref> value of zero prevents the server
+            response, the client can send a <xref target="RST_STREAM" format="none">RST_STREAM</xref> frame, using either the <xref target="CANCEL" format="none">CANCEL</xref> or <xref target="REFUSED_STREAM" format="none">REFUSED_STREAM</xref> code and referencing the pushed stream's identifier.</t>
+          <t>A client can use the <xref target="SETTINGS_MAX_CONCURRENT_STREAMS" format="none">SETTINGS_MAX_CONCURRENT_STREAMS</xref> setting to limit the number of
+            responses that can be concurrently pushed by a server. Advertising a <xref target="SETTINGS_MAX_CONCURRENT_STREAMS" format="none">SETTINGS_MAX_CONCURRENT_STREAMS</xref> value of zero prevents the server
             from opening the streams necessary to push responses. However, this does not prevent the
-            server from reserving streams using <xref target="PUSH_PROMISE"
-            format="none">PUSH_PROMISE</xref> frames, because reserved streams do not count toward
+            server from reserving streams using <xref target="PUSH_PROMISE" format="none">PUSH_PROMISE</xref> frames, because reserved streams do not count toward
             the concurrent stream limit. Clients that do not wish to receive pushed resources need
-            to reset any unwanted reserved streams or set <xref target="SETTINGS_ENABLE_PUSH"
-            format="none">SETTINGS_ENABLE_PUSH</xref> to 0.
-          </t>
-          <t>
-            Clients receiving a pushed response MUST validate that either the server is
+            to reset any unwanted reserved streams or set <xref target="SETTINGS_ENABLE_PUSH" format="none">SETTINGS_ENABLE_PUSH</xref> to 0.</t>
+          <t>Clients receiving a pushed response <bcp14>MUST</bcp14> validate that either the server is
             authoritative (see <xref target="authority"/>) or the proxy that provided the pushed
             response is configured for the corresponding request. For example, a server that offers
             a certificate for only the <tt>example.com</tt> DNS-ID (see <xref target="RFC6125"/>)
-            is not permitted to push a response for &lt;<tt>https://www.example.org/doc</tt>&gt;.
-          </t>
-          <t>
-            The response for a <xref target="PUSH_PROMISE" format="none">PUSH_PROMISE</xref> stream begins with a
+            is not permitted to push a response for &lt;<tt>https://www.example.org/doc</tt>&gt;.</t>
+          <t>The response for a <xref target="PUSH_PROMISE" format="none">PUSH_PROMISE</xref> stream begins with a
             <xref target="HEADERS" format="none">HEADERS</xref> frame, which immediately puts the stream into the "half-closed
             (remote)" state for the server and "half-closed (local)" state for the client, and ends
-            with a frame with the END_STREAM flag set, which places the stream in the "closed" state.
-          </t>
+            with a frame with the END_STREAM flag set, which places the stream in the "closed" state.</t>
           <aside>
             <t>Note:
-              The client never sends a frame with the END_STREAM flag set for a server push.
-            </t>
+              The client never sends a frame with the END_STREAM flag set for a server push.</t>
           </aside>
         </section>
       </section>
       <section anchor="CONNECT">
         <name>The CONNECT Method</name>
-        <t>
-          The CONNECT method (<xref target="HTTP" section="9.3.6"/>) is
+        <t>The CONNECT method (<xref target="HTTP" section="9.3.6"/>) is
           used to convert an HTTP connection into a tunnel to a remote host.
           CONNECT is primarily used with HTTP proxies to establish a TLS session with an origin
-          server for the purposes of interacting with "<tt>https</tt>" resources.
-        </t>
-        <t>
-          In HTTP/2, the CONNECT method establishes a tunnel over a single HTTP/2 stream to a
+          server for the purposes of interacting with "<tt>https</tt>" resources.</t>
+        <t>In HTTP/2, the CONNECT method establishes a tunnel over a single HTTP/2 stream to a
           remote host, rather than converting the entire connection to a tunnel. A CONNECT header
-          section is constructed as defined in <xref target="HttpRequest"/> ("<xref
-          target="HttpRequest" format="title"/>"), with a few differences. Specifically:
-        </t>
+          section is constructed as defined in <xref target="HttpRequest"/> ("<xref target="HttpRequest" format="title"/>"), with a few differences. Specifically:</t>
         <ul spacing="normal">
-          <li>
-              The "<tt>:method</tt>" pseudo-header field is set to <tt>CONNECT</tt>.
-            </li>
-          <li>
-              The "<tt>:scheme</tt>" and "<tt>:path</tt>" pseudo-header
-              fields MUST be omitted.
-            </li>
-          <li>
-              The "<tt>:authority</tt>" pseudo-header field contains the host and port to
+          <li>The "<tt>:method</tt>" pseudo-header field is set to <tt>CONNECT</tt>.</li>
+          <li>The "<tt>:scheme</tt>" and "<tt>:path</tt>" pseudo-header
+              fields <bcp14>MUST</bcp14> be omitted.</li>
+          <li>The "<tt>:authority</tt>" pseudo-header field contains the host and port to
               connect to (equivalent to the authority-form of the request-target of CONNECT
-              requests; see <xref target="HTTP11" section="3.2.3"/>).
-            </li>
+              requests; see <xref target="HTTP11" section="3.2.3"/>).</li>
         </ul>
-        <t>
-          A CONNECT request that does not conform to these restrictions is <xref target="malformed">malformed</xref>.
-        </t>
-        <t>
-          A proxy that supports CONNECT establishes a <xref target="TCP">TCP connection</xref> to
+        <t>A CONNECT request that does not conform to these restrictions is <xref target="malformed">malformed</xref>.</t>
+        <t>A proxy that supports CONNECT establishes a <xref target="TCP">TCP connection</xref> to
           the host and port identified in the "<tt>:authority</tt>" pseudo-header field. Once
           this connection is successfully established, the proxy sends a <xref target="HEADERS" format="none">HEADERS</xref>
-          frame containing a 2xx-series status code to the client, as defined in <xref target="HTTP" section="9.3.6"/>.
-        </t>
-        <t>
-          After the initial <xref target="HEADERS" format="none">HEADERS</xref> frame sent by each
+          frame containing a 2xx-series status code to the client, as defined in <xref target="HTTP" section="9.3.6"/>.</t>
+        <t>After the initial <xref target="HEADERS" format="none">HEADERS</xref> frame sent by each
           peer, all subsequent <xref target="DATA" format="none">DATA</xref> frames correspond to
-          data sent on the TCP connection. The frame payload of any <xref target="DATA"
-          format="none">DATA</xref> frames sent by the client is transmitted by the proxy to the
-          TCP server; data received from the TCP server is assembled into <xref target="DATA"
-          format="none">DATA</xref> frames by the proxy. Frame types other than <xref target="DATA"
-          format="none">DATA</xref> or stream management frames (<xref target="RST_STREAM"
-          format="none">RST_STREAM</xref>, <xref target="WINDOW_UPDATE"
-          format="none">WINDOW_UPDATE</xref>, and <xref target="PRIORITY"
-          format="none">PRIORITY</xref>) MUST NOT be sent on a connected stream and MUST be treated
-          as a <xref target="StreamErrorHandler">stream error</xref> if received.
-        </t>
-        <t>
-          The TCP connection can be closed by either peer.  The END_STREAM flag on a
+          data sent on the TCP connection. The frame payload of any <xref target="DATA" format="none">DATA</xref> frames sent by the client is transmitted by the proxy to the
+          TCP server; data received from the TCP server is assembled into <xref target="DATA" format="none">DATA</xref> frames by the proxy. Frame types other than <xref target="DATA" format="none">DATA</xref> or stream management frames (<xref target="RST_STREAM" format="none">RST_STREAM</xref>, <xref target="WINDOW_UPDATE" format="none">WINDOW_UPDATE</xref>, and <xref target="PRIORITY" format="none">PRIORITY</xref>) <bcp14>MUST NOT</bcp14> be sent on a connected stream and <bcp14>MUST</bcp14> be treated
+          as a <xref target="StreamErrorHandler">stream error</xref> if received.</t>
+        <t>The TCP connection can be closed by either peer.  The END_STREAM flag on a
           <xref target="DATA" format="none">DATA</xref> frame is treated as being equivalent to the TCP FIN bit.  A client is
           expected to send a <xref target="DATA" format="none">DATA</xref> frame with the END_STREAM flag set after receiving
           a frame with the END_STREAM flag set.  A proxy that receives a <xref target="DATA" format="none">DATA</xref> frame
           with the END_STREAM flag set sends the attached data with the FIN bit set on the last TCP
           segment.  A proxy that receives a TCP segment with the FIN bit set sends a
           <xref target="DATA" format="none">DATA</xref> frame with the END_STREAM flag set.  Note that the final TCP segment
-          or <xref target="DATA" format="none">DATA</xref> frame could be empty.
-        </t>
-        <t>
-          A TCP connection error is signaled with <xref target="RST_STREAM" format="none">RST_STREAM</xref>.  A proxy treats any
+          or <xref target="DATA" format="none">DATA</xref> frame could be empty.</t>
+        <t>A TCP connection error is signaled with <xref target="RST_STREAM" format="none">RST_STREAM</xref>.  A proxy treats any
           error in the TCP connection, which includes receiving a TCP segment with the RST bit set,
           as a <xref target="StreamErrorHandler">stream error</xref> of type
-          <xref target="CONNECT_ERROR" format="none">CONNECT_ERROR</xref>.  Correspondingly, a proxy MUST send a TCP segment with the
-          RST bit set if it detects an error with the stream or the HTTP/2 connection.
-        </t>
+          <xref target="CONNECT_ERROR" format="none">CONNECT_ERROR</xref>.  Correspondingly, a proxy <bcp14>MUST</bcp14> send a TCP segment with the
+          RST bit set if it detects an error with the stream or the HTTP/2 connection.</t>
       </section>
       <section anchor="informational-responses">
         <name>The Upgrade Header Field</name>
-        <t>
-          HTTP/2 does not support the 101 (Switching Protocols) informational status code
-          (<xref target="HTTP" section="15.2.2"/>).
-        </t>
-        <t>
-          The semantics of 101 (Switching Protocols) aren't applicable to a multiplexed protocol.
+        <t>HTTP/2 does not support the 101 (Switching Protocols) informational status code
+          (<xref target="HTTP" section="15.2.2"/>).</t>
+        <t>The semantics of 101 (Switching Protocols) aren't applicable to a multiplexed protocol.
           Similar functionality might be enabled through the use of <xref target="RFC8441">extended
           CONNECT</xref>, and other protocols are able to use the same mechanisms that HTTP/2 uses to
-          negotiate their use (see <xref target="starting"/>).
-        </t>
+          negotiate their use (see <xref target="starting"/>).</t>
       </section>
       <section anchor="Reliability">
         <name>Request Reliability</name>
-        <t>
-          In general, an HTTP client is unable to retry a non-idempotent request when an error
+        <t>In general, an HTTP client is unable to retry a non-idempotent request when an error
           occurs because there is no means to determine the nature of the error (see <xref target="HTTP" section="9.2.2"/>).  It is possible
           that some server processing occurred prior to the error, which could result in
-          undesirable effects if the request were reattempted.
-        </t>
-        <t>
-          HTTP/2 provides two mechanisms for providing a guarantee to a client that a request has
-          not been processed:
-        </t>
+          undesirable effects if the request were reattempted.</t>
+        <t>HTTP/2 provides two mechanisms for providing a guarantee to a client that a request has
+          not been processed:</t>
         <ul spacing="normal">
-          <li>
-              The <xref target="GOAWAY" format="none">GOAWAY</xref> frame indicates the highest stream number that might have
+          <li>The <xref target="GOAWAY" format="none">GOAWAY</xref> frame indicates the highest stream number that might have
               been processed.  Requests on streams with higher numbers are therefore guaranteed to
-              be safe to retry.
-            </li>
-          <li>
-              The <xref target="REFUSED_STREAM" format="none">REFUSED_STREAM</xref> error code can be included in a
+              be safe to retry.</li>
+          <li>The <xref target="REFUSED_STREAM" format="none">REFUSED_STREAM</xref> error code can be included in a
               <xref target="RST_STREAM" format="none">RST_STREAM</xref> frame to indicate that the stream is being closed prior to
               any processing having occurred.  Any request that was sent on the reset stream can
-              be safely retried.
-            </li>
+              be safely retried.</li>
         </ul>
-        <t>
-          Requests that have not been processed have not failed; clients MAY automatically retry
-          them, even those with non-idempotent methods.
-        </t>
-        <t>
-          A server MUST NOT indicate that a stream has not been processed unless it can guarantee
+        <t>Requests that have not been processed have not failed; clients <bcp14>MAY</bcp14> automatically retry
+          them, even those with non-idempotent methods.</t>
+        <t>A server <bcp14>MUST NOT</bcp14> indicate that a stream has not been processed unless it can guarantee
           that fact.  If frames that are on a stream are passed to the application layer for any
-          stream, then <xref target="REFUSED_STREAM" format="none">REFUSED_STREAM</xref> MUST NOT be used for that stream, and a
-          <xref target="GOAWAY" format="none">GOAWAY</xref> frame MUST include a stream identifier that is greater than or
-          equal to the given stream identifier.
-        </t>
-        <t>
-          In addition to these mechanisms, the <xref target="PING" format="none">PING</xref> frame provides a way for a
+          stream, then <xref target="REFUSED_STREAM" format="none">REFUSED_STREAM</xref> <bcp14>MUST NOT</bcp14> be used for that stream, and a
+          <xref target="GOAWAY" format="none">GOAWAY</xref> frame <bcp14>MUST</bcp14> include a stream identifier that is greater than or
+          equal to the given stream identifier.</t>
+        <t>In addition to these mechanisms, the <xref target="PING" format="none">PING</xref> frame provides a way for a
           client to easily test a connection.  Connections that remain idle can become broken, because
           some middleboxes (for instance, network address translators or load balancers) silently
           discard connection bindings.  The <xref target="PING" format="none">PING</xref> frame allows a client to safely
-          test whether a connection is still active without sending a request.
-        </t>
+          test whether a connection is still active without sending a request.</t>
       </section>
       <section anchor="HttpExamples">
         <name>Examples</name>
-        <t>
-            This section shows HTTP/1.1 requests and responses, with illustrations of equivalent
-            HTTP/2 requests and responses.
-        </t>
-        <section><name>Simple Request</name>
-        <t>
-            An HTTP GET request includes control data and a request header with no message content and is therefore
+        <t>This section shows HTTP/1.1 requests and responses, with illustrations of equivalent
+            HTTP/2 requests and responses.</t>
+        <section>
+          <name>Simple Request</name>
+          <t>An HTTP GET request includes control data and a request header with no message content and is therefore
             transmitted as a single <xref target="HEADERS" format="none">HEADERS</xref> frame, followed by zero or more
             <xref target="CONTINUATION" format="none">CONTINUATION</xref> frames containing the serialized block of request header
             fields.  The <xref target="HEADERS" format="none">HEADERS</xref> frame in the following has both the END_HEADERS and
-            END_STREAM flags set; no <xref target="CONTINUATION" format="none">CONTINUATION</xref> frames are sent.
-          </t>
-        <artwork type="inline"><![CDATA[
+            END_STREAM flags set; no <xref target="CONTINUATION" format="none">CONTINUATION</xref> frames are sent.</t>
+          <artwork type="inline"><![CDATA[
   GET /resource HTTP/1.1           HEADERS
   Host: example.org          ==>     + END_STREAM
   Accept: image/jpeg                 + END_HEADERS
@@ -3539,14 +2457,13 @@ cookie: e=f
                                        accept = image/jpeg
 ]]></artwork>
         </section>
-        <section><name>Simple Response</name>
-        <t>
-            Similarly, a response that includes only control data and a response header is transmitted as a
+        <section>
+          <name>Simple Response</name>
+          <t>Similarly, a response that includes only control data and a response header is transmitted as a
             <xref target="HEADERS" format="none">HEADERS</xref> frame (again, followed by zero or more
             <xref target="CONTINUATION" format="none">CONTINUATION</xref> frames) containing the serialized block of response header
-            fields.
-          </t>
-        <artwork type="inline"><![CDATA[
+            fields.</t>
+          <artwork type="inline"><![CDATA[
   HTTP/1.1 304 Not Modified        HEADERS
   ETag: "xyzzy"              ==>     + END_STREAM
   Expires: Thu, 23 Jan ...           + END_HEADERS
@@ -3555,16 +2472,15 @@ cookie: e=f
                                        expires = Thu, 23 Jan ...
 ]]></artwork>
         </section>
-        <section><name>Complex Request</name>
-        <t>
-            An HTTP POST request that includes control data and a request header with message content is transmitted
+        <section>
+          <name>Complex Request</name>
+          <t>An HTTP POST request that includes control data and a request header with message content is transmitted
             as one <xref target="HEADERS" format="none">HEADERS</xref> frame, followed by zero or more
             <xref target="CONTINUATION" format="none">CONTINUATION</xref> frames containing the request header, followed by one
             or more <xref target="DATA" format="none">DATA</xref> frames, with the last <xref target="CONTINUATION" format="none">CONTINUATION</xref> (or
             <xref target="HEADERS" format="none">HEADERS</xref>) frame having the END_HEADERS flag set and the final
-            <xref target="DATA" format="none">DATA</xref> frame having the END_STREAM flag set:
-          </t>
-        <artwork type="inline"><![CDATA[
+            <xref target="DATA" format="none">DATA</xref> frame having the END_STREAM flag set:</t>
+          <artwork type="inline"><![CDATA[
   POST /resource HTTP/1.1          HEADERS
   Host: example.org          ==>     - END_STREAM
   Content-Type: image/jpeg           - END_HEADERS
@@ -3583,22 +2499,19 @@ cookie: e=f
                                      + END_STREAM
                                    {binary data}
 ]]></artwork>
-        <t keepWithPrevious="true">
-              Note that data contributing to any given field line could be spread between field
+          <t keepWithPrevious="true">Note that data contributing to any given field line could be spread between field
               block fragments.  The allocation of field lines to frames in this example is
-              illustrative only.
-          </t>
+              illustrative only.</t>
         </section>
-        <section><name>Response with Body</name>
-        <t>
-            A response that includes control data and a response header with message content is
+        <section>
+          <name>Response with Body</name>
+          <t>A response that includes control data and a response header with message content is
             transmitted as a <xref target="HEADERS" format="none">HEADERS</xref> frame, followed by
             zero or more <xref target="CONTINUATION" format="none">CONTINUATION</xref> frames,
             followed by one or more <xref target="DATA" format="none">DATA</xref> frames, with the
             last <xref target="DATA" format="none">DATA</xref> frame in the sequence having the
-            END_STREAM flag set:
-          </t>
-        <artwork type="inline"><![CDATA[
+            END_STREAM flag set:</t>
+          <artwork type="inline"><![CDATA[
   HTTP/1.1 200 OK                  HEADERS
   Content-Type: image/jpeg   ==>     - END_STREAM
   Content-Length: 123                + END_HEADERS
@@ -3611,24 +2524,19 @@ cookie: e=f
                                    {binary data}
 ]]></artwork>
         </section>
-        <section><name>Informational Responses</name>
-        <t>
-            An informational response using a 1xx status code other than 101 is transmitted as a
+        <section>
+          <name>Informational Responses</name>
+          <t>An informational response using a 1xx status code other than 101 is transmitted as a
             <xref target="HEADERS" format="none">HEADERS</xref> frame, followed by zero or more
-            <xref target="CONTINUATION" format="none">CONTINUATION</xref> frames.
-          </t>
-        <t>
-            A trailer section is sent as a field block after both the request or response
+            <xref target="CONTINUATION" format="none">CONTINUATION</xref> frames.</t>
+          <t>A trailer section is sent as a field block after both the request or response
             field block and all the <xref target="DATA" format="none">DATA</xref> frames have been sent.  The
             <xref target="HEADERS" format="none">HEADERS</xref> frame starting the field block that comprises
-            the trailer section has the END_STREAM flag set.
-          </t>
-        <t keepWithNext="true">
-              The following example includes both a 100 (Continue) status code, which is sent in
+            the trailer section has the END_STREAM flag set.</t>
+          <t keepWithNext="true">The following example includes both a 100 (Continue) status code, which is sent in
               response to a request containing a "100-continue" token in the Expect header field,
-              and a trailer section:
-          </t>
-        <artwork type="inline"><![CDATA[
+              and a trailer section:</t>
+          <artwork type="inline"><![CDATA[
   HTTP/1.1 100 Continue            HEADERS
   Extension-Field: bar       ==>     - END_STREAM
                                      + END_HEADERS
@@ -3656,620 +2564,425 @@ cookie: e=f
     </section>
     <section anchor="HttpExtra">
       <name>HTTP/2 Connections</name>
-      <t>
-        This section outlines attributes of HTTP that improve interoperability, reduce exposure to
-        known security vulnerabilities, or reduce the potential for implementation variation.
-      </t>
+      <t>This section outlines attributes of HTTP that improve interoperability, reduce exposure to
+        known security vulnerabilities, or reduce the potential for implementation variation.</t>
       <section>
         <name>Connection Management</name>
-        <t>
-          HTTP/2 connections are persistent.  For best performance, it is expected that clients will not
+        <t>HTTP/2 connections are persistent.  For best performance, it is expected that clients will not
           close connections until it is determined that no further communication with a server is
           necessary (for example, when a user navigates away from a particular web page) or until
-          the server closes the connection.
-        </t>
-        <t>
-          Clients SHOULD NOT open more than one HTTP/2 connection to a given host and port pair,
+          the server closes the connection.</t>
+        <t>Clients <bcp14>SHOULD NOT</bcp14> open more than one HTTP/2 connection to a given host and port pair,
           where the host is derived from a URI, a selected <xref target="ALT-SVC">alternative
-          service</xref>, or a configured proxy.
-        </t>
-        <t>
-          A client can create additional connections as replacements, either to replace connections
+          service</xref>, or a configured proxy.</t>
+        <t>A client can create additional connections as replacements, either to replace connections
           that are near to exhausting the available <xref target="StreamIdentifiers">stream
           identifier space</xref>, to refresh the keying material for a TLS connection, or to
-          replace connections that have encountered <xref target="ConnectionErrorHandler">errors</xref>.
-        </t>
-        <t>
-          A client MAY open multiple connections to the same IP address and TCP port using different
+          replace connections that have encountered <xref target="ConnectionErrorHandler">errors</xref>.</t>
+        <t>A client <bcp14>MAY</bcp14> open multiple connections to the same IP address and TCP port using different
           <xref target="TLS-EXT">Server Name Indication</xref> values or to provide different TLS
-          client certificates but SHOULD avoid creating multiple connections with the same
-          configuration.
-        </t>
-        <t>
-          Servers are encouraged to maintain open connections for as long as possible but are
+          client certificates but <bcp14>SHOULD</bcp14> avoid creating multiple connections with the same
+          configuration.</t>
+        <t>Servers are encouraged to maintain open connections for as long as possible but are
           permitted to terminate idle connections if necessary.  When either endpoint chooses to
-          close the transport-layer TCP connection, the terminating endpoint SHOULD first send a
+          close the transport-layer TCP connection, the terminating endpoint <bcp14>SHOULD</bcp14> first send a
           <xref target="GOAWAY" format="none">GOAWAY</xref> (<xref target="GOAWAY"/>) frame so that both endpoints can reliably
           determine whether previously sent frames have been processed and gracefully complete or
-          terminate any necessary remaining tasks.
-        </t>
+          terminate any necessary remaining tasks.</t>
         <section anchor="reuse">
           <name>Connection Reuse</name>
-          <t>
-            Connections that are made to an origin server, either directly or through a tunnel
-            created using the <xref target="CONNECT">CONNECT method</xref>, MAY be reused for
+          <t>Connections that are made to an origin server, either directly or through a tunnel
+            created using the <xref target="CONNECT">CONNECT method</xref>, <bcp14>MAY</bcp14> be reused for
             requests with multiple different URI authority components.  A connection can be reused
             as long as the origin server is <xref target="authority">authoritative</xref>.  For TCP
             connections without TLS, this depends on the host having resolved to the same IP
-            address.
-          </t>
-          <t>
-            For "<tt>https</tt>" resources, connection reuse additionally depends
+            address.</t>
+          <t>For "<tt>https</tt>" resources, connection reuse additionally depends
             on having a certificate that is valid for the host in the URI.  The certificate
-            presented by the server MUST satisfy any checks that the client would perform when
+            presented by the server <bcp14>MUST</bcp14> satisfy any checks that the client would perform when
             forming a new TLS connection for the host in the URI.  A single certificate can be
             used to establish authority for multiple origins.  <xref target="HTTP" section="4.3"/>
-            describes how a client determines whether a server is authoritative for a URI.
-          </t>
-          <t>
-            In some deployments, reusing a connection for multiple origins can result in requests
+            describes how a client determines whether a server is authoritative for a URI.</t>
+          <t>In some deployments, reusing a connection for multiple origins can result in requests
             being directed to the wrong origin server.  For example, TLS termination might be
             performed by a middlebox that uses the TLS <xref target="TLS-EXT">Server Name
             Indication</xref> extension to select an origin server.  This means that it is possible
             for clients to send requests to servers that might not be the intended target for the
-            request, even though the server is otherwise authoritative.
-          </t>
-          <t>
-            A server that does not wish clients to reuse connections can indicate that it is not
+            request, even though the server is otherwise authoritative.</t>
+          <t>A server that does not wish clients to reuse connections can indicate that it is not
             authoritative for a request by sending a 421 (Misdirected Request) status code in response
-            to the request (see <xref target="HTTP" section="15.5.20"/>).
-          </t>
-          <t>
-            A client that is configured to use a proxy over HTTP/2 directs requests to that proxy
+            to the request (see <xref target="HTTP" section="15.5.20"/>).</t>
+          <t>A client that is configured to use a proxy over HTTP/2 directs requests to that proxy
             through a single connection.  That is, all requests sent via a proxy reuse the
-            connection to the proxy.
-          </t>
+            connection to the proxy.</t>
         </section>
       </section>
       <section anchor="TLSUsage">
         <name>Use of TLS Features</name>
-        <t>
-          Implementations of HTTP/2 MUST use <xref target="TLS12">TLS version 1.2</xref> or higher
-          for HTTP/2 over TLS.  The general TLS usage guidance in <xref target="TLSBCP"/> SHOULD be
-          followed, with some additional restrictions that are specific to HTTP/2.
-        </t>
-        <t>
-          The TLS implementation MUST support the <xref target="TLS-EXT">Server Name Indication
-          (SNI)</xref> extension to TLS. If the server is identified by a <xref
-          target="DNS-TERMS">domain name</xref>, clients MUST send the server_name TLS extension
-          unless an alternative mechanism to indicate the target host is used.
-
-        </t>
-        <t>
-          Requirements for deployments of HTTP/2 that negotiate <xref target="TLS13">TLS 1.3</xref>
+        <t>Implementations of HTTP/2 <bcp14>MUST</bcp14> use <xref target="TLS12">TLS version 1.2</xref> or higher
+          for HTTP/2 over TLS.  The general TLS usage guidance in <xref target="TLSBCP"/> <bcp14>SHOULD</bcp14> be
+          followed, with some additional restrictions that are specific to HTTP/2.</t>
+        <t>The TLS implementation <bcp14>MUST</bcp14> support the <xref target="TLS-EXT">Server Name Indication
+          (SNI)</xref> extension to TLS. If the server is identified by a <xref target="DNS-TERMS">domain name</xref>, clients <bcp14>MUST</bcp14> send the server_name TLS extension
+          unless an alternative mechanism to indicate the target host is used.</t>
+        <t>Requirements for deployments of HTTP/2 that negotiate <xref target="TLS13">TLS 1.3</xref>
           are included in <xref target="tls13features"/>.  Deployments of TLS 1.2 are subject to
-          the requirements in Sections&nbsp;<xref target="tls12features" format="counter"/> and <xref target="tls12ciphers" format="counter"/>.
+          the requirements in Sections <xref target="tls12features" format="counter"/> and <xref target="tls12ciphers" format="counter"/>.
           Implementations are encouraged to provide defaults that comply, but it is recognized that
-          deployments are ultimately responsible for compliance.
-        </t>
+          deployments are ultimately responsible for compliance.</t>
         <section anchor="tls12features">
           <name>TLS 1.2 Features</name>
-          <t>
-            This section describes restrictions on the TLS 1.2 feature set that can be used with
+          <t>This section describes restrictions on the TLS 1.2 feature set that can be used with
             HTTP/2. Due to deployment limitations, it might not be possible to fail TLS negotiation
-            when these restrictions are not met. An endpoint MAY immediately terminate an HTTP/2
-            connection that does not meet these TLS requirements with a <xref
-            target="ConnectionErrorHandler">connection error</xref> of type <xref
-            target="INADEQUATE_SECURITY" format="none">INADEQUATE_SECURITY</xref>.
-
-          </t>
-          <t>
-            A deployment of HTTP/2 over TLS 1.2 MUST disable compression. TLS compression can lead
-            to the exposure of information that would not otherwise be revealed <xref
-            target="RFC3749"/>. Generic compression is unnecessary, since HTTP/2 provides
+            when these restrictions are not met. An endpoint <bcp14>MAY</bcp14> immediately terminate an HTTP/2
+            connection that does not meet these TLS requirements with a <xref target="ConnectionErrorHandler">connection error</xref> of type <xref target="INADEQUATE_SECURITY" format="none">INADEQUATE_SECURITY</xref>.</t>
+          <t>A deployment of HTTP/2 over TLS 1.2 <bcp14>MUST</bcp14> disable compression. TLS compression can lead
+            to the exposure of information that would not otherwise be revealed <xref target="RFC3749"/>. Generic compression is unnecessary, since HTTP/2 provides
             compression features that are more aware of context and therefore likely to be more
-            appropriate for use for performance, security, or other reasons.
-
-          </t>
-          <t>
-            A deployment of HTTP/2 over TLS 1.2 MUST disable renegotiation. An endpoint MUST treat
+            appropriate for use for performance, security, or other reasons.</t>
+          <t>A deployment of HTTP/2 over TLS 1.2 <bcp14>MUST</bcp14> disable renegotiation. An endpoint <bcp14>MUST</bcp14> treat
             a TLS renegotiation as a <xref target="ConnectionErrorHandler">connection error</xref>
             of type <xref target="PROTOCOL_ERROR" format="none">PROTOCOL_ERROR</xref>. Note that
             disabling renegotiation can result in long-lived connections becoming unusable due to
-            limits on the number of messages the underlying cipher suite can encipher.
-
-          </t>
-          <t>
-            An endpoint MAY use renegotiation to provide confidentiality protection for client
-            credentials offered in the handshake, but any renegotiation MUST occur prior to sending
-            the connection preface.  A server SHOULD request a client certificate if it sees a
-            renegotiation request immediately after establishing a connection.
-          </t>
-          <t>
-            This effectively prevents the use of renegotiation in response to a request for a
+            limits on the number of messages the underlying cipher suite can encipher.</t>
+          <t>An endpoint <bcp14>MAY</bcp14> use renegotiation to provide confidentiality protection for client
+            credentials offered in the handshake, but any renegotiation <bcp14>MUST</bcp14> occur prior to sending
+            the connection preface.  A server <bcp14>SHOULD</bcp14> request a client certificate if it sees a
+            renegotiation request immediately after establishing a connection.</t>
+          <t>This effectively prevents the use of renegotiation in response to a request for a
             specific protected resource.  A future specification might provide a way to support this
-            use case. Alternatively, a server might use an <xref target="ErrorHandler">
-            error</xref> of type <xref target="HTTP_1_1_REQUIRED" format="none">HTTP_1_1_REQUIRED</xref> to request that the client
-            use a protocol that supports renegotiation.
-          </t>
-          <t>
-            Implementations MUST support ephemeral key exchange sizes of at least 2048 bits for
-            cipher suites that use ephemeral finite field Diffie-Hellman (DHE) (<xref
-            target="TLS12" section="8.1.2"/>) and 224 bits for cipher suites that use ephemeral elliptic curve
-            Diffie-Hellman (ECDHE) <xref target="RFC8422"/>. Clients MUST accept DHE sizes of up to
-            4096 bits. Endpoints MAY treat negotiation of key sizes smaller than the lower limits
-            as a <xref target="ConnectionErrorHandler">connection error</xref> of type <xref
-            target="INADEQUATE_SECURITY" format="none">INADEQUATE_SECURITY</xref>.
-
-          </t>
+            use case. Alternatively, a server might use an <xref target="ErrorHandler">error</xref> of type <xref target="HTTP_1_1_REQUIRED" format="none">HTTP_1_1_REQUIRED</xref> to request that the client
+            use a protocol that supports renegotiation.</t>
+          <t>Implementations <bcp14>MUST</bcp14> support ephemeral key exchange sizes of at least 2048 bits for
+            cipher suites that use ephemeral finite field Diffie-Hellman (DHE) (<xref target="TLS12" section="8.1.2"/>) and 224 bits for cipher suites that use ephemeral elliptic curve
+            Diffie-Hellman (ECDHE) <xref target="RFC8422"/>. Clients <bcp14>MUST</bcp14> accept DHE sizes of up to
+            4096 bits. Endpoints <bcp14>MAY</bcp14> treat negotiation of key sizes smaller than the lower limits
+            as a <xref target="ConnectionErrorHandler">connection error</xref> of type <xref target="INADEQUATE_SECURITY" format="none">INADEQUATE_SECURITY</xref>.</t>
         </section>
         <section anchor="tls12ciphers">
           <name>TLS 1.2 Cipher Suites</name>
-          <t>
-            A deployment of HTTP/2 over TLS 1.2 SHOULD NOT use any of the prohibited cipher suites listed in <xref target="BadCipherSuites"/>.
-          </t>
-          <t>
-            Endpoints MAY choose to generate a <xref target="ConnectionErrorHandler">connection
-            error</xref> of type <xref target="INADEQUATE_SECURITY"
-            format="none">INADEQUATE_SECURITY</xref> if one of the prohibited cipher suites is
+          <t>A deployment of HTTP/2 over TLS 1.2 <bcp14>SHOULD NOT</bcp14> use any of the prohibited cipher suites listed in <xref target="BadCipherSuites"/>.</t>
+          <t>Endpoints <bcp14>MAY</bcp14> choose to generate a <xref target="ConnectionErrorHandler">connection
+            error</xref> of type <xref target="INADEQUATE_SECURITY" format="none">INADEQUATE_SECURITY</xref> if one of the prohibited cipher suites is
             negotiated. A deployment that chooses to use a prohibited cipher suite risks triggering
             a connection error unless the set of potential peers is known to accept that cipher
-            suite.
-
-          </t>
-          <t>
-            Implementations MUST NOT generate this error in reaction to the negotiation of a cipher
+            suite.</t>
+          <t>Implementations <bcp14>MUST NOT</bcp14> generate this error in reaction to the negotiation of a cipher
             suite that is not prohibited.  Consequently, when clients offer a cipher suite
             that is not prohibited, they have to be prepared to use that cipher suite with
-            HTTP/2.
-          </t>
-          <t>
-            The list of prohibited cipher suites includes the cipher suite that TLS 1.2 makes
+            HTTP/2.</t>
+          <t>The list of prohibited cipher suites includes the cipher suite that TLS 1.2 makes
             mandatory, which means that TLS 1.2 deployments could have non-intersecting sets of
             permitted cipher suites.  To avoid this problem, which causes TLS handshake failures,
-            deployments of HTTP/2 that use TLS 1.2 MUST support
+            deployments of HTTP/2 that use TLS 1.2 <bcp14>MUST</bcp14> support
             TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256 <xref target="TLS-ECDHE"/> with the P-256 elliptic
-            curve <xref target="RFC8422"/>.
-          </t>
-          <t>
-            Note that clients might advertise support of cipher suites that are prohibited in
+            curve <xref target="RFC8422"/>.</t>
+          <t>Note that clients might advertise support of cipher suites that are prohibited in
             order to allow for connection to servers that do not support HTTP/2.  This allows
             servers to select HTTP/1.1 with a cipher suite that is prohibited in HTTP/2.
             However, this can result in HTTP/2 being negotiated with a prohibited cipher suite if
-            the application protocol and cipher suite are independently selected.
-          </t>
+            the application protocol and cipher suite are independently selected.</t>
         </section>
         <section anchor="tls13features">
           <name>TLS 1.3 Features</name>
-          <t>
-            TLS 1.3 includes a number of features not available in earlier versions.  This section
-            discusses the use of these features.
-          </t>
-          <t>
-            HTTP/2 servers MUST NOT send post-handshake TLS 1.3 CertificateRequest messages. HTTP/2
-            clients MUST treat a TLS post-handshake CertificateRequest message as a <xref
-            target="ConnectionErrorHandler">connection error</xref> of type <xref
-            target="PROTOCOL_ERROR" format="none">PROTOCOL_ERROR</xref>.
-          </t>
-          <t>
-            The prohibition on post-handshake authentication applies even if the client offered the
+          <t>TLS 1.3 includes a number of features not available in earlier versions.  This section
+            discusses the use of these features.</t>
+          <t>HTTP/2 servers <bcp14>MUST NOT</bcp14> send post-handshake TLS 1.3 CertificateRequest messages. HTTP/2
+            clients <bcp14>MUST</bcp14> treat a TLS post-handshake CertificateRequest message as a <xref target="ConnectionErrorHandler">connection error</xref> of type <xref target="PROTOCOL_ERROR" format="none">PROTOCOL_ERROR</xref>.</t>
+          <t>The prohibition on post-handshake authentication applies even if the client offered the
             "post_handshake_auth" TLS extension.  Post-handshake authentication support might be
             advertised independently of <xref target="TLS-ALPN">ALPN</xref>.  Clients might offer
             the capability for use in other protocols, but inclusion of the extension cannot imply
-            support within HTTP/2.
-          </t>
+            support within HTTP/2.</t>
           <t><xref target="TLS13"/> defines other post-handshake messages, NewSessionTicket and
             KeyUpdate, which can be used as they have no direct interaction with HTTP/2.  Unless the
             use of a new type of TLS message depends on an interaction with the application-layer
-            protocol, that TLS message can be sent after the handshake completes.
-          </t>
-          <t>
-            TLS early data MAY be used to send requests, provided that the guidance in <xref
-            target="RFC8470"/> is observed. Clients send requests in early data assuming initial
-            values for all server settings.
-          </t>
+            protocol, that TLS message can be sent after the handshake completes.</t>
+          <t>TLS early data <bcp14>MAY</bcp14> be used to send requests, provided that the guidance in <xref target="RFC8470"/> is observed. Clients send requests in early data assuming initial
+            values for all server settings.</t>
         </section>
       </section>
     </section>
     <section anchor="security">
       <name>Security Considerations</name>
-      <t>
-        The use of TLS is necessary to provide many of the security properties of this protocol.
-        Many of the claims in this section do not hold unless TLS is used as described in <xref
-        target="TLSUsage"/>.
-      </t>
+      <t>The use of TLS is necessary to provide many of the security properties of this protocol.
+        Many of the claims in this section do not hold unless TLS is used as described in <xref target="TLSUsage"/>.</t>
       <section anchor="authority">
         <name>Server Authority</name>
-        <t>
-          HTTP/2 relies on the HTTP definition of authority for determining whether a server is
+        <t>HTTP/2 relies on the HTTP definition of authority for determining whether a server is
           authoritative in providing a given response (see <xref target="HTTP" section="4.3"/>).
           This relies on local name resolution for the "<tt>http</tt>" URI scheme and the authenticated server
-          identity for the "<tt>https</tt>" scheme.
-        </t>
+          identity for the "<tt>https</tt>" scheme.</t>
       </section>
       <section>
         <name>Cross-Protocol Attacks</name>
-        <t>
-          In a cross-protocol attack, an attacker causes a client to initiate a transaction in one
+        <t>In a cross-protocol attack, an attacker causes a client to initiate a transaction in one
           protocol toward a server that understands a different protocol.  An attacker might be able
           to cause the transaction to appear as a valid transaction in the second protocol.  In
           combination with the capabilities of the web context, this can be used to interact with
-          poorly protected servers in private networks.
-        </t>
-        <t>
-          Completing a TLS handshake with an ALPN identifier for HTTP/2 can be considered sufficient
+          poorly protected servers in private networks.</t>
+        <t>Completing a TLS handshake with an ALPN identifier for HTTP/2 can be considered sufficient
           protection against cross-protocol attacks.  ALPN provides a positive indication that a
           server is willing to proceed with HTTP/2, which prevents attacks on other TLS-based
-          protocols.
-        </t>
-        <t>
-          The encryption in TLS makes it difficult for attackers to control the data that could be
-          used in a cross-protocol attack on a cleartext protocol.
-        </t>
-        <t>
-          The cleartext version of HTTP/2 has minimal protection against cross-protocol attacks.
+          protocols.</t>
+        <t>The encryption in TLS makes it difficult for attackers to control the data that could be
+          used in a cross-protocol attack on a cleartext protocol.</t>
+        <t>The cleartext version of HTTP/2 has minimal protection against cross-protocol attacks.
           The <xref target="preface">connection preface</xref> contains a string that is
           designed to confuse HTTP/1.1 servers, but no special protection is offered for other
-          protocols.
-        </t>
+          protocols.</t>
       </section>
       <section>
         <name>Intermediary Encapsulation Attacks</name>
-        <t>
-          HPACK permits encoding of field names and values that might be treated as delimiters in
-          other HTTP versions.  An intermediary that translates an HTTP/2 request or response MUST
+        <t>HPACK permits encoding of field names and values that might be treated as delimiters in
+          other HTTP versions.  An intermediary that translates an HTTP/2 request or response <bcp14>MUST</bcp14>
           validate fields according to the rules in <xref target="HttpHeaders"/> before
           translating a message to another HTTP version.  Translating a field that includes invalid
           delimiters could be used to cause recipients to incorrectly interpret a message, which
-          could be exploited by an attacker.
-        </t>
-        <t>
-          <xref target="HttpHeaders"/> does not include specific rules for validation of
+          could be exploited by an attacker.</t>
+        <t><xref target="HttpHeaders"/> does not include specific rules for validation of
           pseudo-header fields.  If the values of these fields are used, additional validation is
           necessary. This is particularly important where "<tt>:scheme</tt>", "<tt>:authority</tt>", and
-          "<tt>:path</tt>" are combined to form a single URI string <xref
-          target="RFC3986"/>. Similar problems might occur when that URI or just "<tt>:path</tt>" is
-          combined with "<tt>:method</tt>" to construct a request line (as in <xref target="HTTP11"
-          section="3"/>). Simple concatenation is not secure unless the input values are fully
-          validated.
-        </t>
-        <t>
-          An intermediary can reject fields that contain invalid field names or values for other
+          "<tt>:path</tt>" are combined to form a single URI string <xref target="RFC3986"/>. Similar problems might occur when that URI or just "<tt>:path</tt>" is
+          combined with "<tt>:method</tt>" to construct a request line (as in <xref target="HTTP11" section="3"/>). Simple concatenation is not secure unless the input values are fully
+          validated.</t>
+        <t>An intermediary can reject fields that contain invalid field names or values for other
           reasons -- in particular, those fields that do not conform to the HTTP ABNF grammar from <xref target="HTTP" section="5"/>. Intermediaries that do not perform any validation of fields
           other than the minimum required by <xref target="HttpHeaders"/> could forward messages
-          that contain invalid field names or values.
-        </t>
-        <t>
-          An intermediary that receives any fields that require removal before forwarding
-          (see <xref target="HTTP" section="7.6.1"/>) MUST remove or replace those header fields when
+          that contain invalid field names or values.</t>
+        <t>An intermediary that receives any fields that require removal before forwarding
+          (see <xref target="HTTP" section="7.6.1"/>) <bcp14>MUST</bcp14> remove or replace those header fields when
           forwarding messages. Additionally, intermediaries should take care when forwarding messages
           containing <tt>Content-Length</tt> fields to ensure that the message is <xref target="malformed">well-formed</xref>.
-          This ensures that if the message is translated into HTTP/1.1 at any point, the framing will be correct.
-        </t>
+          This ensures that if the message is translated into HTTP/1.1 at any point, the framing will be correct.</t>
       </section>
       <section>
         <name>Cacheability of Pushed Responses</name>
-        <t>
-          Pushed responses do not have an explicit request from the client; the request
-          is provided by the server in the <xref target="PUSH_PROMISE" format="none">PUSH_PROMISE</xref> frame.
-        </t>
-        <t>
-          Caching responses that are pushed is possible based on the guidance provided by the origin
+        <t>Pushed responses do not have an explicit request from the client; the request
+          is provided by the server in the <xref target="PUSH_PROMISE" format="none">PUSH_PROMISE</xref> frame.</t>
+        <t>Caching responses that are pushed is possible based on the guidance provided by the origin
           server in the Cache-Control header field.  However, this can cause issues if a single
           server hosts more than one tenant.  For example, a server might offer multiple users each
-          a small portion of its URI space.
-        </t>
-        <t>
-          Where multiple tenants share space on the same server, that server MUST ensure that
+          a small portion of its URI space.</t>
+        <t>Where multiple tenants share space on the same server, that server <bcp14>MUST</bcp14> ensure that
           tenants are not able to push representations of resources that they do not have authority
           over.  Failure to enforce this would allow a tenant to provide a representation that would
           be served out of cache, overriding the actual representation that the authoritative tenant
-          provides.
-        </t>
-        <t>
-          Pushed responses for which an origin server is not authoritative (see
-          <xref target="authority"/>) MUST NOT be used or cached.
-        </t>
+          provides.</t>
+        <t>Pushed responses for which an origin server is not authoritative (see
+          <xref target="authority"/>) <bcp14>MUST NOT</bcp14> be used or cached.</t>
       </section>
       <section anchor="dos">
         <name>Denial-of-Service Considerations</name>
-        <t>
-          An HTTP/2 connection can demand a greater commitment of resources to operate than an
+        <t>An HTTP/2 connection can demand a greater commitment of resources to operate than an
           HTTP/1.1 connection.  Both field section compression and flow control depend on a
           commitment of a greater amount of state.  Settings for these
-          features ensure that memory commitments for these features are strictly bounded.
-        </t>
-        <t>
-          The number of <xref target="PUSH_PROMISE" format="none">PUSH_PROMISE</xref> frames is not
-          constrained in the same fashion.  A client that accepts server push SHOULD limit the
+          features ensure that memory commitments for these features are strictly bounded.</t>
+        <t>The number of <xref target="PUSH_PROMISE" format="none">PUSH_PROMISE</xref> frames is not
+          constrained in the same fashion.  A client that accepts server push <bcp14>SHOULD</bcp14> limit the
           number of streams it allows to be in the "reserved (remote)" state.  An excessive number
           of server push streams can be treated as a <xref target="StreamErrorHandler">stream
-          error</xref> of type <xref target="ENHANCE_YOUR_CALM" format="none">ENHANCE_YOUR_CALM</xref>.
-        </t>
-        <t>
-          A number of HTTP/2 implementations were found to be vulnerable to denial of service <xref target="NFLX-2019-002"/>.  Below is a list of known ways that implementations might be
-          subject to denial-of-service attacks:
-        </t>
+          error</xref> of type <xref target="ENHANCE_YOUR_CALM" format="none">ENHANCE_YOUR_CALM</xref>.</t>
+        <t>A number of HTTP/2 implementations were found to be vulnerable to denial of service <xref target="NFLX-2019-002"/>.  Below is a list of known ways that implementations might be
+          subject to denial-of-service attacks:</t>
         <ul>
           <li>
-            <t>
-              Inefficient tracking of outstanding outbound frames can lead to overload if an adversary can
+            <t>Inefficient tracking of outstanding outbound frames can lead to overload if an adversary can
               cause large numbers of frames to be enqueued for sending.  A peer could use one of
-              several techniques to cause large numbers of frames to be generated:
-            </t>
+              several techniques to cause large numbers of frames to be generated:</t>
             <ul>
-              <li>
-                Providing tiny increments to flow control in <xref target="WINDOW_UPDATE" format="none">WINDOW_UPDATE</xref> frames can cause a sender to generate a large
-                number of <xref target="DATA" format="none">DATA</xref> frames.
-              </li>
-              <li>
-                An endpoint is required to respond to a <xref target="PING" format="none">PING</xref> frame.
-              </li>
-              <li>
-                Each <xref target="SETTINGS" format="none">SETTINGS</xref> frame requires
-                acknowledgment.
-              </li>
-              <li>
-                An invalid request (or server push) can cause a peer to send <xref target="RST_STREAM" format="none">RST_STREAM</xref> frames in response.
-              </li>
+              <li>Providing tiny increments to flow control in <xref target="WINDOW_UPDATE" format="none">WINDOW_UPDATE</xref> frames can cause a sender to generate a large
+                number of <xref target="DATA" format="none">DATA</xref> frames.</li>
+              <li>An endpoint is required to respond to a <xref target="PING" format="none">PING</xref> frame.</li>
+              <li>Each <xref target="SETTINGS" format="none">SETTINGS</xref> frame requires
+                acknowledgment.</li>
+              <li>An invalid request (or server push) can cause a peer to send <xref target="RST_STREAM" format="none">RST_STREAM</xref> frames in response.</li>
             </ul>
           </li>
-          <li>
-            An attacker can provide large amounts of flow-control credit at the HTTP/2 layer but
+          <li>An attacker can provide large amounts of flow-control credit at the HTTP/2 layer but
             withhold credit at the TCP layer, preventing frames from being sent.  An endpoint that
             constructs and remembers frames for sending without considering TCP limits might be
-            subject to resource exhaustion.
-          </li>
-          <li>
-            Large numbers of small or empty frames can be abused to cause a peer to expend time
+            subject to resource exhaustion.</li>
+          <li>Large numbers of small or empty frames can be abused to cause a peer to expend time
             processing frame headers.  Caution is required here as some uses of small frames are
-            entirely legitimate, such as the sending of an empty <xref target="DATA"
-            format="none">DATA</xref> or <xref target="CONTINUATION"
-            format="none">CONTINUATION</xref> frame at the end of a stream.
-          </li>
-          <li>
-            The <xref target="SETTINGS" format="none">SETTINGS</xref> frame might also be abused to
+            entirely legitimate, such as the sending of an empty <xref target="DATA" format="none">DATA</xref> or <xref target="CONTINUATION" format="none">CONTINUATION</xref> frame at the end of a stream.</li>
+          <li>The <xref target="SETTINGS" format="none">SETTINGS</xref> frame might also be abused to
             cause a peer to expend additional processing time.  This might be done by pointlessly
             changing settings, sending multiple undefined settings, or changing the
-            same setting multiple times in the same frame.
-          </li>
-          <li>
-            Handling reprioritization with <xref target="PRIORITY" format="none">PRIORITY</xref>
-            frames can require significant processing time and can lead to overload if many <xref target="PRIORITY" format="none">PRIORITY</xref> frames are sent.
-          </li>
-          <li>
-            Field section compression also provides opportunities for an attacker to waste
+            same setting multiple times in the same frame.</li>
+          <li>Handling reprioritization with <xref target="PRIORITY" format="none">PRIORITY</xref>
+            frames can require significant processing time and can lead to overload if many <xref target="PRIORITY" format="none">PRIORITY</xref> frames are sent.</li>
+          <li>Field section compression also provides opportunities for an attacker to waste
             processing resources; see <xref target="COMPRESSION" section="7"/> for more details on
-            potential abuses.
-          </li>
-          <li>
-            Limits in <xref target="SETTINGS" format="none">SETTINGS</xref> cannot be reduced
+            potential abuses.</li>
+          <li>Limits in <xref target="SETTINGS" format="none">SETTINGS</xref> cannot be reduced
             instantaneously, which leaves an endpoint exposed to behavior from a peer that could
             exceed the new limits. In particular, immediately after establishing a connection,
             limits set by a server are not known to clients and could be exceeded without being an
-            obvious protocol violation.
-          </li>
+            obvious protocol violation.</li>
         </ul>
-        <t>
-          Most of the features that might be exploited for denial of service -- such as <xref
-          target="SETTINGS" format="none">SETTINGS</xref> changes, small frames, field section
+        <t>Most of the features that might be exploited for denial of service -- such as <xref target="SETTINGS" format="none">SETTINGS</xref> changes, small frames, field section
           compression -- have legitimate uses.  These features become a burden only when they are
-          used unnecessarily or to excess.
-        </t>
-        <t>
-          An endpoint that doesn't monitor use of these features exposes itself to a risk of
-          denial of service.  Implementations SHOULD track the use of these features and set
-          limits on their use.  An endpoint MAY treat activity that is suspicious as a <xref target="ConnectionErrorHandler">connection error</xref> of type <xref target="ENHANCE_YOUR_CALM" format="none">ENHANCE_YOUR_CALM</xref>.
-        </t>
+          used unnecessarily or to excess.</t>
+        <t>An endpoint that doesn't monitor use of these features exposes itself to a risk of
+          denial of service.  Implementations <bcp14>SHOULD</bcp14> track the use of these features and set
+          limits on their use.  An endpoint <bcp14>MAY</bcp14> treat activity that is suspicious as a <xref target="ConnectionErrorHandler">connection error</xref> of type <xref target="ENHANCE_YOUR_CALM" format="none">ENHANCE_YOUR_CALM</xref>.</t>
         <section anchor="MaxFieldBlock">
           <name>Limits on Field Block Size</name>
-          <t>
-            A large <xref target="FieldBlock">field block</xref> can cause an implementation to
+          <t>A large <xref target="FieldBlock">field block</xref> can cause an implementation to
             commit a large amount of state.  Field lines that are critical for routing can appear
             toward the end of a field block, which prevents streaming of fields to their
             ultimate destination.  This ordering and other reasons, such as ensuring cache
             correctness, mean that an endpoint might need to buffer the entire field block.  Since
             there is no hard limit to the size of a field block, some endpoints could be forced to
-            commit a large amount of available memory for field blocks.
-          </t>
-          <t>
-            An endpoint can use the <xref target="SETTINGS_MAX_HEADER_LIST_SIZE" format="none">SETTINGS_MAX_HEADER_LIST_SIZE</xref> to advise peers of
+            commit a large amount of available memory for field blocks.</t>
+          <t>An endpoint can use the <xref target="SETTINGS_MAX_HEADER_LIST_SIZE" format="none">SETTINGS_MAX_HEADER_LIST_SIZE</xref> to advise peers of
             limits that might apply on the size of uncompressed field blocks.  This setting is only advisory, so
-            endpoints MAY choose to send field blocks that exceed this limit and risk the
+            endpoints <bcp14>MAY</bcp14> choose to send field blocks that exceed this limit and risk the
             request or response being treated as malformed.  This setting is specific to a
             connection, so any request or response could encounter a hop with a lower, unknown
             limit.  An intermediary can attempt to avoid this problem by passing on values presented
-            by different peers, but they are not obliged to do so.
-          </t>
-          <t>
-            A server that receives a larger field block than it is willing to handle can send an
+            by different peers, but they are not obliged to do so.</t>
+          <t>A server that receives a larger field block than it is willing to handle can send an
             HTTP 431 (Request Header Fields Too Large) status code <xref target="RFC6585"/>.  A
-            client can discard responses that it cannot process.  The field block MUST be processed
-            to ensure a consistent connection state, unless the connection is closed.
-          </t>
+            client can discard responses that it cannot process.  The field block <bcp14>MUST</bcp14> be processed
+            to ensure a consistent connection state, unless the connection is closed.</t>
         </section>
         <section anchor="connectDos">
           <name>CONNECT Issues</name>
-          <t>
-            The CONNECT method can be used to create disproportionate load on a proxy, since stream
+          <t>The CONNECT method can be used to create disproportionate load on a proxy, since stream
             creation is relatively inexpensive when compared to the creation and maintenance of a
             TCP connection.  A proxy might also maintain some resources for a TCP connection beyond
             the closing of the stream that carries the CONNECT request, since the outgoing TCP
             connection remains in the TIME_WAIT state.  Therefore, a proxy cannot rely on
             <xref target="SETTINGS_MAX_CONCURRENT_STREAMS" format="none">SETTINGS_MAX_CONCURRENT_STREAMS</xref> alone to limit the resources consumed by
-            CONNECT requests.
-          </t>
+            CONNECT requests.</t>
         </section>
       </section>
       <section>
         <name>Use of Compression</name>
-        <t>
-          Compression can allow an attacker to recover secret data when it is compressed in the same
+        <t>Compression can allow an attacker to recover secret data when it is compressed in the same
           context as data under attacker control.  HTTP/2 enables compression of field lines
           (<xref target="FieldBlock"/>); the following concerns also apply to the use of HTTP
-          compressed content-codings (<xref target="HTTP" section="8.4.1"/>).
-        </t>
-        <t>
-          There are demonstrable attacks on compression that exploit the characteristics of the Web
+          compressed content-codings (<xref target="HTTP" section="8.4.1"/>).</t>
+        <t>There are demonstrable attacks on compression that exploit the characteristics of the Web
           (e.g., <xref target="BREACH"/>).  The attacker induces multiple requests containing
           varying plaintext, observing the length of the resulting ciphertext in each, which
-          reveals a shorter length when a guess about the secret is correct.
-        </t>
-        <t>
-          Implementations communicating on a secure channel MUST NOT compress content that includes
+          reveals a shorter length when a guess about the secret is correct.</t>
+        <t>Implementations communicating on a secure channel <bcp14>MUST NOT</bcp14> compress content that includes
           both confidential and attacker-controlled data unless separate compression dictionaries
-          are used for each source of data.  Compression MUST NOT be used if the source of data
+          are used for each source of data.  Compression <bcp14>MUST NOT</bcp14> be used if the source of data
           cannot be reliably determined.  Generic stream compression, such as that provided by TLS,
-          MUST NOT be used with HTTP/2 (see <xref target="TLSUsage"/>).
-        </t>
-        <t>
-          Further considerations regarding the compression of header fields are described in <xref target="COMPRESSION"/>.
-        </t>
+          <bcp14>MUST NOT</bcp14> be used with HTTP/2 (see <xref target="TLSUsage"/>).</t>
+        <t>Further considerations regarding the compression of header fields are described in <xref target="COMPRESSION"/>.</t>
       </section>
       <section anchor="padding">
         <name>Use of Padding</name>
-        <t>
-          Padding within HTTP/2 is not intended as a replacement for general purpose padding, such
+        <t>Padding within HTTP/2 is not intended as a replacement for general purpose padding, such
           as that provided by <xref target="TLS13">TLS</xref>.  Redundant padding could even be
           counterproductive.  Correct application can depend on having specific knowledge of the
-          data that is being padded.
-        </t>
-        <t>
-          To mitigate attacks that rely on compression, disabling or limiting compression might be
-          preferable to padding as a countermeasure.
-        </t>
-        <t>
-          Padding can be used to obscure the exact size of frame content and is provided to
+          data that is being padded.</t>
+        <t>To mitigate attacks that rely on compression, disabling or limiting compression might be
+          preferable to padding as a countermeasure.</t>
+        <t>Padding can be used to obscure the exact size of frame content and is provided to
           mitigate specific attacks within HTTP -- for example, attacks where compressed content
-          includes both attacker-controlled plaintext and secret data (e.g., <xref target="BREACH"/>).
-        </t>
-        <t>
-          Use of padding can result in less protection than might seem immediately obvious.  At
+          includes both attacker-controlled plaintext and secret data (e.g., <xref target="BREACH"/>).</t>
+        <t>Use of padding can result in less protection than might seem immediately obvious.  At
           best, padding only makes it more difficult for an attacker to infer length information by
           increasing the number of frames an attacker has to observe.  Incorrectly implemented
           padding schemes can be easily defeated.  In particular, randomized padding with a
           predictable distribution provides very little protection; similarly, padding frame payloads to a
           fixed size exposes information as frame payload sizes cross the fixed-sized boundary, which could
-          be possible if an attacker can control plaintext.
-        </t>
-        <t>
-          Intermediaries SHOULD retain padding for <xref target="DATA" format="none">DATA</xref> frames but MAY drop padding
+          be possible if an attacker can control plaintext.</t>
+        <t>Intermediaries <bcp14>SHOULD</bcp14> retain padding for <xref target="DATA" format="none">DATA</xref> frames but <bcp14>MAY</bcp14> drop padding
           for <xref target="HEADERS" format="none">HEADERS</xref> and <xref target="PUSH_PROMISE" format="none">PUSH_PROMISE</xref> frames.  A valid reason for an
           intermediary to change the amount of padding of frames is to improve the protections that
-          padding provides.
-        </t>
+          padding provides.</t>
       </section>
       <section>
         <name>Privacy Considerations</name>
-        <t>
-          Several characteristics of HTTP/2 provide an observer an opportunity to correlate actions
+        <t>Several characteristics of HTTP/2 provide an observer an opportunity to correlate actions
           of a single client or server over time.  These include the values of settings, the manner
           in which flow-control windows are managed, the way priorities are allocated to streams,
           the timing of reactions to stimulus, and the handling of any features that are controlled by
-          settings.
-        </t>
-        <t>
-          As far as these create observable differences in behavior, they could be used as a basis
-          for fingerprinting a specific client, as defined in <xref target="PRIVACY" section="3.2"/>.
-        </t>
-        <t>
-          HTTP/2's preference for using a single TCP connection allows correlation of a user's
+          settings.</t>
+        <t>As far as these create observable differences in behavior, they could be used as a basis
+          for fingerprinting a specific client, as defined in <xref target="PRIVACY" section="3.2"/>.</t>
+        <t>HTTP/2's preference for using a single TCP connection allows correlation of a user's
           activity on a site.  Reusing connections for different origins allows tracking
-          across those origins.
-        </t>
-        <t>
-          Because the PING and SETTINGS frames solicit immediate responses, they can be used by an
+          across those origins.</t>
+        <t>Because the PING and SETTINGS frames solicit immediate responses, they can be used by an
           endpoint to measure latency to their peer.  This might have privacy implications in
-          certain scenarios.
-        </t>
+          certain scenarios.</t>
       </section>
       <section>
         <name>Remote Timing Attacks</name>
-        <t>
-          Remote timing attacks extract secrets from servers by observing variations in the time
+        <t>Remote timing attacks extract secrets from servers by observing variations in the time
           that servers take when processing requests that use secrets. HTTP/2 enables concurrent
           request creation and processing, which can give attackers better control over when request
           processing commences.  Multiple HTTP/2 requests can be included in the same IP packet or
           TLS record.  HTTP/2 can therefore make remote timing attacks more efficient by eliminating
           variability in request delivery, leaving only request order and the delivery of responses
-          as sources of timing variability.
-        </t>
-        <t>
-          Ensuring that processing time is not dependent on the value of a secret is the best
-          defense against any form of timing attack.
-        </t>
+          as sources of timing variability.</t>
+        <t>Ensuring that processing time is not dependent on the value of a secret is the best
+          defense against any form of timing attack.</t>
       </section>
     </section>
     <section anchor="iana">
       <name>IANA Considerations</name>
-      <t>
-        This revision of HTTP/2 marks the <tt>HTTP2-Settings</tt> header field and the
-        <tt>h2c</tt> upgrade token, both defined in <xref target="RFC7540"/>, as obsolete.
-      </t>
-      <t>
-        <xref target="RFC7540" section="11"/> registered the <tt>h2</tt> and <tt>h2c</tt> ALPN
+      <t>This revision of HTTP/2 marks the <tt>HTTP2-Settings</tt> header field and the
+        <tt>h2c</tt> upgrade token, both defined in <xref target="RFC7540"/>, as obsolete.</t>
+      <t><xref target="RFC7540" section="11"/> registered the <tt>h2</tt> and <tt>h2c</tt> ALPN
         identifiers along with the <tt>PRI</tt> HTTP method.  RFC 7540 also established a registry
         for frame types, settings, and error codes.  These registrations and registries apply to
-        HTTP/2, but are not redefined in this document.
-      </t>
-      <t>
-        IANA has updated references to RFC 7540 in the
+        HTTP/2, but are not redefined in this document.</t>
+      <t>IANA has updated references to RFC 7540 in the
         following registries to refer to this document: "TLS
         Application-Layer Protocol Negotiation (ALPN) Protocol IDs",
         "HTTP/2 Frame Type", "HTTP/2 Settings", "HTTP/2 Error Code",
         and "HTTP Method Registry".  The registration of the
-        <tt>PRI</tt> method has been updated to refer to <xref
-        target="preface"/>; all other section numbers have not
-        changed.
-      </t>
-      <t>
-        IANA has changed the policy on those portions of the "HTTP/2
+        <tt>PRI</tt> method has been updated to refer to <xref target="preface"/>; all other section numbers have not
+        changed.</t>
+      <t>IANA has changed the policy on those portions of the "HTTP/2
         Frame Type" and "HTTP/2 Settings" registries that were
         reserved for Experimental Use in RFC 7540. These portions of
         the registries shall operate on the same policy as the
-        remainder of each registry.
-      </t>
+        remainder of each registry.</t>
       <section anchor="HTTP2-Settings">
         <name>HTTP2-Settings Header Field Registration</name>
-        <t>
-          This section marks the <tt>HTTP2-Settings</tt> header field registered by <xref
-          target="RFC7540" section="11.5"/> in the "Hypertext Transfer Protocol (HTTP) Field Name
+        <t>This section marks the <tt>HTTP2-Settings</tt> header field registered by <xref target="RFC7540" section="11.5"/> in the "Hypertext Transfer Protocol (HTTP) Field Name
           Registry" as obsolete.  This capability has been removed: see <xref target="versioning"/>.
-          The registration is updated to include the details as required by <xref target="HTTP"
-          section="18.4"/>:
-        </t>
+          The registration is updated to include the details as required by <xref target="HTTP" section="18.4"/>:</t>
         <dl newline="false" spacing="normal">
           <dt>Field Name:</dt>
           <dd>HTTP2-Settings</dd>
           <dt>Status:</dt>
           <dd>obsoleted</dd>
           <dt>Reference:</dt>
-          <dd>
-            <xref target="RFC7540" section="3.2.1"/>
-          </dd>
+          <dd><xref target="RFC7540" section="3.2.1"/></dd>
           <dt>Comments:</dt>
           <dd>Obsolete; see <xref target="HTTP2-Settings"/> of this document.</dd>
         </dl>
       </section>
       <section anchor="iana-h2c">
         <name>The h2c Upgrade Token</name>
-        <t>
-          This section records the <tt>h2c</tt> upgrade token registered by <xref target="RFC7540"
-          section="11.8"/> in the "Hypertext Transfer Protocol (HTTP) Upgrade Token Registry" as
+        <t>This section records the <tt>h2c</tt> upgrade token registered by <xref target="RFC7540" section="11.8"/> in the "Hypertext Transfer Protocol (HTTP) Upgrade Token Registry" as
           obsolete.  This capability has been removed: see <xref target="versioning"/>.  The
-          registration is updated as follows:
-        </t>
+          registration is updated as follows:</t>
         <dl>
-          <dt>Value:</dt><dd>h2c</dd>
-          <dt>Description:</dt><dd>(OBSOLETE) Hypertext Transfer Protocol version 2 (HTTP/2)</dd>
-          <dt>Expected Version Tokens:</dt><dd>None</dd>
-          <dt>Reference:</dt><dd><xref target="versioning"/> of this document</dd>
+          <dt>Value:</dt>
+          <dd>h2c</dd>
+          <dt>Description:</dt>
+          <dd>(OBSOLETE) Hypertext Transfer Protocol version 2 (HTTP/2)</dd>
+          <dt>Expected Version Tokens:</dt>
+          <dd>None</dd>
+          <dt>Reference:</dt>
+          <dd><xref target="versioning"/> of this document</dd>
         </dl>
       </section>
     </section>
   </middle>
   <back>
-
     <displayreference target="CACHE" to="HTTP-CACHING"/>
     <displayreference target="HTTP11" to="HTTP/1.1"/>
     <displayreference target="I-D.ietf-httpbis-priority" to="HTTP-PRIORITY"/>
@@ -4289,9 +3002,7 @@ cookie: e=f
         </reference>
         <reference anchor="TCP">
           <front>
-            <title abbrev="Transmission Control Protocol">
-            Transmission Control Protocol
-            </title>
+            <title abbrev="Transmission Control Protocol">Transmission Control Protocol</title>
             <seriesInfo name="STD" value="7"/>
             <seriesInfo name="RFC" value="793"/>
             <seriesInfo name="DOI" value="10.17487/RFC793"/>
@@ -4316,9 +3027,7 @@ cookie: e=f
         </reference>
         <reference anchor="RFC2119">
           <front>
-            <title>
-            Key words for use in RFCs to Indicate Requirement Levels
-            </title>
+            <title>Key words for use in RFCs to Indicate Requirement Levels</title>
             <seriesInfo name="BCP" value="14"/>
             <seriesInfo name="RFC" value="2119"/>
             <seriesInfo name="DOI" value="10.17487/RFC2119"/>
@@ -4343,7 +3052,6 @@ cookie: e=f
           <seriesInfo name="RFC" value="8174"/>
           <seriesInfo name="DOI" value="10.17487/RFC8174"/>
         </reference>
-
         <reference anchor="RFC3986">
           <front>
             <title abbrev="URI Generic Syntax">Uniform Resource Identifier (URI): Generic
@@ -4389,9 +3097,7 @@ cookie: e=f
         </reference>
         <reference anchor="TLS-EXT">
           <front>
-            <title>
-            Transport Layer Security (TLS) Extensions: Extension Definitions
-            </title>
+            <title>Transport Layer Security (TLS) Extensions: Extension Definitions</title>
             <seriesInfo name="RFC" value="6066"/>
             <seriesInfo name="DOI" value="10.17487/RFC6066"/>
             <author initials="D." surname="Eastlake 3rd" fullname="D. Eastlake 3rd"/>
@@ -4412,17 +3118,15 @@ cookie: e=f
         </reference>
         <reference anchor="TLS-ECDHE">
           <front>
-            <title>
-            TLS Elliptic Curve Cipher Suites with SHA-256/384 and AES Galois
-            Counter Mode (GCM)
-            </title>
+            <title>TLS Elliptic Curve Cipher Suites with SHA-256/384 and AES Galois
+            Counter Mode (GCM)</title>
             <seriesInfo name="RFC" value="5289"/>
             <seriesInfo name="DOI" value="10.17487/RFC5289"/>
             <author initials="E." surname="Rescorla" fullname="E. Rescorla"/>
             <date year="2008" month="August"/>
           </front>
         </reference>
-        <reference  anchor="RFC8422" target="https://www.rfc-editor.org/info/rfc8422">
+        <reference anchor="RFC8422" target="https://www.rfc-editor.org/info/rfc8422">
           <front>
             <title>Elliptic Curve Cryptography (ECC) Cipher Suites for Transport Layer Security (TLS) Versions 1.2 and Earlier</title>
             <seriesInfo name="RFC" value="8422"/>
@@ -4430,7 +3134,7 @@ cookie: e=f
             <author initials="Y." surname="Nir" fullname="Y. Nir"/>
             <author initials="S." surname="Josefsson" fullname="S. Josefsson"/>
             <author initials="M." surname="Pegourie-Gonnard" fullname="M. Pegourie-Gonnard"/>
-            <date year="2018" month="August" />
+            <date year="2018" month="August"/>
           </front>
         </reference>
         <reference anchor="COOKIE">
@@ -4515,7 +3219,7 @@ cookie: e=f
             <seriesInfo name="RFC" value="8441"/>
             <seriesInfo name="DOI" value="10.17487/RFC8441"/>
             <author initials="P." surname="McManus" fullname="P. McManus"/>
-            <date year="2018" month="September" />
+            <date year="2018" month="September"/>
           </front>
         </reference>
         <reference anchor="RFC1122">
@@ -4539,14 +3243,14 @@ cookie: e=f
             <date year="2014" month="September"/>
           </front>
         </reference>
-        <reference  anchor="RFC6125" target="https://www.rfc-editor.org/info/rfc6125">
+        <reference anchor="RFC6125" target="https://www.rfc-editor.org/info/rfc6125">
           <front>
             <title>Representation and Verification of Domain-Based Application Service Identity within Internet Public Key Infrastructure Using X.509 (PKIX) Certificates in the Context of Transport Layer Security (TLS)</title>
             <seriesInfo name="RFC" value="6125"/>
             <seriesInfo name="DOI" value="10.17487/RFC6125"/>
             <author initials="P." surname="Saint-Andre" fullname="P. Saint-Andre"/>
             <author initials="J." surname="Hodges" fullname="J. Hodges"/>
-            <date year="2011" month="March" />
+            <date year="2011" month="March"/>
           </front>
         </reference>
         <reference anchor="RFC3749">
@@ -4585,9 +3289,7 @@ cookie: e=f
         </reference>
         <reference anchor="TALKING" target="https://www.adambarth.com/papers/2011/huang-chen-barth-rescorla-jackson.pdf">
           <front>
-            <title>
-            Talking to Yourself for Fun and Profit
-            </title>
+            <title>Talking to Yourself for Fun and Profit</title>
             <author initials="L." surname="Huang"/>
             <author initials="E." surname="Chen"/>
             <author initials="A." surname="Barth"/>
@@ -4598,9 +3300,7 @@ cookie: e=f
         </reference>
         <reference anchor="BREACH" target="https://breachattack.com/resources/BREACH%20-%20SSL,%20gone%20in%2030%20seconds.pdf">
           <front>
-            <title>
-            BREACH: Reviving the CRIME Attack
-            </title>
+            <title>BREACH: Reviving the CRIME Attack</title>
             <author initials="Y." surname="Gluck"/>
             <author initials="N." surname="Harris"/>
             <author initials="A." surname="Prado"/>
@@ -4609,9 +3309,7 @@ cookie: e=f
         </reference>
         <reference anchor="ALT-SVC">
           <front>
-            <title>
-            HTTP Alternative Services
-            </title>
+            <title>HTTP Alternative Services</title>
             <seriesInfo name="RFC" value="7838"/>
             <seriesInfo name="DOI" value="10.17487/RFC7838"/>
             <author initials="M." surname="Nottingham" fullname="Mark Nottingham">
@@ -4652,11 +3350,9 @@ cookie: e=f
     </references>
     <section anchor="BadCipherSuites">
       <name>Prohibited TLS 1.2 Cipher Suites</name>
-      <t>
-        An HTTP/2 implementation MAY treat the negotiation of any of the following cipher suites
+      <t>An HTTP/2 implementation <bcp14>MAY</bcp14> treat the negotiation of any of the following cipher suites
         with TLS 1.2 as a <xref target="ConnectionErrorHandler">connection error</xref> of type
-        <xref target="INADEQUATE_SECURITY" format="none">INADEQUATE_SECURITY</xref>:
-      </t>
+        <xref target="INADEQUATE_SECURITY" format="none">INADEQUATE_SECURITY</xref>:</t>
       <ul spacing="compact">
         <li>TLS_NULL_WITH_NULL_NULL</li>
         <li>TLS_RSA_WITH_NULL_MD5</li>
@@ -4935,78 +3631,55 @@ cookie: e=f
         <li>TLS_PSK_WITH_AES_128_CCM_8</li>
         <li>TLS_PSK_WITH_AES_256_CCM_8</li>
       </ul>
-      <aside><t>Note: This list was assembled from the set of registered TLS cipher suites when
+      <aside>
+        <t>Note: This list was assembled from the set of registered TLS cipher suites when
       <xref target="RFC7540"/> was developed.  This list includes those cipher suites that do not
       offer an ephemeral key exchange and those that are based on the TLS null, stream, or block
       cipher type (as defined in <xref target="TLS12" section="6.2.3"/>).  Additional cipher suites
-      with these properties could be defined; these would not be explicitly prohibited.</t></aside>
-      <t>
-        For more details, see <xref target="tls12ciphers"/>
-      </t>
+      with these properties could be defined; these would not be explicitly prohibited.</t>
+      </aside>
+      <t>For more details, see <xref target="tls12ciphers"/></t>
     </section>
     <section anchor="revision-updates">
       <name>Changes from RFC 7540</name>
-      <t>
-        This revision includes the following substantive changes:
-      </t>
+      <t>This revision includes the following substantive changes:</t>
       <ul spacing="normal">
-        <li>
-          Use of TLS 1.3 was defined based on <xref target="RFC8740"/>, which this document obsoletes.
-        </li>
-        <li>
-          The priority scheme defined in RFC 7540 is deprecated.  Definitions for the format of the
+        <li>Use of TLS 1.3 was defined based on <xref target="RFC8740"/>, which this document obsoletes.</li>
+        <li>The priority scheme defined in RFC 7540 is deprecated.  Definitions for the format of the
           <xref target="PRIORITY" format="none">PRIORITY</xref> frame and the priority fields in the
           <xref target="HEADERS" format="none">HEADERS</xref> frame have been retained, plus the
           rules governing when <xref target="PRIORITY" format="none">PRIORITY</xref> frames can be
           sent and received, but the semantics of these fields are only described in RFC 7540.  The
           priority signaling scheme from RFC 7540 was not successful.  Using the simpler signaling
-          in <xref target="I-D.ietf-httpbis-priority"/> is recommended.
-        </li>
-        <li>
-          The HTTP/1.1 Upgrade mechanism is deprecated and no longer specified in this document. It
+          in <xref target="I-D.ietf-httpbis-priority"/> is recommended.</li>
+        <li>The HTTP/1.1 Upgrade mechanism is deprecated and no longer specified in this document. It
           was never widely deployed, with plaintext HTTP/2 users choosing to use the prior-knowledge
-          implementation instead.
-        </li>
-        <li>
-          Validation for field names and values has been narrowed.  The validation that is mandatory
+          implementation instead.</li>
+        <li>Validation for field names and values has been narrowed.  The validation that is mandatory
           for intermediaries is precisely defined, and error reporting for requests has been amended
-          to encourage sending 400-series status codes.
-        </li>
-        <li>
-          The ranges of codepoints for settings and frame types that were reserved for Experimental
-          Use are now available for general use.
-        </li>
-        <li>
-          Connection-specific header fields -- which are prohibited -- are more precisely and
-          comprehensively identified.
-        </li>
-        <li>
-          <tt>Host</tt> and "<tt>:authority</tt>" are no longer permitted to disagree.
-        </li>
-        <li>
-          Rules for sending Dynamic Table Size Update instructions after changes in settings have
-          been clarified in <xref target="dynamic-table"/>.
-        </li>
+          to encourage sending 400-series status codes.</li>
+        <li>The ranges of codepoints for settings and frame types that were reserved for Experimental
+          Use are now available for general use.</li>
+        <li>Connection-specific header fields -- which are prohibited -- are more precisely and
+          comprehensively identified.</li>
+        <li><tt>Host</tt> and "<tt>:authority</tt>" are no longer permitted to disagree.</li>
+        <li>Rules for sending Dynamic Table Size Update instructions after changes in settings have
+          been clarified in <xref target="dynamic-table"/>.</li>
       </ul>
-      <t>
-        Editorial changes are also included. In particular, changes to terminology and document
+      <t>Editorial changes are also included. In particular, changes to terminology and document
         structure are in response to updates to <xref target="HTTP">core HTTP
         semantics</xref>. Those documents now include some concepts that were first defined in RFC
-        7540, such as the 421 status code or connection coalescing.
-      </t>
+        7540, such as the 421 status code or connection coalescing.</t>
     </section>
     <section numbered="false">
       <name>Acknowledgments</name>
-      <t>
-        Credit for non-trivial input to this document is owed to a large number of people who have
+      <t>Credit for non-trivial input to this document is owed to a large number of people who have
         contributed to the HTTP Working Group over the years.  <xref target="RFC7540"/> contains a
         more extensive list of people that deserve acknowledgment for their contributions.</t>
     </section>
     <section numbered="false">
       <name>Contributors</name>
-      <t>
-        <contact fullname="Mike Belshe"/> and <contact fullname="Roberto Peon"/> authored the text that this document is based on.
-      </t>
+      <t><contact fullname="Mike Belshe"/> and <contact fullname="Roberto Peon"/> authored the text that this document is based on.</t>
     </section>
   </back>
 </rfc>

--- a/draft-ietf-httpbis-http2bis.xml
+++ b/draft-ietf-httpbis-http2bis.xml
@@ -754,7 +754,7 @@ HTTP Frame {
           for sending and receiving those frames are also unknown; see <xref target="extensibility"/>.</t>
         <t>An example of the state transitions for an HTTP request/response exchange can be found in
           <xref target="HttpExamples"/>.  An example of the state transitions for server push can be
-          found in Sections <xref target="PushRequests" format="counter"/> and <xref target="PushResponses" format="counter"/>.</t>
+          found in Sections&#xa0;<xref target="PushRequests" format="counter"/> and <xref target="PushResponses" format="counter"/>.</t>
         <section anchor="StreamIdentifiers">
           <name>Stream Identifiers</name>
           <t>Streams are identified by an unsigned 31-bit integer.  Streams initiated by a client


### PR DESCRIPTION
I had to remove the <bcp14> tags from the BCP 14 text, but the tool
restored them.

Other than that, there is no difference in output in the text files that
this generates, so I'm going to say that this was successful.

The source has a ton of whitespace changes, but that seems to be all.